### PR TITLE
Add fight scene titles, category tags, and social sharing

### DIFF
--- a/prisma/migrations/20260731205510_fight_scene_tags_and_title/migration.sql
+++ b/prisma/migrations/20260731205510_fight_scene_tags_and_title/migration.sql
@@ -1,0 +1,35 @@
+-- AlterTable
+-- Backfill any pre-existing rows with a placeholder, then drop the default so
+-- the column stays required for new rows going forward (the app always
+-- supplies a real title at creation time; this default only exists to make
+-- the ALTER safe against a non-empty table).
+ALTER TABLE "FightScene" ADD COLUMN     "title" TEXT NOT NULL DEFAULT 'Untitled fight scene';
+ALTER TABLE "FightScene" ALTER COLUMN "title" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "FightSceneTag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "FightSceneTag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_FightSceneToFightSceneTag" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_FightSceneToFightSceneTag_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FightSceneTag_name_key" ON "FightSceneTag"("name");
+
+-- CreateIndex
+CREATE INDEX "_FightSceneToFightSceneTag_B_index" ON "_FightSceneToFightSceneTag"("B");
+
+-- AddForeignKey
+ALTER TABLE "_FightSceneToFightSceneTag" ADD CONSTRAINT "_FightSceneToFightSceneTag_A_fkey" FOREIGN KEY ("A") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_FightSceneToFightSceneTag" ADD CONSTRAINT "_FightSceneToFightSceneTag_B_fkey" FOREIGN KEY ("B") REFERENCES "FightSceneTag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,6 +212,7 @@ model FightScene {
   id                 String   @id @default(cuid())
   movieId            String
   submittedById      String
+  title              String
   youtubeVideoId     String
   youtubeStartSeconds Int?
   isVerified         Boolean  @default(false)
@@ -222,10 +223,22 @@ model FightScene {
   movie       Movie                   @relation(fields: [movieId], references: [id], onDelete: Cascade)
   submittedBy User                    @relation(fields: [submittedById], references: [id], onDelete: Cascade)
   cast        FightSceneCast[]
+  tags        FightSceneTag[]
   ratings     FightSceneRating[]
   adminRatings FightSceneAdminRating[]
 
   @@index([movieId])
+}
+
+// Admin-curated vocabulary members pick from when tagging a fight scene's
+// category (e.g. "One vs. Many", "Weapon Duel") — plain many-to-many, same
+// shape as Genre <-> Movie above, since there's nothing extra to store per
+// assignment.
+model FightSceneTag {
+  id   String @id @default(cuid())
+  name String @unique
+
+  fightScenes FightScene[]
 }
 
 model FightSceneCast {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -155,6 +155,13 @@ async function main() {
     create: { adminId: admin.id, movieId: enterTheDragon.id, score: 9, note: "A genre-defining classic." },
   });
 
+  const FIGHT_SCENE_TAGS = ["One vs. Many", "Weapon Duel", "Mirror Maze"];
+  const tagByName = new Map<string, { id: string }>();
+  for (const name of FIGHT_SCENE_TAGS) {
+    const tag = await prisma.fightSceneTag.upsert({ where: { name }, update: {}, create: { name } });
+    tagByName.set(name, tag);
+  }
+
   const bruceLee = await prisma.person.findUniqueOrThrow({ where: { tmdbId: 900201 } });
   const existingFightScene = await prisma.fightScene.findFirst({
     where: { movieId: enterTheDragon.id, submittedById: member.id },
@@ -165,10 +172,12 @@ async function main() {
       data: {
         movieId: enterTheDragon.id,
         submittedById: member.id,
+        title: "Mirror room finale",
         // Sample data: not a real YouTube video id.
         youtubeVideoId: "sampleClip1",
         isVerified: true,
         cast: { create: [{ personId: bruceLee.id, order: 0 }] },
+        tags: { connect: ["One vs. Many", "Mirror Maze"].map((name) => ({ id: tagByName.get(name)!.id })) },
       },
     }));
   await prisma.fightSceneRating.upsert({

--- a/src/app/admin/fight-scene-tags/page.tsx
+++ b/src/app/admin/fight-scene-tags/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+import { AdminFightSceneTags } from "@/components/admin-fight-scene-tags";
+
+export default async function AdminFightSceneTagsPage() {
+  const session = await requireAdminSession();
+  if (!session) {
+    redirect("/");
+  }
+
+  const tags = await prisma.fightSceneTag.findMany({
+    orderBy: { name: "asc" },
+    include: { _count: { select: { fightScenes: true } } },
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-bold text-white">Fight scene tags</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Category tags members pick from when tagging a fight scene (e.g. &ldquo;One vs. Many&rdquo;,
+        &ldquo;Weapon Duel&rdquo;). Members can&rsquo;t create new tags &mdash; only assign from this list.
+      </p>
+      <AdminFightSceneTags initialTags={tags} />
+    </div>
+  );
+}

--- a/src/app/api/admin/fight-scene-tags/[tagId]/route.ts
+++ b/src/app/api/admin/fight-scene-tags/[tagId]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+const MAX_TAG_NAME_LENGTH = 40;
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ tagId: string }> }) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { tagId } = await params;
+  const existing = await prisma.fightSceneTag.findUnique({ where: { id: tagId } });
+  if (!existing) {
+    return NextResponse.json({ error: "Tag not found." }, { status: 404 });
+  }
+
+  const { name } = await request.json();
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "name is required." }, { status: 400 });
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > MAX_TAG_NAME_LENGTH) {
+    return NextResponse.json(
+      { error: `name must be ${MAX_TAG_NAME_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const nameTaken = await prisma.fightSceneTag.findFirst({ where: { name: trimmedName, id: { not: tagId } } });
+  if (nameTaken) {
+    return NextResponse.json({ error: "A tag with that name already exists." }, { status: 400 });
+  }
+
+  const tag = await prisma.fightSceneTag.update({ where: { id: tagId }, data: { name: trimmedName } });
+  return NextResponse.json({ tag });
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ tagId: string }> }) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { tagId } = await params;
+  const existing = await prisma.fightSceneTag.findUnique({ where: { id: tagId } });
+  if (!existing) {
+    return NextResponse.json({ error: "Tag not found." }, { status: 404 });
+  }
+
+  // Hard-delete is fine here (unlike fight scenes/discussion posts): a tag
+  // carries no history worth preserving, it just drops out of scenes that
+  // used it via the implicit join table's cascade.
+  await prisma.fightSceneTag.delete({ where: { id: tagId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/fight-scene-tags/route.ts
+++ b/src/app/api/admin/fight-scene-tags/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+const MAX_TAG_NAME_LENGTH = 40;
+
+export async function GET() {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const tags = await prisma.fightSceneTag.findMany({
+    orderBy: { name: "asc" },
+    include: { _count: { select: { fightScenes: true } } },
+  });
+  return NextResponse.json({ tags });
+}
+
+export async function POST(request: Request) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { name } = await request.json();
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "name is required." }, { status: 400 });
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > MAX_TAG_NAME_LENGTH) {
+    return NextResponse.json(
+      { error: `name must be ${MAX_TAG_NAME_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.fightSceneTag.findUnique({ where: { name: trimmedName } });
+  if (existing) {
+    return NextResponse.json({ error: "A tag with that name already exists." }, { status: 400 });
+  }
+
+  const tag = await prisma.fightSceneTag.create({ data: { name: trimmedName } });
+  return NextResponse.json({ tag: { ...tag, _count: { fightScenes: 0 } } });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { parseYoutubeUrl } from "@/lib/youtube";
-import { MAX_FIGHT_SCENE_CAST } from "@/lib/fight-scenes";
+import { parseAndValidateFightSceneInput } from "@/lib/fight-scenes";
 
 export async function PATCH(
   request: Request,
@@ -22,56 +21,31 @@ export async function PATCH(
     return NextResponse.json({ error: "You can only edit your own submissions." }, { status: 403 });
   }
 
-  const { youtubeUrl, personIds } = await request.json();
-
-  if (typeof youtubeUrl !== "string" || youtubeUrl.trim().length === 0) {
-    return NextResponse.json({ error: "youtubeUrl is required." }, { status: 400 });
+  const body = await request.json();
+  const result = await parseAndValidateFightSceneInput(movieId, body);
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
   }
-
-  const parsed = parseYoutubeUrl(youtubeUrl.trim());
-  if (!parsed) {
-    return NextResponse.json({ error: "That doesn't look like a valid YouTube link." }, { status: 400 });
-  }
-
-  if (!Array.isArray(personIds) || personIds.length === 0 || !personIds.every((p) => typeof p === "string")) {
-    return NextResponse.json({ error: "personIds must be a non-empty array of actor ids." }, { status: 400 });
-  }
-
-  const uniquePersonIds = [...new Set(personIds)];
-  if (uniquePersonIds.length > MAX_FIGHT_SCENE_CAST) {
-    return NextResponse.json(
-      { error: `A fight scene can list at most ${MAX_FIGHT_SCENE_CAST} actors.` },
-      { status: 400 },
-    );
-  }
-
-  const castCount = await prisma.castCredit.count({
-    where: { movieId, personId: { in: uniquePersonIds } },
-  });
-  if (castCount !== uniquePersonIds.length) {
-    return NextResponse.json(
-      { error: "All actors must be part of this movie's cast." },
-      { status: 400 },
-    );
-  }
+  const { title, videoId, startSeconds, personIds, tagIds } = result;
 
   const fightScene = await prisma.$transaction(async (tx) => {
     await tx.fightSceneCast.deleteMany({ where: { fightSceneId } });
     return tx.fightScene.update({
       where: { id: fightSceneId },
       data: {
-        youtubeVideoId: parsed.videoId,
-        youtubeStartSeconds: parsed.startSeconds,
+        title,
+        youtubeVideoId: videoId,
+        youtubeStartSeconds: startSeconds,
         // Content changed, so an earlier admin verification no longer
         // vouches for what's actually there — require re-review.
         isVerified: false,
-        cast: {
-          create: uniquePersonIds.map((personId, order) => ({ personId, order })),
-        },
+        cast: { create: personIds.map((personId, order) => ({ personId, order })) },
+        tags: { set: tagIds.map((id) => ({ id })) },
       },
       include: {
         submittedBy: { select: { name: true, image: true } },
         cast: { orderBy: { order: "asc" }, include: { person: true } },
+        tags: true,
       },
     });
   });

--- a/src/app/api/movies/[id]/fight-scenes/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { isEmailVerified } from "@/lib/verification";
-import { parseYoutubeUrl } from "@/lib/youtube";
-import { MAX_FIGHT_SCENE_CAST } from "@/lib/fight-scenes";
+import { parseAndValidateFightSceneInput } from "@/lib/fight-scenes";
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await auth();
@@ -15,54 +14,27 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
 
   const { id: movieId } = await params;
-  const { youtubeUrl, personIds } = await request.json();
-
-  if (typeof youtubeUrl !== "string" || youtubeUrl.trim().length === 0) {
-    return NextResponse.json({ error: "youtubeUrl is required." }, { status: 400 });
+  const body = await request.json();
+  const result = await parseAndValidateFightSceneInput(movieId, body);
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
   }
-
-  const parsed = parseYoutubeUrl(youtubeUrl.trim());
-  if (!parsed) {
-    return NextResponse.json({ error: "That doesn't look like a valid YouTube link." }, { status: 400 });
-  }
-
-  if (!Array.isArray(personIds) || personIds.length === 0 || !personIds.every((p) => typeof p === "string")) {
-    return NextResponse.json({ error: "personIds must be a non-empty array of actor ids." }, { status: 400 });
-  }
-
-  const uniquePersonIds = [...new Set(personIds)];
-  if (uniquePersonIds.length > MAX_FIGHT_SCENE_CAST) {
-    return NextResponse.json(
-      { error: `A fight scene can list at most ${MAX_FIGHT_SCENE_CAST} actors.` },
-      { status: 400 },
-    );
-  }
-
-  // Actors must already be part of this movie's cast, so members can't tag
-  // someone who was never in the film.
-  const castCount = await prisma.castCredit.count({
-    where: { movieId, personId: { in: uniquePersonIds } },
-  });
-  if (castCount !== uniquePersonIds.length) {
-    return NextResponse.json(
-      { error: "All actors must be part of this movie's cast." },
-      { status: 400 },
-    );
-  }
+  const { title, videoId, startSeconds, personIds, tagIds } = result;
 
   const fightScene = await prisma.fightScene.create({
     data: {
       movieId,
       submittedById: session.user.id,
-      youtubeVideoId: parsed.videoId,
-      youtubeStartSeconds: parsed.startSeconds,
-      cast: {
-        create: uniquePersonIds.map((personId, order) => ({ personId, order })),
-      },
+      title,
+      youtubeVideoId: videoId,
+      youtubeStartSeconds: startSeconds,
+      cast: { create: personIds.map((personId, order) => ({ personId, order })) },
+      tags: { connect: tagIds.map((id) => ({ id })) },
     },
     include: {
       submittedBy: { select: { name: true, image: true } },
       cast: { orderBy: { order: "asc" }, include: { person: true } },
+      tags: true,
     },
   });
 

--- a/src/app/api/youtube/title/route.ts
+++ b/src/app/api/youtube/title/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { parseYoutubeUrl, fetchYoutubeTitle } from "@/lib/youtube";
+
+// Convenience lookup so the fight-scene form can suggest a title as soon as a
+// member pastes a YouTube link. Signed-in gate only (not verified-email) —
+// it has no side effects, this just avoids leaving it as an open relay.
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const url = new URL(request.url).searchParams.get("url");
+  if (!url) {
+    return NextResponse.json({ error: "url is required." }, { status: 400 });
+  }
+
+  const parsed = parseYoutubeUrl(url);
+  if (!parsed) {
+    return NextResponse.json({ title: null });
+  }
+
+  const title = await fetchYoutubeTitle(parsed.videoId);
+  return NextResponse.json({ title });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000"),
   title: "Kung Fu Movie DB",
   description: "An IMDB-style database for kung fu and martial arts films.",
 };

--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { youtubeThumbnailUrl } from "@/lib/youtube";
+import {
+  getFightSceneById,
+  getFightSceneRatingSummaries,
+  getFightSceneAdminRatingSummaries,
+  getFightSceneTags,
+} from "@/lib/fight-scenes";
+import { FightSceneSection } from "@/components/fight-scene-section";
+
+type Params = { id: string; fightSceneId: string };
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { id: movieId, fightSceneId } = await params;
+  const scene = await getFightSceneById(movieId, fightSceneId);
+  if (!scene) return {};
+
+  const summary = await getFightSceneRatingSummaries([scene.id]);
+  const rating = summary.get(scene.id);
+  const description = rating?.count
+    ? `${rating.average?.toFixed(1)}/10 from ${rating.count} member${rating.count === 1 ? "" : "s"} · watch the scene from ${scene.movie.title}`
+    : `Watch the scene from ${scene.movie.title}`;
+
+  return {
+    title: `${scene.title} — ${scene.movie.title}`,
+    description,
+    openGraph: {
+      title: `${scene.title} — ${scene.movie.title}`,
+      description,
+      images: [youtubeThumbnailUrl(scene.youtubeVideoId)],
+    },
+  };
+}
+
+export default async function FightScenePage({ params }: { params: Promise<Params> }) {
+  const { id: movieId, fightSceneId } = await params;
+  const session = await auth();
+
+  const scene = await getFightSceneById(movieId, fightSceneId);
+  if (!scene) {
+    notFound();
+  }
+
+  const [movieCast, tagOptions, ratingSummaries, adminRatingSummaries, myRating, myAdminRating] = await Promise.all([
+    prisma.castCredit.findMany({ where: { movieId }, include: { person: true } }),
+    getFightSceneTags(),
+    getFightSceneRatingSummaries([scene.id]),
+    getFightSceneAdminRatingSummaries([scene.id]),
+    session?.user
+      ? prisma.fightSceneRating.findUnique({
+          where: { userId_fightSceneId: { userId: session.user.id, fightSceneId: scene.id } },
+        })
+      : null,
+    session?.user?.role === "ADMIN"
+      ? prisma.fightSceneAdminRating.findUnique({
+          where: { adminId_fightSceneId: { adminId: session.user.id, fightSceneId: scene.id } },
+        })
+      : null,
+  ]);
+
+  const summary = ratingSummaries.get(scene.id);
+  const adminSummary = adminRatingSummaries.get(scene.id);
+
+  const serializedScene = {
+    id: scene.id,
+    title: scene.title,
+    youtubeVideoId: scene.youtubeVideoId,
+    youtubeStartSeconds: scene.youtubeStartSeconds,
+    isVerified: scene.isVerified,
+    submittedById: scene.submittedById,
+    createdAt: scene.createdAt.toISOString(),
+    updatedAt: scene.updatedAt.toISOString(),
+    submittedBy: scene.submittedBy,
+    cast: scene.cast,
+    tags: scene.tags,
+    ratingAverage: summary?.average ?? null,
+    ratingCount: summary?.count ?? 0,
+    adminRatingAverage: adminSummary?.average ?? null,
+    adminRatingCount: adminSummary?.count ?? 0,
+  };
+
+  const castOptions = movieCast.map((credit) => ({ id: credit.person.id, name: credit.person.name }));
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <Link href={`/movies/${movieId}`} className="inline-flex items-center gap-1 text-sm text-neutral-400 hover:text-white">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+          <path d="M15 18l-6-6 6-6" />
+        </svg>
+        {scene.movie.title}
+      </Link>
+
+      <FightSceneSection
+        movieId={movieId}
+        initialFightScenes={[serializedScene]}
+        castOptions={castOptions}
+        tagOptions={tagOptions}
+        signedIn={!!session?.user}
+        currentUserId={session?.user?.id ?? null}
+        isAdmin={session?.user?.role === "ADMIN"}
+        myRatings={myRating ? { [scene.id]: myRating.score } : {}}
+        myAdminRatings={myAdminRating ? { [scene.id]: myAdminRating.score } : {}}
+        heading={null}
+        allowAdd={false}
+      />
+    </div>
+  );
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   getFightScenesForMovie,
   getFightSceneRatingSummaries,
   getFightSceneAdminRatingSummaries,
+  getFightSceneTags,
 } from "@/lib/fight-scenes";
 import { RatingWidget } from "@/components/rating-widget";
 import { AdminRatingWidget } from "@/components/admin-rating-widget";
@@ -35,20 +36,22 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     notFound();
   }
 
-  const [communityRating, editorsRating, myRating, myListEntries, discussionPage, fightScenes] = await Promise.all([
-    getCommunityRatingSummary(movie.id),
-    getEditorsRatingSummary(movie.id),
-    session?.user
-      ? prisma.rating.findUnique({
-          where: { userId_movieId: { userId: session.user.id, movieId: movie.id } },
-        })
-      : null,
-    session?.user
-      ? prisma.listEntry.findMany({ where: { userId: session.user.id, movieId: movie.id } })
-      : [],
-    getDiscussionPage(movie.id),
-    getFightScenesForMovie(movie.id),
-  ]);
+  const [communityRating, editorsRating, myRating, myListEntries, discussionPage, fightScenes, fightSceneTags] =
+    await Promise.all([
+      getCommunityRatingSummary(movie.id),
+      getEditorsRatingSummary(movie.id),
+      session?.user
+        ? prisma.rating.findUnique({
+            where: { userId_movieId: { userId: session.user.id, movieId: movie.id } },
+          })
+        : null,
+      session?.user
+        ? prisma.listEntry.findMany({ where: { userId: session.user.id, movieId: movie.id } })
+        : [],
+      getDiscussionPage(movie.id),
+      getFightScenesForMovie(movie.id),
+      getFightSceneTags(),
+    ]);
 
   const myAdminRating = session?.user?.role === "ADMIN"
     ? await prisma.adminRating.findUnique({
@@ -84,6 +87,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     const adminSummary = fightSceneAdminRatingSummaries.get(scene.id);
     return {
       id: scene.id,
+      title: scene.title,
       youtubeVideoId: scene.youtubeVideoId,
       youtubeStartSeconds: scene.youtubeStartSeconds,
       isVerified: scene.isVerified,
@@ -92,6 +96,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       updatedAt: scene.updatedAt.toISOString(),
       submittedBy: scene.submittedBy,
       cast: scene.cast,
+      tags: scene.tags,
       ratingAverage: summary?.average ?? null,
       ratingCount: summary?.count ?? 0,
       adminRatingAverage: adminSummary?.average ?? null,
@@ -245,6 +250,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           movieId={movie.id}
           initialFightScenes={serializedFightScenes}
           castOptions={castOptions}
+          tagOptions={fightSceneTags}
           signedIn={!!session?.user}
           currentUserId={session?.user?.id ?? null}
           isAdmin={session?.user?.role === "ADMIN"}

--- a/src/components/admin-fight-scene-tags.tsx
+++ b/src/components/admin-fight-scene-tags.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import type { FightSceneTag } from "@/generated/prisma/client";
+
+type TagItem = Pick<FightSceneTag, "id" | "name"> & { _count: { fightScenes: number } };
+
+export function AdminFightSceneTags({ initialTags }: { initialTags: TagItem[] }) {
+  const [tags, setTags] = useState(initialTags);
+  const [newName, setNewName] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setSaving(true);
+    setError(null);
+    const res = await fetch("/api/admin/fight-scene-tags", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { tag } = await res.json();
+    setTags((prev) => [...prev, tag].sort((a, b) => a.name.localeCompare(b.name)));
+    setNewName("");
+  }
+
+  function startEdit(tag: TagItem) {
+    setEditingId(tag.id);
+    setEditName(tag.name);
+    setError(null);
+  }
+
+  async function saveEdit(id: string) {
+    if (!editName.trim()) return;
+    setSaving(true);
+    setError(null);
+    const res = await fetch(`/api/admin/fight-scene-tags/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editName.trim() }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { tag } = await res.json();
+    setTags((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, name: tag.name } : t)).sort((a, b) => a.name.localeCompare(b.name)),
+    );
+    setEditingId(null);
+  }
+
+  async function handleDelete(id: string) {
+    if (!window.confirm("Delete this tag? It will be removed from any fight scenes using it.")) return;
+    setError(null);
+    const res = await fetch(`/api/admin/fight-scene-tags/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setTags((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleAdd} className="mb-6 flex gap-2">
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder='New tag name, e.g. "Weapon Duel"'
+          className="flex-1 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={saving || !newName.trim()}
+          className="rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+        >
+          Add tag
+        </button>
+      </form>
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      <ul className="flex flex-col gap-2">
+        {tags.map((tag) => (
+          <li
+            key={tag.id}
+            className="flex items-center justify-between gap-2 rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2"
+          >
+            {editingId === tag.id ? (
+              <>
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="flex-1 rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                />
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => saveEdit(tag.id)}
+                    disabled={saving}
+                    className="text-xs text-neutral-300 hover:text-white"
+                  >
+                    Save
+                  </button>
+                  <button onClick={() => setEditingId(null)} className="text-xs text-neutral-400 hover:text-white">
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <span className="text-sm text-neutral-100">{tag.name}</span>
+                <div className="flex items-center gap-3 text-xs text-neutral-500">
+                  <span>
+                    {tag._count.fightScenes} scene{tag._count.fightScenes === 1 ? "" : "s"}
+                  </span>
+                  <button onClick={() => startEdit(tag)} className="text-neutral-400 hover:text-white">
+                    Rename
+                  </button>
+                  <button onClick={() => handleDelete(tag.id)} className="text-neutral-400 hover:text-red-400">
+                    Delete
+                  </button>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
+        {tags.length === 0 && <p className="text-sm text-neutral-500">No tags yet.</p>}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { FightSceneCast, Person, User } from "@/generated/prisma/client";
+import type { FightSceneCast, FightSceneTag, Person, User } from "@/generated/prisma/client";
+import { ShareButton } from "@/components/share-button";
 
 const SCORES = Array.from({ length: 10 }, (_, i) => i + 1);
 const MAX_NOTE_LENGTH = 2000;
+const MAX_TITLE_LENGTH = 200;
 
 export type CastOption = Pick<Person, "id" | "name">;
+export type TagOption = Pick<FightSceneTag, "id" | "name">;
 
 type FightSceneSubmitter = Pick<User, "name" | "image">;
 type FightSceneCastPerson = Pick<Person, "id" | "name" | "profilePath">;
@@ -17,6 +21,7 @@ type FightSceneCastItem = Pick<FightSceneCast, "id" | "order"> & { person: Fight
 // same reasoning as DiscussionThread.
 export type FightSceneItem = {
   id: string;
+  title: string;
   youtubeVideoId: string;
   youtubeStartSeconds: number | null;
   isVerified: boolean;
@@ -25,6 +30,7 @@ export type FightSceneItem = {
   updatedAt: string;
   submittedBy: FightSceneSubmitter;
   cast: FightSceneCastItem[];
+  tags: TagOption[];
   ratingAverage: number | null;
   ratingCount: number;
   adminRatingAverage: number | null;
@@ -38,29 +44,33 @@ function embedUrl(videoId: string, startSeconds: number | null) {
   return `https://www.youtube-nocookie.com/embed/${videoId}${query ? `?${query}` : ""}`;
 }
 
-function CastPicker({
+function ChipPicker({
   options,
   selected,
   onToggle,
+  tagStyle,
 }: {
-  options: CastOption[];
+  options: { id: string; name: string }[];
   selected: Set<string>;
   onToggle: (id: string) => void;
+  tagStyle?: boolean;
 }) {
   return (
     <div className="flex max-h-32 flex-wrap gap-2 overflow-y-auto rounded-md border border-neutral-700 bg-neutral-950 p-2">
-      {options.map((person) => (
+      {options.map((option) => (
         <label
-          key={person.id}
-          className="flex cursor-pointer items-center gap-1.5 rounded-full border border-neutral-700 px-2 py-1 text-xs text-neutral-300 has-checked:border-red-600 has-checked:text-white"
+          key={option.id}
+          className={`flex cursor-pointer items-center gap-1.5 rounded-full border border-neutral-700 px-2 py-1 text-xs text-neutral-300 ${
+            tagStyle ? "has-checked:border-red-600 has-checked:bg-red-950/40 has-checked:text-red-300" : "has-checked:border-red-600 has-checked:text-white"
+          }`}
         >
           <input
             type="checkbox"
-            checked={selected.has(person.id)}
-            onChange={() => onToggle(person.id)}
+            checked={selected.has(option.id)}
+            onChange={() => onToggle(option.id)}
             className="sr-only"
           />
-          {person.name}
+          {option.name}
         </label>
       ))}
     </div>
@@ -69,31 +79,70 @@ function CastPicker({
 
 function FightSceneForm({
   castOptions,
+  tagOptions,
+  initialTitle = "",
   initialUrl = "",
   initialPersonIds = [],
+  initialTagIds = [],
   submitLabel,
   submitting,
   onCancel,
   onSubmit,
 }: {
   castOptions: CastOption[];
+  tagOptions: TagOption[];
+  initialTitle?: string;
   initialUrl?: string;
   initialPersonIds?: string[];
+  initialTagIds?: string[];
   submitLabel: string;
   submitting: boolean;
   onCancel?: () => void;
-  onSubmit: (youtubeUrl: string, personIds: string[]) => void;
+  onSubmit: (title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) => void;
 }) {
+  const [title, setTitle] = useState(initialTitle);
   const [url, setUrl] = useState(initialUrl);
-  const [selected, setSelected] = useState<Set<string>>(new Set(initialPersonIds));
+  const [selectedCast, setSelectedCast] = useState<Set<string>>(new Set(initialPersonIds));
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set(initialTagIds));
+  const [suggestingTitle, setSuggestingTitle] = useState(false);
+  const lastSuggestedTitle = useRef("");
 
-  function toggle(id: string) {
-    setSelected((prev) => {
+  function toggleCast(id: string) {
+    setSelectedCast((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
+  }
+
+  function toggleTag(id: string) {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function suggestTitle() {
+    if (!url.trim()) return;
+    // Don't clobber a title the submitter already typed themselves — only
+    // fill in if it's still blank or still equals our last suggestion.
+    if (title.trim() && title !== lastSuggestedTitle.current) return;
+    setSuggestingTitle(true);
+    try {
+      const res = await fetch(`/api/youtube/title?url=${encodeURIComponent(url.trim())}`);
+      if (res.ok) {
+        const body = await res.json();
+        if (typeof body.title === "string" && body.title) {
+          lastSuggestedTitle.current = body.title;
+          setTitle(body.title);
+        }
+      }
+    } finally {
+      setSuggestingTitle(false);
+    }
   }
 
   return (
@@ -102,17 +151,30 @@ function FightSceneForm({
         type="url"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
+        onBlur={suggestTitle}
         placeholder="Paste the YouTube link to this fight scene…"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+      />
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        maxLength={MAX_TITLE_LENGTH}
+        placeholder={suggestingTitle ? "Suggesting a title from YouTube…" : 'Title, e.g. "Mirror Room Finale"'}
         className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
       />
       <div>
         <p className="mb-1 text-xs text-neutral-500">Actors in this scene</p>
-        <CastPicker options={castOptions} selected={selected} onToggle={toggle} />
+        <ChipPicker options={castOptions} selected={selectedCast} onToggle={toggleCast} />
+      </div>
+      <div>
+        <p className="mb-1 text-xs text-neutral-500">Category tags (optional)</p>
+        <ChipPicker options={tagOptions} selected={selectedTags} onToggle={toggleTag} tagStyle />
       </div>
       <div className="flex gap-2">
         <button
-          onClick={() => onSubmit(url, [...selected])}
-          disabled={submitting || !url.trim() || selected.size === 0}
+          onClick={() => onSubmit(title, url, [...selectedCast], [...selectedTags])}
+          disabled={submitting || !url.trim() || !title.trim() || selectedCast.size === 0}
           className="w-fit rounded-md bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
         >
           {submitting ? "Saving…" : submitLabel}
@@ -169,20 +231,26 @@ export function FightSceneSection({
   movieId,
   initialFightScenes,
   castOptions,
+  tagOptions,
   signedIn,
   currentUserId,
   isAdmin,
   myRatings,
   myAdminRatings,
+  heading = "Fight Scenes",
+  allowAdd = true,
 }: {
   movieId: string;
   initialFightScenes: FightSceneItem[];
   castOptions: CastOption[];
+  tagOptions: TagOption[];
   signedIn: boolean;
   currentUserId: string | null;
   isAdmin: boolean;
   myRatings: Record<string, number>;
   myAdminRatings: Record<string, number>;
+  heading?: string | null;
+  allowAdd?: boolean;
 }) {
   const router = useRouter();
   const [scenes, setScenes] = useState(initialFightScenes);
@@ -194,13 +262,13 @@ export function FightSceneSection({
   const [error, setError] = useState<string | null>(null);
   const [adminNoteDrafts, setAdminNoteDrafts] = useState<Record<string, string>>({});
 
-  async function handleCreate(youtubeUrl: string, personIds: string[]) {
+  async function handleCreate(title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) {
     setSubmitting(true);
     setError(null);
     const res = await fetch(`/api/movies/${movieId}/fight-scenes`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ youtubeUrl, personIds }),
+      body: JSON.stringify({ title, youtubeUrl, personIds, tagIds }),
     });
     setSubmitting(false);
     if (!res.ok) {
@@ -216,13 +284,13 @@ export function FightSceneSection({
     setAdding(false);
   }
 
-  async function handleEdit(id: string, youtubeUrl: string, personIds: string[]) {
+  async function handleEdit(id: string, title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) {
     setSubmitting(true);
     setError(null);
     const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ youtubeUrl, personIds }),
+      body: JSON.stringify({ title, youtubeUrl, personIds, tagIds }),
     });
     setSubmitting(false);
     if (!res.ok) {
@@ -297,17 +365,19 @@ export function FightSceneSection({
 
   return (
     <section className="mt-10">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-xl font-bold text-white">Fight Scenes</h2>
-        {signedIn && !adding && castOptions.length > 0 && (
-          <button
-            onClick={() => setAdding(true)}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
-          >
-            + Add fight scene
-          </button>
-        )}
-      </div>
+      {heading && (
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-white">{heading}</h2>
+          {allowAdd && signedIn && !adding && castOptions.length > 0 && (
+            <button
+              onClick={() => setAdding(true)}
+              className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+            >
+              + Add fight scene
+            </button>
+          )}
+        </div>
+      )}
 
       {!signedIn && (
         <p className="mb-4 text-sm text-neutral-400">
@@ -324,6 +394,7 @@ export function FightSceneSection({
         <div className="mb-6 rounded-md border border-neutral-800 bg-neutral-900 p-3">
           <FightSceneForm
             castOptions={castOptions}
+            tagOptions={tagOptions}
             submitLabel="Add fight scene"
             submitting={submitting}
             onCancel={() => setAdding(false)}
@@ -336,28 +407,39 @@ export function FightSceneSection({
         {scenes.map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;
+          const permalinkPath = `/movies/${movieId}/fight-scenes/${scene.id}`;
 
           return (
             <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
               {editingId === scene.id ? (
                 <FightSceneForm
                   castOptions={castOptions}
+                  tagOptions={tagOptions}
+                  initialTitle={scene.title}
                   initialPersonIds={scene.cast.map((c) => c.person.id)}
+                  initialTagIds={scene.tags.map((t) => t.id)}
                   submitLabel="Save"
                   submitting={submitting}
                   onCancel={() => setEditingId(null)}
-                  onSubmit={(url, personIds) => handleEdit(scene.id, url, personIds)}
+                  onSubmit={(title, url, personIds, tagIds) => handleEdit(scene.id, title, url, personIds, tagIds)}
                 />
               ) : (
                 <>
                   <div className="aspect-video w-full overflow-hidden rounded-md bg-black">
                     <iframe
                       src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
-                      title="Fight scene"
+                      title={scene.title}
                       className="h-full w-full"
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                       allowFullScreen
                     />
+                  </div>
+
+                  <div className="mt-2 flex items-start justify-between gap-2">
+                    <Link href={permalinkPath} className="font-medium text-neutral-100 hover:text-red-400">
+                      {scene.title}
+                    </Link>
+                    <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
                   </div>
 
                   <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
@@ -367,6 +449,14 @@ export function FightSceneSection({
                         className="rounded-full border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300"
                       >
                         {c.person.name}
+                      </span>
+                    ))}
+                    {scene.tags.map((tag) => (
+                      <span
+                        key={tag.id}
+                        className="rounded-full border border-red-900/60 bg-red-950/30 px-2 py-0.5 text-xs text-red-300"
+                      >
+                        {tag.name}
                       </span>
                     ))}
                     {scene.isVerified && (

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+
+export function ShareButton({
+  path,
+  title,
+  variant = "button",
+}: {
+  path: string;
+  title: string;
+  variant?: "button" | "icon";
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  function absoluteUrl() {
+    return `${window.location.origin}${path}`;
+  }
+
+  async function handleClick() {
+    const url = absoluteUrl();
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({ title, url });
+      } catch {
+        // Ignored: user cancelled the OS share sheet.
+      }
+      return;
+    }
+    setMenuOpen((open) => !open);
+  }
+
+  async function copyLink() {
+    await navigator.clipboard.writeText(absoluteUrl());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  function shareIntent(platform: "x" | "facebook" | "reddit") {
+    const url = absoluteUrl();
+    const encodedUrl = encodeURIComponent(url);
+    const encodedTitle = encodeURIComponent(title);
+    const intents = {
+      x: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+      reddit: `https://www.reddit.com/submit?url=${encodedUrl}&title=${encodedTitle}`,
+    };
+    window.open(intents[platform], "_blank", "noopener,noreferrer,width=600,height=500");
+    setMenuOpen(false);
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={handleClick}
+        title="Share"
+        className={
+          variant === "icon"
+            ? "flex h-8 w-8 items-center justify-center rounded-md border border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:text-white"
+            : "flex items-center gap-1.5 rounded-md bg-red-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-600"
+        }
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+        >
+          <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7M16 6l-4-4-4 4M12 2v14" />
+        </svg>
+        {variant === "button" && "Share"}
+      </button>
+
+      {menuOpen && (
+        <div className="absolute right-0 top-full z-10 mt-1.5 min-w-44 rounded-md border border-neutral-700 bg-neutral-800 p-1 shadow-xl">
+          <button
+            onClick={copyLink}
+            className="w-full rounded px-3 py-1.5 text-left text-sm text-neutral-100 hover:bg-neutral-700"
+          >
+            {copied ? "Copied!" : "Copy link"}
+          </button>
+          <div className="my-1 h-px bg-neutral-700" />
+          <button
+            onClick={() => shareIntent("x")}
+            className="w-full rounded px-3 py-1.5 text-left text-sm text-neutral-100 hover:bg-neutral-700"
+          >
+            Share to X
+          </button>
+          <button
+            onClick={() => shareIntent("facebook")}
+            className="w-full rounded px-3 py-1.5 text-left text-sm text-neutral-100 hover:bg-neutral-700"
+          >
+            Share to Facebook
+          </button>
+          <button
+            onClick={() => shareIntent("reddit")}
+            className="w-full rounded px-3 py-1.5 text-left text-sm text-neutral-100 hover:bg-neutral-700"
+          >
+            Share to Reddit
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/fight-scenes.ts
+++ b/src/lib/fight-scenes.ts
@@ -1,24 +1,43 @@
 import { prisma } from "@/lib/prisma";
+import { parseYoutubeUrl } from "@/lib/youtube";
 
 export const MAX_FIGHT_SCENE_CAST = 20;
+export const MAX_FIGHT_SCENE_TAGS = 10;
+export const MAX_FIGHT_SCENE_TITLE_LENGTH = 200;
 
 export interface FightSceneRatingSummary {
   average: number | null;
   count: number;
 }
 
+const fightSceneInclude = {
+  submittedBy: { select: { name: true, image: true } },
+  cast: {
+    orderBy: { order: "asc" as const },
+    include: { person: true },
+  },
+  tags: true,
+};
+
 export async function getFightScenesForMovie(movieId: string) {
   return prisma.fightScene.findMany({
     where: { movieId, isDeleted: false },
     orderBy: { createdAt: "desc" },
-    include: {
-      submittedBy: { select: { name: true, image: true } },
-      cast: {
-        orderBy: { order: "asc" },
-        include: { person: true },
-      },
-    },
+    include: fightSceneInclude,
   });
+}
+
+export async function getFightSceneById(movieId: string, fightSceneId: string) {
+  const scene = await prisma.fightScene.findUnique({
+    where: { id: fightSceneId },
+    include: { ...fightSceneInclude, movie: { select: { id: true, title: true } } },
+  });
+  if (!scene || scene.movieId !== movieId || scene.isDeleted) return null;
+  return scene;
+}
+
+export function getFightSceneTags() {
+  return prisma.fightSceneTag.findMany({ orderBy: { name: "asc" } });
 }
 
 export async function getFightSceneRatingSummaries(
@@ -57,4 +76,76 @@ export async function getFightSceneAdminRatingSummaries(
     map.set(row.fightSceneId, { average: row._avg.score, count: row._count._all });
   }
   return map;
+}
+
+interface ValidatedFightSceneInput {
+  title: string;
+  videoId: string;
+  startSeconds: number | null;
+  personIds: string[];
+  tagIds: string[];
+}
+
+// Shared by the create and edit routes: parses/validates title, YouTube link,
+// actors (must be in the movie's cast), and tags (must exist) from a raw
+// request body. Returns either the validated fields or a {error, status} to
+// send straight back to the client.
+export async function parseAndValidateFightSceneInput(
+  movieId: string,
+  body: unknown,
+): Promise<ValidatedFightSceneInput | { error: string; status: number }> {
+  const { title, youtubeUrl, personIds, tagIds } = (body ?? {}) as Record<string, unknown>;
+
+  if (typeof title !== "string" || title.trim().length === 0) {
+    return { error: "title is required.", status: 400 };
+  }
+  const trimmedTitle = title.trim();
+  if (trimmedTitle.length > MAX_FIGHT_SCENE_TITLE_LENGTH) {
+    return { error: `title must be ${MAX_FIGHT_SCENE_TITLE_LENGTH} characters or fewer.`, status: 400 };
+  }
+
+  if (typeof youtubeUrl !== "string" || youtubeUrl.trim().length === 0) {
+    return { error: "youtubeUrl is required.", status: 400 };
+  }
+  const parsed = parseYoutubeUrl(youtubeUrl.trim());
+  if (!parsed) {
+    return { error: "That doesn't look like a valid YouTube link.", status: 400 };
+  }
+
+  if (!Array.isArray(personIds) || personIds.length === 0 || !personIds.every((p) => typeof p === "string")) {
+    return { error: "personIds must be a non-empty array of actor ids.", status: 400 };
+  }
+  const uniquePersonIds = [...new Set(personIds)];
+  if (uniquePersonIds.length > MAX_FIGHT_SCENE_CAST) {
+    return { error: `A fight scene can list at most ${MAX_FIGHT_SCENE_CAST} actors.`, status: 400 };
+  }
+  // Actors must already be part of this movie's cast, so members can't tag
+  // someone who was never in the film.
+  const castCount = await prisma.castCredit.count({ where: { movieId, personId: { in: uniquePersonIds } } });
+  if (castCount !== uniquePersonIds.length) {
+    return { error: "All actors must be part of this movie's cast.", status: 400 };
+  }
+
+  const rawTagIds = tagIds ?? [];
+  if (!Array.isArray(rawTagIds) || !rawTagIds.every((t) => typeof t === "string")) {
+    return { error: "tagIds must be an array of tag ids.", status: 400 };
+  }
+  const uniqueTagIds = [...new Set(rawTagIds)];
+  if (uniqueTagIds.length > MAX_FIGHT_SCENE_TAGS) {
+    return { error: `A fight scene can have at most ${MAX_FIGHT_SCENE_TAGS} tags.`, status: 400 };
+  }
+  if (uniqueTagIds.length > 0) {
+    const tagCount = await prisma.fightSceneTag.count({ where: { id: { in: uniqueTagIds } } });
+    if (tagCount !== uniqueTagIds.length) {
+      return { error: "One or more tags don't exist.", status: 400 };
+    }
+  }
+
+  return {
+    title: trimmedTitle,
+    videoId: parsed.videoId,
+    startSeconds: parsed.startSeconds,
+    personIds: uniquePersonIds,
+    tagIds: uniqueTagIds,
+  };
 }

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -60,3 +60,25 @@ export function youtubeEmbedUrl(videoId: string, startSeconds?: number | null): 
   const query = params.toString();
   return `https://www.youtube-nocookie.com/embed/${videoId}${query ? `?${query}` : ""}`;
 }
+
+export function youtubeThumbnailUrl(videoId: string): string {
+  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+}
+
+// YouTube's public oEmbed endpoint needs no API key/quota, unlike the Data
+// API — good enough for "suggest a title the submitter can overwrite."
+// Returns null on any failure (private/deleted video, network error) so
+// callers can fall back to asking the submitter to type their own title.
+export async function fetchYoutubeTitle(videoId: string): Promise<string | null> {
+  const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+  const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(watchUrl)}&format=json`;
+
+  try {
+    const res = await fetch(oembedUrl);
+    if (!res.ok) return null;
+    const body = await res.json();
+    return typeof body.title === "string" ? body.title : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Three additions to the Fight Scenes feature (from #4):

- **Titles** — fight scenes now have a required, submitter-editable title. The add/edit form suggests one automatically via YouTube's public oEmbed endpoint (no API key/quota needed) as soon as a link is pasted, but never overwrites a title the submitter already typed themselves, and degrades silently to manual entry if the lookup fails.
- **Category tags** — `FightSceneTag` is an admin-curated vocabulary, plain many-to-many with `FightScene` (same shape as the existing `Genre` <-> `Movie` relation). Members pick from the list when submitting/editing a scene; they can't invent new tags. New `/admin/fight-scene-tags` page for admin CRUD (create/rename/delete, with usage counts).
- **Sharing** — every fight scene gets a permalink at `/movies/[id]/fight-scenes/[fightSceneId]`, with per-scene Open Graph tags (title/description built from that scene's own rating, image pulled from the YouTube thumbnail) so shared links unfurl correctly instead of showing the generic movie page. `ShareButton` uses `navigator.share()` where supported, falling back to X/Facebook/Reddit intent links plus copy-link. The permalink page reuses `FightSceneSection` (now takes optional `heading`/`allowAdd` props) against a single-item list rather than duplicating the rating/edit/verify interaction logic.

## Migration note

This adds a required `title` column and a new `FightSceneTag` table. The migration backfills any pre-existing `FightScene` rows with a placeholder title before making the column required, so it's safe to run against a database that already has data — unlike the previous migration, which wasn't and broke the movie pages in production until `prisma migrate deploy` was run manually. **This still needs `prisma migrate deploy` run against production after merge**, before these pages will work there.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds, no type errors
- [x] Ran the new migration against a local Postgres instance (including the backfill path, by seeding rows before adding the migration) and reseeded
- [x] End-to-end smoke test against the dev server via signed-in member/admin sessions:
  - Title required on create (400 without it); oEmbed suggestion endpoint gracefully returns `{title: null}` on lookup failure rather than erroring (verified the fallback path; the success path is blocked by this sandbox's network egress allowlist, not app code — needs confirming once deployed)
  - Tag CRUD: 403 for non-admins, duplicate-name rejection, rename, delete
  - Creating/editing a fight scene with tags: bogus tag id rejected (400), tag set correctly re-synced on edit (including clearing to empty)
  - Permalink page: renders scene title/actors/tags/breadcrumb; `og:description` dynamically reflects rating average/count as ratings come in; `og:image` is the YouTube thumbnail
  - Admin-only `/admin/fight-scene-tags` page: 307 redirect for non-admins, renders correctly for admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_