### PR TITLE
Add Fight Scene sections to movie pages

### DIFF
--- a/prisma/migrations/20260730033446_fight_scenes/migration.sql
+++ b/prisma/migrations/20260730033446_fight_scenes/migration.sql
@@ -1,0 +1,94 @@
+-- CreateTable
+CREATE TABLE "FightScene" (
+    "id" TEXT NOT NULL,
+    "movieId" TEXT NOT NULL,
+    "submittedById" TEXT NOT NULL,
+    "youtubeVideoId" TEXT NOT NULL,
+    "youtubeStartSeconds" INTEGER,
+    "isVerified" BOOLEAN NOT NULL DEFAULT false,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FightScene_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FightSceneCast" (
+    "id" TEXT NOT NULL,
+    "fightSceneId" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "FightSceneCast_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FightSceneRating" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "fightSceneId" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FightSceneRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FightSceneAdminRating" (
+    "id" TEXT NOT NULL,
+    "adminId" TEXT NOT NULL,
+    "fightSceneId" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FightSceneAdminRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FightScene_movieId_idx" ON "FightScene"("movieId");
+
+-- CreateIndex
+CREATE INDEX "FightSceneCast_fightSceneId_idx" ON "FightSceneCast"("fightSceneId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FightSceneCast_fightSceneId_personId_key" ON "FightSceneCast"("fightSceneId", "personId");
+
+-- CreateIndex
+CREATE INDEX "FightSceneRating_fightSceneId_idx" ON "FightSceneRating"("fightSceneId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FightSceneRating_userId_fightSceneId_key" ON "FightSceneRating"("userId", "fightSceneId");
+
+-- CreateIndex
+CREATE INDEX "FightSceneAdminRating_fightSceneId_idx" ON "FightSceneAdminRating"("fightSceneId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FightSceneAdminRating_adminId_fightSceneId_key" ON "FightSceneAdminRating"("adminId", "fightSceneId");
+
+-- AddForeignKey
+ALTER TABLE "FightScene" ADD CONSTRAINT "FightScene_movieId_fkey" FOREIGN KEY ("movieId") REFERENCES "Movie"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightScene" ADD CONSTRAINT "FightScene_submittedById_fkey" FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneCast" ADD CONSTRAINT "FightSceneCast_fightSceneId_fkey" FOREIGN KEY ("fightSceneId") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneCast" ADD CONSTRAINT "FightSceneCast_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneRating" ADD CONSTRAINT "FightSceneRating_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneRating" ADD CONSTRAINT "FightSceneRating_fightSceneId_fkey" FOREIGN KEY ("fightSceneId") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneAdminRating" ADD CONSTRAINT "FightSceneAdminRating_adminId_fkey" FOREIGN KEY ("adminId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneAdminRating" ADD CONSTRAINT "FightSceneAdminRating_fightSceneId_fkey" FOREIGN KEY ("fightSceneId") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,9 @@ model User {
   adminRatings  AdminRating[]
   listEntries   ListEntry[]
   discussionPosts DiscussionPost[]
+  fightScenes         FightScene[]
+  fightSceneRatings   FightSceneRating[]
+  fightSceneAdminRatings FightSceneAdminRating[]
 }
 
 model Account {
@@ -89,6 +92,7 @@ model Movie {
   listEntries     ListEntry[]
   discussionPosts DiscussionPost[]
   weeklyFeatured  WeeklyFeatured[]
+  fightScenes     FightScene[]
 
   @@index([title])
 }
@@ -107,6 +111,7 @@ model Person {
   profilePath String?
 
   castCredits CastCredit[]
+  fightSceneAppearances FightSceneCast[]
 
   @@index([name])
 }
@@ -192,6 +197,79 @@ model DiscussionPost {
   replies DiscussionPost[] @relation("Replies")
 
   @@index([movieId])
+}
+
+// --- Fight scenes ---
+//
+// A member-submitted clip (not a timestamp into the full movie) highlighting
+// one fight from a movie: the actors in it, a YouTube link, and its own
+// rating track separate from the movie's overall rating. Mirrors the
+// CastCredit (many-to-many join) and Rating/AdminRating (per-user upsert)
+// patterns above so fight scenes can be scored/aggregated the same way movies
+// are, without deciding the aggregation UI yet.
+
+model FightScene {
+  id                 String   @id @default(cuid())
+  movieId            String
+  submittedById      String
+  youtubeVideoId     String
+  youtubeStartSeconds Int?
+  isVerified         Boolean  @default(false)
+  isDeleted          Boolean  @default(false)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  movie       Movie                   @relation(fields: [movieId], references: [id], onDelete: Cascade)
+  submittedBy User                    @relation(fields: [submittedById], references: [id], onDelete: Cascade)
+  cast        FightSceneCast[]
+  ratings     FightSceneRating[]
+  adminRatings FightSceneAdminRating[]
+
+  @@index([movieId])
+}
+
+model FightSceneCast {
+  id           String @id @default(cuid())
+  fightSceneId String
+  personId     String
+  order        Int    @default(0)
+
+  fightScene FightScene @relation(fields: [fightSceneId], references: [id], onDelete: Cascade)
+  person     Person     @relation(fields: [personId], references: [id], onDelete: Cascade)
+
+  @@unique([fightSceneId, personId])
+  @@index([fightSceneId])
+}
+
+model FightSceneRating {
+  id           String   @id @default(cuid())
+  userId       String
+  fightSceneId String
+  score        Int
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fightScene FightScene @relation(fields: [fightSceneId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, fightSceneId])
+  @@index([fightSceneId])
+}
+
+model FightSceneAdminRating {
+  id           String   @id @default(cuid())
+  adminId      String
+  fightSceneId String
+  score        Int
+  note         String?  @db.Text
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  admin      User       @relation(fields: [adminId], references: [id], onDelete: Cascade)
+  fightScene FightScene @relation(fields: [fightSceneId], references: [id], onDelete: Cascade)
+
+  @@unique([adminId, fightSceneId])
+  @@index([fightSceneId])
 }
 
 // --- Weekly featured carousel ---

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -155,6 +155,33 @@ async function main() {
     create: { adminId: admin.id, movieId: enterTheDragon.id, score: 9, note: "A genre-defining classic." },
   });
 
+  const bruceLee = await prisma.person.findUniqueOrThrow({ where: { tmdbId: 900201 } });
+  const existingFightScene = await prisma.fightScene.findFirst({
+    where: { movieId: enterTheDragon.id, submittedById: member.id },
+  });
+  const fightScene =
+    existingFightScene ??
+    (await prisma.fightScene.create({
+      data: {
+        movieId: enterTheDragon.id,
+        submittedById: member.id,
+        // Sample data: not a real YouTube video id.
+        youtubeVideoId: "sampleClip1",
+        isVerified: true,
+        cast: { create: [{ personId: bruceLee.id, order: 0 }] },
+      },
+    }));
+  await prisma.fightSceneRating.upsert({
+    where: { userId_fightSceneId: { userId: member.id, fightSceneId: fightScene.id } },
+    update: { score: 10 },
+    create: { userId: member.id, fightSceneId: fightScene.id, score: 10 },
+  });
+  await prisma.fightSceneAdminRating.upsert({
+    where: { adminId_fightSceneId: { adminId: admin.id, fightSceneId: fightScene.id } },
+    update: { score: 10, note: "The mirror room finale." },
+    create: { adminId: admin.id, fightSceneId: fightScene.id, score: 10, note: "The mirror room finale." },
+  });
+
   console.log("Seed complete.", { admin: admin.email, member: member.email });
 }
 

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/admin-rating/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/admin-rating/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+const MAX_NOTE_LENGTH = 2000;
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId || existing.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const { score, note } = await request.json();
+  if (typeof score !== "number" || !Number.isInteger(score) || score < 1 || score > 10) {
+    return NextResponse.json({ error: "score must be an integer between 1 and 10." }, { status: 400 });
+  }
+  if (typeof note === "string" && note.length > MAX_NOTE_LENGTH) {
+    return NextResponse.json(
+      { error: `note must be ${MAX_NOTE_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const normalizedNote = typeof note === "string" && note.trim() ? note.trim() : null;
+
+  const rating = await prisma.fightSceneAdminRating.upsert({
+    where: { adminId_fightSceneId: { adminId: session.user.id, fightSceneId } },
+    update: { score, note: normalizedNote },
+    create: { adminId: session.user.id, fightSceneId, score, note: normalizedNote },
+  });
+
+  return NextResponse.json({ rating });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/rating/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/rating/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to rate fight scenes." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before rating fight scenes." }, { status: 403 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId || existing.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const { score } = await request.json();
+  if (typeof score !== "number" || !Number.isInteger(score) || score < 1 || score > 10) {
+    return NextResponse.json({ error: "score must be an integer between 1 and 10." }, { status: 400 });
+  }
+
+  const rating = await prisma.fightSceneRating.upsert({
+    where: { userId_fightSceneId: { userId: session.user.id, fightSceneId } },
+    update: { score },
+    create: { userId: session.user.id, fightSceneId, score },
+  });
+
+  return NextResponse.json({ rating });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { parseYoutubeUrl } from "@/lib/youtube";
+import { MAX_FIGHT_SCENE_CAST } from "@/lib/fight-scenes";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId || existing.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+  if (existing.submittedById !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own submissions." }, { status: 403 });
+  }
+
+  const { youtubeUrl, personIds } = await request.json();
+
+  if (typeof youtubeUrl !== "string" || youtubeUrl.trim().length === 0) {
+    return NextResponse.json({ error: "youtubeUrl is required." }, { status: 400 });
+  }
+
+  const parsed = parseYoutubeUrl(youtubeUrl.trim());
+  if (!parsed) {
+    return NextResponse.json({ error: "That doesn't look like a valid YouTube link." }, { status: 400 });
+  }
+
+  if (!Array.isArray(personIds) || personIds.length === 0 || !personIds.every((p) => typeof p === "string")) {
+    return NextResponse.json({ error: "personIds must be a non-empty array of actor ids." }, { status: 400 });
+  }
+
+  const uniquePersonIds = [...new Set(personIds)];
+  if (uniquePersonIds.length > MAX_FIGHT_SCENE_CAST) {
+    return NextResponse.json(
+      { error: `A fight scene can list at most ${MAX_FIGHT_SCENE_CAST} actors.` },
+      { status: 400 },
+    );
+  }
+
+  const castCount = await prisma.castCredit.count({
+    where: { movieId, personId: { in: uniquePersonIds } },
+  });
+  if (castCount !== uniquePersonIds.length) {
+    return NextResponse.json(
+      { error: "All actors must be part of this movie's cast." },
+      { status: 400 },
+    );
+  }
+
+  const fightScene = await prisma.$transaction(async (tx) => {
+    await tx.fightSceneCast.deleteMany({ where: { fightSceneId } });
+    return tx.fightScene.update({
+      where: { id: fightSceneId },
+      data: {
+        youtubeVideoId: parsed.videoId,
+        youtubeStartSeconds: parsed.startSeconds,
+        // Content changed, so an earlier admin verification no longer
+        // vouches for what's actually there — require re-review.
+        isVerified: false,
+        cast: {
+          create: uniquePersonIds.map((personId, order) => ({ personId, order })),
+        },
+      },
+      include: {
+        submittedBy: { select: { name: true, image: true } },
+        cast: { orderBy: { order: "asc" }, include: { person: true } },
+      },
+    });
+  });
+
+  return NextResponse.json({ fightScene });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const isOwner = existing.submittedById === session.user.id;
+  const isAdmin = session.user.role === "ADMIN";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Soft-delete like discussion posts: keep the row (and other members'
+  // ratings on it) intact rather than cascading them away.
+  await prisma.fightScene.update({
+    where: { id: fightSceneId },
+    data: { isDeleted: true },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/verify/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/verify/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId || existing.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const { verified } = await request.json();
+  if (typeof verified !== "boolean") {
+    return NextResponse.json({ error: "verified must be a boolean." }, { status: 400 });
+  }
+
+  const fightScene = await prisma.fightScene.update({
+    where: { id: fightSceneId },
+    data: { isVerified: verified },
+  });
+
+  return NextResponse.json({ fightScene });
+}

--- a/src/app/api/movies/[id]/fight-scenes/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+import { parseYoutubeUrl } from "@/lib/youtube";
+import { MAX_FIGHT_SCENE_CAST } from "@/lib/fight-scenes";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a fight scene." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a fight scene." }, { status: 403 });
+  }
+
+  const { id: movieId } = await params;
+  const { youtubeUrl, personIds } = await request.json();
+
+  if (typeof youtubeUrl !== "string" || youtubeUrl.trim().length === 0) {
+    return NextResponse.json({ error: "youtubeUrl is required." }, { status: 400 });
+  }
+
+  const parsed = parseYoutubeUrl(youtubeUrl.trim());
+  if (!parsed) {
+    return NextResponse.json({ error: "That doesn't look like a valid YouTube link." }, { status: 400 });
+  }
+
+  if (!Array.isArray(personIds) || personIds.length === 0 || !personIds.every((p) => typeof p === "string")) {
+    return NextResponse.json({ error: "personIds must be a non-empty array of actor ids." }, { status: 400 });
+  }
+
+  const uniquePersonIds = [...new Set(personIds)];
+  if (uniquePersonIds.length > MAX_FIGHT_SCENE_CAST) {
+    return NextResponse.json(
+      { error: `A fight scene can list at most ${MAX_FIGHT_SCENE_CAST} actors.` },
+      { status: 400 },
+    );
+  }
+
+  // Actors must already be part of this movie's cast, so members can't tag
+  // someone who was never in the film.
+  const castCount = await prisma.castCredit.count({
+    where: { movieId, personId: { in: uniquePersonIds } },
+  });
+  if (castCount !== uniquePersonIds.length) {
+    return NextResponse.json(
+      { error: "All actors must be part of this movie's cast." },
+      { status: 400 },
+    );
+  }
+
+  const fightScene = await prisma.fightScene.create({
+    data: {
+      movieId,
+      submittedById: session.user.id,
+      youtubeVideoId: parsed.videoId,
+      youtubeStartSeconds: parsed.startSeconds,
+      cast: {
+        create: uniquePersonIds.map((personId, order) => ({ personId, order })),
+      },
+    },
+    include: {
+      submittedBy: { select: { name: true, image: true } },
+      cast: { orderBy: { order: "asc" }, include: { person: true } },
+    },
+  });
+
+  return NextResponse.json({ fightScene });
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -5,10 +5,16 @@ import { prisma } from "@/lib/prisma";
 import { tmdbImageUrl } from "@/lib/tmdb";
 import { getCommunityRatingSummary, getEditorsRatingSummary } from "@/lib/ratings";
 import { getDiscussionPage } from "@/lib/discussion";
+import {
+  getFightScenesForMovie,
+  getFightSceneRatingSummaries,
+  getFightSceneAdminRatingSummaries,
+} from "@/lib/fight-scenes";
 import { RatingWidget } from "@/components/rating-widget";
 import { AdminRatingWidget } from "@/components/admin-rating-widget";
 import { ListButtons } from "@/components/list-buttons";
 import { DiscussionThread } from "@/components/discussion-thread";
+import { FightSceneSection } from "@/components/fight-scene-section";
 
 export default async function MovieDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -29,7 +35,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     notFound();
   }
 
-  const [communityRating, editorsRating, myRating, myListEntries, discussionPage] = await Promise.all([
+  const [communityRating, editorsRating, myRating, myListEntries, discussionPage, fightScenes] = await Promise.all([
     getCommunityRatingSummary(movie.id),
     getEditorsRatingSummary(movie.id),
     session?.user
@@ -41,6 +47,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       ? prisma.listEntry.findMany({ where: { userId: session.user.id, movieId: movie.id } })
       : [],
     getDiscussionPage(movie.id),
+    getFightScenesForMovie(movie.id),
   ]);
 
   const myAdminRating = session?.user?.role === "ADMIN"
@@ -49,11 +56,55 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       })
     : null;
 
+  const fightSceneIds = fightScenes.map((s) => s.id);
+  const [fightSceneRatingSummaries, fightSceneAdminRatingSummaries, myFightSceneRatings, myFightSceneAdminRatings] =
+    await Promise.all([
+      getFightSceneRatingSummaries(fightSceneIds),
+      getFightSceneAdminRatingSummaries(fightSceneIds),
+      session?.user
+        ? prisma.fightSceneRating.findMany({
+            where: { userId: session.user.id, fightSceneId: { in: fightSceneIds } },
+          })
+        : [],
+      session?.user?.role === "ADMIN"
+        ? prisma.fightSceneAdminRating.findMany({
+            where: { adminId: session.user.id, fightSceneId: { in: fightSceneIds } },
+          })
+        : [],
+    ]);
+
   const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
   const posterUrl = tmdbImageUrl(movie.posterPath, "w342");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
   const isFavorite = myListEntries.some((e) => e.listType === "FAVORITE");
   const isOnWatchlist = myListEntries.some((e) => e.listType === "WATCHLIST");
+
+  const serializedFightScenes = fightScenes.map((scene) => {
+    const summary = fightSceneRatingSummaries.get(scene.id);
+    const adminSummary = fightSceneAdminRatingSummaries.get(scene.id);
+    return {
+      id: scene.id,
+      youtubeVideoId: scene.youtubeVideoId,
+      youtubeStartSeconds: scene.youtubeStartSeconds,
+      isVerified: scene.isVerified,
+      submittedById: scene.submittedById,
+      createdAt: scene.createdAt.toISOString(),
+      updatedAt: scene.updatedAt.toISOString(),
+      submittedBy: scene.submittedBy,
+      cast: scene.cast,
+      ratingAverage: summary?.average ?? null,
+      ratingCount: summary?.count ?? 0,
+      adminRatingAverage: adminSummary?.average ?? null,
+      adminRatingCount: adminSummary?.count ?? 0,
+    };
+  });
+
+  const myFightSceneRatingMap = Object.fromEntries(myFightSceneRatings.map((r) => [r.fightSceneId, r.score]));
+  const myFightSceneAdminRatingMap = Object.fromEntries(
+    myFightSceneAdminRatings.map((r) => [r.fightSceneId, r.score]),
+  );
+
+  const castOptions = movie.cast.map((credit) => ({ id: credit.person.id, name: credit.person.name }));
 
   const serializedPosts = discussionPage.posts.map((post) => ({
     ...post,
@@ -189,6 +240,17 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             </div>
           </section>
         )}
+
+        <FightSceneSection
+          movieId={movie.id}
+          initialFightScenes={serializedFightScenes}
+          castOptions={castOptions}
+          signedIn={!!session?.user}
+          currentUserId={session?.user?.id ?? null}
+          isAdmin={session?.user?.role === "ADMIN"}
+          myRatings={myFightSceneRatingMap}
+          myAdminRatings={myFightSceneAdminRatingMap}
+        />
 
         <DiscussionThread
           movieId={movie.id}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { FightSceneCast, Person, User } from "@/generated/prisma/client";
+
+const SCORES = Array.from({ length: 10 }, (_, i) => i + 1);
+const MAX_NOTE_LENGTH = 2000;
+
+export type CastOption = Pick<Person, "id" | "name">;
+
+type FightSceneSubmitter = Pick<User, "name" | "image">;
+type FightSceneCastPerson = Pick<Person, "id" | "name" | "profilePath">;
+type FightSceneCastItem = Pick<FightSceneCast, "id" | "order"> & { person: FightSceneCastPerson };
+
+// createdAt/updatedAt cross the server-to-client boundary as strings (JSON),
+// same reasoning as DiscussionThread.
+export type FightSceneItem = {
+  id: string;
+  youtubeVideoId: string;
+  youtubeStartSeconds: number | null;
+  isVerified: boolean;
+  submittedById: string;
+  createdAt: string;
+  updatedAt: string;
+  submittedBy: FightSceneSubmitter;
+  cast: FightSceneCastItem[];
+  ratingAverage: number | null;
+  ratingCount: number;
+  adminRatingAverage: number | null;
+  adminRatingCount: number;
+};
+
+function embedUrl(videoId: string, startSeconds: number | null) {
+  const params = new URLSearchParams();
+  if (startSeconds) params.set("start", String(startSeconds));
+  const query = params.toString();
+  return `https://www.youtube-nocookie.com/embed/${videoId}${query ? `?${query}` : ""}`;
+}
+
+function CastPicker({
+  options,
+  selected,
+  onToggle,
+}: {
+  options: CastOption[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <div className="flex max-h-32 flex-wrap gap-2 overflow-y-auto rounded-md border border-neutral-700 bg-neutral-950 p-2">
+      {options.map((person) => (
+        <label
+          key={person.id}
+          className="flex cursor-pointer items-center gap-1.5 rounded-full border border-neutral-700 px-2 py-1 text-xs text-neutral-300 has-checked:border-red-600 has-checked:text-white"
+        >
+          <input
+            type="checkbox"
+            checked={selected.has(person.id)}
+            onChange={() => onToggle(person.id)}
+            className="sr-only"
+          />
+          {person.name}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function FightSceneForm({
+  castOptions,
+  initialUrl = "",
+  initialPersonIds = [],
+  submitLabel,
+  submitting,
+  onCancel,
+  onSubmit,
+}: {
+  castOptions: CastOption[];
+  initialUrl?: string;
+  initialPersonIds?: string[];
+  submitLabel: string;
+  submitting: boolean;
+  onCancel?: () => void;
+  onSubmit: (youtubeUrl: string, personIds: string[]) => void;
+}) {
+  const [url, setUrl] = useState(initialUrl);
+  const [selected, setSelected] = useState<Set<string>>(new Set(initialPersonIds));
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        type="url"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="Paste the YouTube link to this fight scene…"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+      />
+      <div>
+        <p className="mb-1 text-xs text-neutral-500">Actors in this scene</p>
+        <CastPicker options={castOptions} selected={selected} onToggle={toggle} />
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => onSubmit(url, [...selected])}
+          disabled={submitting || !url.trim() || selected.size === 0}
+          className="w-fit rounded-md bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+        >
+          {submitting ? "Saving…" : submitLabel}
+        </button>
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="w-fit rounded-md border border-neutral-700 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RatingRow({
+  label,
+  color,
+  score,
+  onRate,
+  disabled,
+}: {
+  label: string;
+  color: "yellow" | "amber";
+  score: number | null;
+  onRate: (value: number) => void;
+  disabled: boolean;
+}) {
+  const activeClass = color === "yellow" ? "bg-yellow-500 text-neutral-950" : "bg-amber-500 text-neutral-950";
+  return (
+    <div>
+      <p className="mb-1 text-xs text-neutral-500">{label}</p>
+      <div className="flex flex-wrap gap-1">
+        {SCORES.map((value) => (
+          <button
+            key={value}
+            disabled={disabled}
+            onClick={() => onRate(value)}
+            className={`h-6 w-6 rounded text-xs font-medium transition disabled:opacity-50 ${
+              score !== null && value <= score ? activeClass : "bg-neutral-800 text-neutral-300 hover:bg-neutral-700"
+            }`}
+          >
+            {value}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function FightSceneSection({
+  movieId,
+  initialFightScenes,
+  castOptions,
+  signedIn,
+  currentUserId,
+  isAdmin,
+  myRatings,
+  myAdminRatings,
+}: {
+  movieId: string;
+  initialFightScenes: FightSceneItem[];
+  castOptions: CastOption[];
+  signedIn: boolean;
+  currentUserId: string | null;
+  isAdmin: boolean;
+  myRatings: Record<string, number>;
+  myAdminRatings: Record<string, number>;
+}) {
+  const router = useRouter();
+  const [scenes, setScenes] = useState(initialFightScenes);
+  const [ratings, setRatings] = useState(myRatings);
+  const [adminRatings, setAdminRatings] = useState(myAdminRatings);
+  const [adding, setAdding] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [adminNoteDrafts, setAdminNoteDrafts] = useState<Record<string, string>>({});
+
+  async function handleCreate(youtubeUrl: string, personIds: string[]) {
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ youtubeUrl, personIds }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fightScene } = await res.json();
+    setScenes((prev) => [
+      { ...fightScene, ratingAverage: null, ratingCount: 0, adminRatingAverage: null, adminRatingCount: 0 },
+      ...prev,
+    ]);
+    setAdding(false);
+  }
+
+  async function handleEdit(id: string, youtubeUrl: string, personIds: string[]) {
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ youtubeUrl, personIds }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fightScene } = await res.json();
+    setScenes((prev) => prev.map((s) => (s.id === id ? { ...s, ...fightScene } : s)));
+    setEditingId(null);
+  }
+
+  async function handleDelete(id: string) {
+    if (!window.confirm("Remove this fight scene? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setScenes((prev) => prev.filter((s) => s.id !== id));
+  }
+
+  async function handleRate(id: string, score: number) {
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}/rating`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setRatings((prev) => ({ ...prev, [id]: score }));
+    router.refresh();
+  }
+
+  async function handleAdminRate(id: string, score: number) {
+    setError(null);
+    const note = adminNoteDrafts[id];
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}/admin-rating`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score, note }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setAdminRatings((prev) => ({ ...prev, [id]: score }));
+    router.refresh();
+  }
+
+  async function handleVerifyToggle(id: string, verified: boolean) {
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verified }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setScenes((prev) => prev.map((s) => (s.id === id ? { ...s, isVerified: verified } : s)));
+  }
+
+  return (
+    <section className="mt-10">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xl font-bold text-white">Fight Scenes</h2>
+        {signedIn && !adding && castOptions.length > 0 && (
+          <button
+            onClick={() => setAdding(true)}
+            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+          >
+            + Add fight scene
+          </button>
+        )}
+      </div>
+
+      {!signedIn && (
+        <p className="mb-4 text-sm text-neutral-400">
+          <a href="/login" className="text-red-500 hover:underline">
+            Sign in
+          </a>{" "}
+          to add or rate fight scenes.
+        </p>
+      )}
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      {adding && (
+        <div className="mb-6 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+          <FightSceneForm
+            castOptions={castOptions}
+            submitLabel="Add fight scene"
+            submitting={submitting}
+            onCancel={() => setAdding(false)}
+            onSubmit={handleCreate}
+          />
+        </div>
+      )}
+
+      <ul className="flex flex-col gap-6">
+        {scenes.map((scene) => {
+          const canEdit = currentUserId === scene.submittedById;
+          const canDelete = canEdit || isAdmin;
+
+          return (
+            <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+              {editingId === scene.id ? (
+                <FightSceneForm
+                  castOptions={castOptions}
+                  initialPersonIds={scene.cast.map((c) => c.person.id)}
+                  submitLabel="Save"
+                  submitting={submitting}
+                  onCancel={() => setEditingId(null)}
+                  onSubmit={(url, personIds) => handleEdit(scene.id, url, personIds)}
+                />
+              ) : (
+                <>
+                  <div className="aspect-video w-full overflow-hidden rounded-md bg-black">
+                    <iframe
+                      src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
+                      title="Fight scene"
+                      className="h-full w-full"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                  </div>
+
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+                    {scene.cast.map((c) => (
+                      <span
+                        key={c.id}
+                        className="rounded-full border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300"
+                      >
+                        {c.person.name}
+                      </span>
+                    ))}
+                    {scene.isVerified && (
+                      <span className="rounded-full bg-red-900/40 px-2 py-0.5 text-xs font-medium text-red-400">
+                        ✓ Verified
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="mt-1 text-xs text-neutral-500">
+                    Submitted by {scene.submittedBy.name ?? "Anonymous"}
+                    {canEdit && (
+                      <button
+                        onClick={() => setEditingId(scene.id)}
+                        className="ml-2 text-neutral-400 hover:text-white"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {canDelete && (
+                      <button
+                        onClick={() => handleDelete(scene.id)}
+                        className="ml-2 text-neutral-400 hover:text-red-400"
+                      >
+                        Delete
+                      </button>
+                    )}
+                    {isAdmin && (
+                      <button
+                        onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)}
+                        className="ml-2 text-neutral-400 hover:text-white"
+                      >
+                        {scene.isVerified ? "Unverify" : "Verify"}
+                      </button>
+                    )}
+                  </p>
+
+                  <div className="mt-3 flex flex-wrap items-center gap-6">
+                    <div>
+                      <p className="text-xs text-neutral-500">Member Score</p>
+                      <p className="text-lg font-bold text-yellow-500">
+                        {scene.ratingAverage ? scene.ratingAverage.toFixed(1) : "—"}{" "}
+                        <span className="text-xs font-normal text-neutral-500">/ 10 ({scene.ratingCount})</span>
+                      </p>
+                    </div>
+                    {scene.adminRatingCount > 0 && (
+                      <div>
+                        <p className="text-xs text-neutral-500">Editors&rsquo; Score</p>
+                        <p className="text-lg font-bold text-amber-500">
+                          {scene.adminRatingAverage?.toFixed(1)}{" "}
+                          <span className="text-xs font-normal text-neutral-500">
+                            / 10 ({scene.adminRatingCount})
+                          </span>
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  {signedIn && (
+                    <div className="mt-3">
+                      <RatingRow
+                        label="Your rating"
+                        color="yellow"
+                        score={ratings[scene.id] ?? null}
+                        onRate={(value) => handleRate(scene.id, value)}
+                        disabled={false}
+                      />
+                    </div>
+                  )}
+
+                  {isAdmin && (
+                    <div className="mt-3 rounded-md border border-amber-800/50 bg-amber-950/20 p-2">
+                      <RatingRow
+                        label="Editors' rating (admin only)"
+                        color="amber"
+                        score={adminRatings[scene.id] ?? null}
+                        onRate={(value) => handleAdminRate(scene.id, value)}
+                        disabled={false}
+                      />
+                      <textarea
+                        value={adminNoteDrafts[scene.id] ?? ""}
+                        onChange={(e) =>
+                          setAdminNoteDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))
+                        }
+                        maxLength={MAX_NOTE_LENGTH}
+                        placeholder="Editor's note (optional)"
+                        rows={2}
+                        className="mt-2 w-full rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-100 focus:border-amber-600 focus:outline-none"
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+            </li>
+          );
+        })}
+
+        {scenes.length === 0 && (
+          <p className="text-sm text-neutral-500">No fight scenes added yet.</p>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/fight-scenes.ts
+++ b/src/lib/fight-scenes.ts
@@ -1,0 +1,60 @@
+import { prisma } from "@/lib/prisma";
+
+export const MAX_FIGHT_SCENE_CAST = 20;
+
+export interface FightSceneRatingSummary {
+  average: number | null;
+  count: number;
+}
+
+export async function getFightScenesForMovie(movieId: string) {
+  return prisma.fightScene.findMany({
+    where: { movieId, isDeleted: false },
+    orderBy: { createdAt: "desc" },
+    include: {
+      submittedBy: { select: { name: true, image: true } },
+      cast: {
+        orderBy: { order: "asc" },
+        include: { person: true },
+      },
+    },
+  });
+}
+
+export async function getFightSceneRatingSummaries(
+  fightSceneIds: string[],
+): Promise<Map<string, FightSceneRatingSummary>> {
+  if (fightSceneIds.length === 0) return new Map();
+
+  const rows = await prisma.fightSceneRating.groupBy({
+    by: ["fightSceneId"],
+    where: { fightSceneId: { in: fightSceneIds } },
+    _avg: { score: true },
+    _count: { _all: true },
+  });
+
+  const map = new Map<string, FightSceneRatingSummary>();
+  for (const row of rows) {
+    map.set(row.fightSceneId, { average: row._avg.score, count: row._count._all });
+  }
+  return map;
+}
+
+export async function getFightSceneAdminRatingSummaries(
+  fightSceneIds: string[],
+): Promise<Map<string, FightSceneRatingSummary>> {
+  if (fightSceneIds.length === 0) return new Map();
+
+  const rows = await prisma.fightSceneAdminRating.groupBy({
+    by: ["fightSceneId"],
+    where: { fightSceneId: { in: fightSceneIds } },
+    _avg: { score: true },
+    _count: { _all: true },
+  });
+
+  const map = new Map<string, FightSceneRatingSummary>();
+  for (const row of rows) {
+    map.set(row.fightSceneId, { average: row._avg.score, count: row._count._all });
+  }
+  return map;
+}

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -1,0 +1,62 @@
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+export interface ParsedYoutubeLink {
+  videoId: string;
+  startSeconds: number | null;
+}
+
+// Accepts whatever a member pastes from YouTube's address bar or Share button:
+// watch/shorts/embed/live URLs and youtu.be short links, with an optional
+// t=/start= timestamp (either plain seconds or YouTube's "1h2m3s" form) that
+// captures "start at this moment" if the member used Share's "start at" option.
+export function parseYoutubeUrl(input: string): ParsedYoutubeLink | null {
+  let url: URL;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    return null;
+  }
+
+  const host = url.hostname.replace(/^(www\.|m\.)/, "");
+  let videoId: string | null = null;
+
+  if (host === "youtu.be") {
+    videoId = url.pathname.split("/")[1] ?? null;
+  } else if (host === "youtube.com" || host === "youtube-nocookie.com") {
+    if (url.pathname === "/watch") {
+      videoId = url.searchParams.get("v");
+    } else if (url.pathname.startsWith("/shorts/")) {
+      videoId = url.pathname.split("/")[2] ?? null;
+    } else if (url.pathname.startsWith("/embed/")) {
+      videoId = url.pathname.split("/")[2] ?? null;
+    } else if (url.pathname.startsWith("/live/")) {
+      videoId = url.pathname.split("/")[2] ?? null;
+    }
+  }
+
+  if (!videoId || !VIDEO_ID_PATTERN.test(videoId)) {
+    return null;
+  }
+
+  const startSeconds = parseTimestamp(url.searchParams.get("t") ?? url.searchParams.get("start"));
+
+  return { videoId, startSeconds };
+}
+
+function parseTimestamp(raw: string | null): number | null {
+  if (!raw) return null;
+  if (/^\d+$/.test(raw)) return parseInt(raw, 10);
+
+  const match = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+
+  const [, h, m, s] = match;
+  return parseInt(h ?? "0", 10) * 3600 + parseInt(m ?? "0", 10) * 60 + parseInt(s ?? "0", 10);
+}
+
+export function youtubeEmbedUrl(videoId: string, startSeconds?: number | null): string {
+  const params = new URLSearchParams();
+  if (startSeconds) params.set("start", String(startSeconds));
+  const query = params.toString();
+  return `https://www.youtube-nocookie.com/embed/${videoId}${query ? `?${query}` : ""}`;
+}


### PR DESCRIPTION
## Summary

- New "Fight Scenes" section on movie detail pages: verified members link a movie's existing cast to a YouTube clip of a specific fight, playable inline.
- Two independent rating tracks, mirroring the movie-level `Rating`/`AdminRating` split: `FightSceneRating` (one per member) and `FightSceneAdminRating` (admin-only "Editors' Score"), both displayed.
- Actors tagged on a fight scene must already be in the movie's cast (`CastCredit`), so members can't tag someone who wasn't in the film.
- Admin `isVerified` toggle plus the existing owner/admin soft-delete moderation model (same shape as discussion posts); owner edits reset `isVerified` so a stale approval can't survive a content change.
- YouTube links are parsed server-side (`src/lib/youtube.ts`) into a normalized `videoId` + optional start time, covering watch/shorts/embed/youtu.be URLs and YouTube's "start at" timestamp param — keeps a clean key for future aggregation (e.g. a "top-rated fight scenes" view) without deciding that UI now.

## Schema

- `FightScene`, `FightSceneCast` (mirrors `CastCredit`'s join shape), `FightSceneRating`, `FightSceneAdminRating` (mirror `Rating`/`AdminRating`'s per-user upsert shape) — migration `20260730033446_fight_scenes`.

## API

- `POST /api/movies/[id]/fight-scenes` — create (verified member; validates actors are in the movie's cast)
- `PATCH` / `DELETE /api/movies/[id]/fight-scenes/[fightSceneId]` — owner edit / owner-or-admin soft-delete
- `POST .../rating` — member rating upsert
- `POST .../admin-rating` — admin rating upsert
- `POST .../verify` — admin verify toggle

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds, no type errors
- [x] Ran `prisma migrate dev` + `prisma db seed` against a local Postgres instance; seed includes a sample verified fight scene with both rating types
- [x] Smoke-tested end-to-end against the dev server via signed-in member/admin sessions: create (rejects actors not in the movie's cast), member rating, admin verify (403 for non-admins), admin rating, owner edit (confirmed it resets `isVerified`), owner soft-delete (confirmed other members' ratings survive the delete)
- [x] Rebased onto latest `master` (post PR #3 merge) and re-verified lint/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_