### PR TITLE
Poster House visual theme + Fight Ticket card redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,4 +3,33 @@
 @theme inline {
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+
+  /* --- "Poster House" preview palette ---
+     Remaps the neutral/red/yellow/amber scales the whole app already uses,
+     so every bg-neutral-950 / text-red-600 / etc. across every page picks
+     this up automatically — no per-component edits needed. Experimental;
+     revert by deleting this block. */
+  --color-neutral-950: #120d0a;
+  --color-neutral-900: #1e150e;
+  --color-neutral-800: #2a1c10;
+  --color-neutral-700: #3a2a1c;
+  --color-neutral-600: #4d3a26;
+  --color-neutral-500: #8f7a63;
+  --color-neutral-400: #c9b8a0;
+  --color-neutral-300: #dcd0bd;
+  --color-neutral-100: #f2e6d3;
+
+  --color-red-950: #2c0f0a;
+  --color-red-900: #4a1810;
+  --color-red-700: #b8241b;
+  --color-red-600: #d4382c;
+  --color-red-500: #d4685c;
+  --color-red-400: #e2857c;
+
+  --color-yellow-500: #d4a72c;
+
+  --color-amber-950: #2a1d0c;
+  --color-amber-900: #3d2a12;
+  --color-amber-800: #5c4420;
+  --color-amber-500: #cf9a3e;
 }

--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -9,6 +9,7 @@ import {
   getFightSceneRatingSummaries,
   getFightSceneAdminRatingSummaries,
   getFightSceneTags,
+  getFightSceneRoundNumbers,
 } from "@/lib/fight-scenes";
 import { FightSceneSection } from "@/components/fight-scene-section";
 
@@ -45,28 +46,31 @@ export default async function FightScenePage({ params }: { params: Promise<Param
     notFound();
   }
 
-  const [movieCast, tagOptions, ratingSummaries, adminRatingSummaries, myRating, myAdminRating] = await Promise.all([
-    prisma.castCredit.findMany({ where: { movieId }, include: { person: true } }),
-    getFightSceneTags(),
-    getFightSceneRatingSummaries([scene.id]),
-    getFightSceneAdminRatingSummaries([scene.id]),
-    session?.user
-      ? prisma.fightSceneRating.findUnique({
-          where: { userId_fightSceneId: { userId: session.user.id, fightSceneId: scene.id } },
-        })
-      : null,
-    session?.user?.role === "ADMIN"
-      ? prisma.fightSceneAdminRating.findUnique({
-          where: { adminId_fightSceneId: { adminId: session.user.id, fightSceneId: scene.id } },
-        })
-      : null,
-  ]);
+  const [movieCast, tagOptions, ratingSummaries, adminRatingSummaries, myRating, myAdminRating, roundNumbers] =
+    await Promise.all([
+      prisma.castCredit.findMany({ where: { movieId }, include: { person: true } }),
+      getFightSceneTags(),
+      getFightSceneRatingSummaries([scene.id]),
+      getFightSceneAdminRatingSummaries([scene.id]),
+      session?.user
+        ? prisma.fightSceneRating.findUnique({
+            where: { userId_fightSceneId: { userId: session.user.id, fightSceneId: scene.id } },
+          })
+        : null,
+      session?.user?.role === "ADMIN"
+        ? prisma.fightSceneAdminRating.findUnique({
+            where: { adminId_fightSceneId: { adminId: session.user.id, fightSceneId: scene.id } },
+          })
+        : null,
+      getFightSceneRoundNumbers(movieId),
+    ]);
 
   const summary = ratingSummaries.get(scene.id);
   const adminSummary = adminRatingSummaries.get(scene.id);
 
   const serializedScene = {
     id: scene.id,
+    roundNumber: roundNumbers.get(scene.id) ?? 0,
     title: scene.title,
     youtubeVideoId: scene.youtubeVideoId,
     youtubeStartSeconds: scene.youtubeStartSeconds,

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   getFightSceneRatingSummaries,
   getFightSceneAdminRatingSummaries,
   getFightSceneTags,
+  getFightSceneRoundNumbers,
 } from "@/lib/fight-scenes";
 import { RatingWidget } from "@/components/rating-widget";
 import { AdminRatingWidget } from "@/components/admin-rating-widget";
@@ -65,21 +66,27 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     : null;
 
   const fightSceneIds = fightScenes.map((s) => s.id);
-  const [fightSceneRatingSummaries, fightSceneAdminRatingSummaries, myFightSceneRatings, myFightSceneAdminRatings] =
-    await Promise.all([
-      getFightSceneRatingSummaries(fightSceneIds),
-      getFightSceneAdminRatingSummaries(fightSceneIds),
-      session?.user
-        ? prisma.fightSceneRating.findMany({
-            where: { userId: session.user.id, fightSceneId: { in: fightSceneIds } },
-          })
-        : [],
-      session?.user?.role === "ADMIN"
-        ? prisma.fightSceneAdminRating.findMany({
-            where: { adminId: session.user.id, fightSceneId: { in: fightSceneIds } },
-          })
-        : [],
-    ]);
+  const [
+    fightSceneRatingSummaries,
+    fightSceneAdminRatingSummaries,
+    myFightSceneRatings,
+    myFightSceneAdminRatings,
+    fightSceneRoundNumbers,
+  ] = await Promise.all([
+    getFightSceneRatingSummaries(fightSceneIds),
+    getFightSceneAdminRatingSummaries(fightSceneIds),
+    session?.user
+      ? prisma.fightSceneRating.findMany({
+          where: { userId: session.user.id, fightSceneId: { in: fightSceneIds } },
+        })
+      : [],
+    session?.user?.role === "ADMIN"
+      ? prisma.fightSceneAdminRating.findMany({
+          where: { adminId: session.user.id, fightSceneId: { in: fightSceneIds } },
+        })
+      : [],
+    getFightSceneRoundNumbers(movie.id),
+  ]);
 
   const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
   const posterUrl = tmdbImageUrl(movie.posterPath, "w342");
@@ -92,6 +99,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     const adminSummary = fightSceneAdminRatingSummaries.get(scene.id);
     return {
       id: scene.id,
+      roundNumber: fightSceneRoundNumbers.get(scene.id) ?? 0,
       title: scene.title,
       youtubeVideoId: scene.youtubeVideoId,
       youtubeStartSeconds: scene.youtubeStartSeconds,

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -158,7 +158,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         </div>
 
         <div className="flex-1 pt-6 sm:pt-24">
-          <h1 className="text-3xl font-bold text-white">
+          <h1 className="font-serif text-3xl font-bold text-white">
             {movie.title} {year && <span className="text-neutral-400">({year})</span>}
           </h1>
 
@@ -234,7 +234,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       <div className="mx-auto w-full max-w-6xl px-4 py-8">
         {movie.cast.length > 0 && (
           <section className="mb-8">
-            <h2 className="mb-4 text-xl font-bold text-white">Cast</h2>
+            <h2 className="mb-4 font-serif text-xl font-bold text-white">Cast</h2>
             <div className="flex gap-4 overflow-x-auto pb-2">
               {movie.cast.map((credit) => (
                 <div key={credit.id} className="w-28 shrink-0 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export default async function HomePage() {
       <HeroCarousel movies={featured} />
 
       <section className="mx-auto w-full max-w-6xl px-4 py-8">
-        <h2 className="mb-4 text-xl font-bold text-white">Recently Added</h2>
+        <h2 className="mb-4 font-serif text-xl font-bold text-white">Recently Added</h2>
         {recent.length === 0 ? (
           <p className="text-sm text-neutral-400">
             No movies in the catalog yet. An admin can import films from TMDB on the{" "}

--- a/src/components/discussion-thread.tsx
+++ b/src/components/discussion-thread.tsx
@@ -220,7 +220,7 @@ export function DiscussionThread({
 
   return (
     <section className="mt-10">
-      <h2 className="mb-4 text-xl font-bold text-white">Discussion</h2>
+      <h2 className="mb-4 font-serif text-xl font-bold text-white">Discussion</h2>
 
       {signedIn ? (
         <div className="mb-6 flex flex-col gap-2">

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -192,36 +192,40 @@ function FightSceneForm({
   );
 }
 
-function RatingRow({
-  label,
-  color,
-  score,
-  onRate,
-  disabled,
-}: {
-  label: string;
-  color: "yellow" | "amber";
-  score: number | null;
-  onRate: (value: number) => void;
-  disabled: boolean;
-}) {
-  const activeClass = color === "yellow" ? "bg-yellow-500 text-neutral-950" : "bg-amber-500 text-neutral-950";
+// "Fight Ticket" styling: ink-on-cream ticket-stub card, distinct from the
+// rest of the (dark, serif) site on purpose — this is the differentiator
+// feature and reads like a physical tournament ticket rather than a movie
+// poster. TICKET_INK / TICKET_STAMP are shared between here and the card
+// markup below.
+const TICKET_INK = "#1a1712";
+const TICKET_MUTED = "#6b6148";
+const TICKET_STAMP = "#a4291e";
+
+function RatingRow({ label, score, onRate, disabled }: { label: string; score: number | null; onRate: (value: number) => void; disabled: boolean }) {
   return (
-    <div>
-      <p className="mb-1 text-xs text-neutral-500">{label}</p>
+    <div className="mt-3">
+      <p className="mb-1 text-[10px] uppercase tracking-wide" style={{ color: TICKET_MUTED }}>
+        {label}
+      </p>
       <div className="flex flex-wrap gap-1">
-        {SCORES.map((value) => (
-          <button
-            key={value}
-            disabled={disabled}
-            onClick={() => onRate(value)}
-            className={`h-6 w-6 rounded text-xs font-medium transition disabled:opacity-50 ${
-              score !== null && value <= score ? activeClass : "bg-neutral-800 text-neutral-300 hover:bg-neutral-700"
-            }`}
-          >
-            {value}
-          </button>
-        ))}
+        {SCORES.map((value) => {
+          const active = score !== null && value <= score;
+          return (
+            <button
+              key={value}
+              disabled={disabled}
+              onClick={() => onRate(value)}
+              className="h-6 w-6 border text-[10px] font-bold transition disabled:opacity-50"
+              style={{
+                borderColor: TICKET_INK,
+                background: active ? TICKET_INK : "transparent",
+                color: active ? "#e8dcc4" : TICKET_INK,
+              }}
+            >
+              {value}
+            </button>
+          );
+        })}
       </div>
     </div>
   );
@@ -409,9 +413,9 @@ export function FightSceneSection({
           const canDelete = canEdit || isAdmin;
           const permalinkPath = `/movies/${movieId}/fight-scenes/${scene.id}`;
 
-          return (
-            <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
-              {editingId === scene.id ? (
+          if (editingId === scene.id) {
+            return (
+              <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
                 <FightSceneForm
                   castOptions={castOptions}
                   tagOptions={tagOptions}
@@ -423,132 +427,137 @@ export function FightSceneSection({
                   onCancel={() => setEditingId(null)}
                   onSubmit={(title, url, personIds, tagIds) => handleEdit(scene.id, title, url, personIds, tagIds)}
                 />
-              ) : (
-                <>
-                  <div className="aspect-video w-full overflow-hidden rounded-md bg-black">
-                    <iframe
-                      src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
-                      title={scene.title}
-                      className="h-full w-full"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
+              </li>
+            );
+          }
+
+          const avgLabel = scene.ratingAverage ? scene.ratingAverage.toFixed(1) : "—";
+
+          return (
+            <li
+              key={scene.id}
+              className="relative bg-[#e8dcc4] p-4 font-mono"
+              style={{
+                color: TICKET_INK,
+                clipPath:
+                  "polygon(0 10px, 10px 0, calc(100% - 10px) 0, 100% 10px, 100% calc(100% - 10px), calc(100% - 10px) 100%, 10px 100%, 0 calc(100% - 10px))",
+              }}
+            >
+              <div className="flex items-center justify-between text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
+                <span>Ticket No. {scene.id.slice(-6)}</span>
+                <div className="flex items-center gap-2">
+                  <span>Admit One</span>
+                  <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
+                </div>
+              </div>
+
+              <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>
+                {/* Smaller inset "photo" rather than a full-width player, to read as a ticket detail. */}
+                <div className="mx-auto aspect-video w-1/2 max-w-[220px] overflow-hidden border-[3px]" style={{ borderColor: TICKET_INK, background: TICKET_INK }}>
+                  <iframe
+                    src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
+                    title={scene.title}
+                    className="h-full w-full"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
+              </div>
+
+              <Link href={permalinkPath} className="mt-3 block text-lg font-bold hover:opacity-70" style={{ fontFamily: "Georgia, serif" }}>
+                {scene.title}
+              </Link>
+              {scene.cast.length > 0 && (
+                <p className="mt-0.5 text-[11px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
+                  Featuring {scene.cast.map((c) => c.person.name).join(", ")}
+                </p>
+              )}
+
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {scene.tags.map((tag) => (
+                  <span key={tag.id} className="border px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ borderColor: TICKET_INK }}>
+                    {tag.name}
+                  </span>
+                ))}
+                {scene.isVerified && (
+                  <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#e8dcc4" }}>
+                    ✓ Verified
+                  </span>
+                )}
+              </div>
+
+              <div className="mt-4 flex items-end justify-between gap-3">
+                <p className="text-[10px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
+                  Submitted by
+                  <br />
+                  {scene.submittedBy.name ?? "Anonymous"}
+                  {canEdit && (
+                    <button onClick={() => setEditingId(scene.id)} className="ml-2 underline hover:opacity-70">
+                      Edit
+                    </button>
+                  )}
+                  {canDelete && (
+                    <button onClick={() => handleDelete(scene.id)} className="ml-2 underline hover:opacity-70">
+                      Delete
+                    </button>
+                  )}
+                  {isAdmin && (
+                    <button onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)} className="ml-2 underline hover:opacity-70">
+                      {scene.isVerified ? "Unverify" : "Verify"}
+                    </button>
+                  )}
+                </p>
+
+                <div className="flex gap-3">
+                  <div className="text-center">
+                    <div
+                      className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border-2 text-base font-bold"
+                      style={{ borderColor: TICKET_STAMP, color: TICKET_STAMP, transform: "rotate(-8deg)" }}
+                    >
+                      {avgLabel}
+                    </div>
+                    <p className="text-[8.5px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
+                      Member ({scene.ratingCount})
+                    </p>
                   </div>
-
-                  <div className="mt-2 flex items-start justify-between gap-2">
-                    <Link href={permalinkPath} className="font-serif text-lg font-medium text-neutral-100 hover:text-red-400">
-                      {scene.title}
-                    </Link>
-                    <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
-                  </div>
-
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
-                    {scene.cast.map((c) => (
-                      <span
-                        key={c.id}
-                        className="rounded-full border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300"
+                  {scene.adminRatingCount > 0 && (
+                    <div className="text-center">
+                      <div
+                        className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border-2 text-base font-bold"
+                        style={{ borderColor: TICKET_STAMP, color: TICKET_STAMP, transform: "rotate(6deg)" }}
                       >
-                        {c.person.name}
-                      </span>
-                    ))}
-                    {scene.tags.map((tag) => (
-                      <span
-                        key={tag.id}
-                        className="rounded-full border border-red-900/60 bg-red-950/30 px-2 py-0.5 text-xs text-red-300"
-                      >
-                        {tag.name}
-                      </span>
-                    ))}
-                    {scene.isVerified && (
-                      <span className="rounded-full bg-red-900/40 px-2 py-0.5 text-xs font-medium text-red-400">
-                        ✓ Verified
-                      </span>
-                    )}
-                  </div>
-
-                  <p className="mt-1 text-xs text-neutral-500">
-                    Submitted by {scene.submittedBy.name ?? "Anonymous"}
-                    {canEdit && (
-                      <button
-                        onClick={() => setEditingId(scene.id)}
-                        className="ml-2 text-neutral-400 hover:text-white"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {canDelete && (
-                      <button
-                        onClick={() => handleDelete(scene.id)}
-                        className="ml-2 text-neutral-400 hover:text-red-400"
-                      >
-                        Delete
-                      </button>
-                    )}
-                    {isAdmin && (
-                      <button
-                        onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)}
-                        className="ml-2 text-neutral-400 hover:text-white"
-                      >
-                        {scene.isVerified ? "Unverify" : "Verify"}
-                      </button>
-                    )}
-                  </p>
-
-                  <div className="mt-3 flex flex-wrap items-center gap-6">
-                    <div>
-                      <p className="text-xs text-neutral-500">Member Score</p>
-                      <p className="text-lg font-bold text-yellow-500">
-                        {scene.ratingAverage ? scene.ratingAverage.toFixed(1) : "—"}{" "}
-                        <span className="text-xs font-normal text-neutral-500">/ 10 ({scene.ratingCount})</span>
+                        {scene.adminRatingAverage?.toFixed(1)}
+                      </div>
+                      <p className="text-[8.5px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
+                        Editors&rsquo;
                       </p>
                     </div>
-                    {scene.adminRatingCount > 0 && (
-                      <div>
-                        <p className="text-xs text-neutral-500">Editors&rsquo; Score</p>
-                        <p className="text-lg font-bold text-amber-500">
-                          {scene.adminRatingAverage?.toFixed(1)}{" "}
-                          <span className="text-xs font-normal text-neutral-500">
-                            / 10 ({scene.adminRatingCount})
-                          </span>
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  {signedIn && (
-                    <div className="mt-3">
-                      <RatingRow
-                        label="Your rating"
-                        color="yellow"
-                        score={ratings[scene.id] ?? null}
-                        onRate={(value) => handleRate(scene.id, value)}
-                        disabled={false}
-                      />
-                    </div>
                   )}
+                </div>
+              </div>
 
-                  {isAdmin && (
-                    <div className="mt-3 rounded-md border border-amber-800/50 bg-amber-950/20 p-2">
-                      <RatingRow
-                        label="Editors' rating (admin only)"
-                        color="amber"
-                        score={adminRatings[scene.id] ?? null}
-                        onRate={(value) => handleAdminRate(scene.id, value)}
-                        disabled={false}
-                      />
-                      <textarea
-                        value={adminNoteDrafts[scene.id] ?? ""}
-                        onChange={(e) =>
-                          setAdminNoteDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))
-                        }
-                        maxLength={MAX_NOTE_LENGTH}
-                        placeholder="Editor's note (optional)"
-                        rows={2}
-                        className="mt-2 w-full rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-100 focus:border-amber-600 focus:outline-none"
-                      />
-                    </div>
-                  )}
-                </>
+              {signedIn && (
+                <RatingRow label="Your rating" score={ratings[scene.id] ?? null} onRate={(value) => handleRate(scene.id, value)} disabled={false} />
+              )}
+
+              {isAdmin && (
+                <div className="mt-3 border-t pt-3" style={{ borderColor: "#b8ab8c" }}>
+                  <RatingRow
+                    label="Editors' rating (admin only)"
+                    score={adminRatings[scene.id] ?? null}
+                    onRate={(value) => handleAdminRate(scene.id, value)}
+                    disabled={false}
+                  />
+                  <textarea
+                    value={adminNoteDrafts[scene.id] ?? ""}
+                    onChange={(e) => setAdminNoteDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))}
+                    maxLength={MAX_NOTE_LENGTH}
+                    placeholder="Editor's note (optional)"
+                    rows={2}
+                    className="mt-2 w-full border bg-transparent px-2 py-1 text-xs focus:outline-none"
+                    style={{ borderColor: TICKET_INK, color: TICKET_INK }}
+                  />
+                </div>
               )}
             </li>
           );

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -21,6 +21,11 @@ type FightSceneCastItem = Pick<FightSceneCast, "id" | "order"> & { person: Fight
 // same reasoning as DiscussionThread.
 export type FightSceneItem = {
   id: string;
+  // Movie-scoped position (1st scene added = Round 1), not a stored value —
+  // computed server-side from creation order among surviving scenes, so
+  // deleting one reflows the rest. See handleCreate/handleDelete below for
+  // how this stays correct after client-side mutations.
+  roundNumber: number;
   title: string;
   youtubeVideoId: string;
   youtubeStartSeconds: number | null;
@@ -282,7 +287,16 @@ export function FightSceneSection({
     }
     const { fightScene } = await res.json();
     setScenes((prev) => [
-      { ...fightScene, ratingAverage: null, ratingCount: 0, adminRatingAverage: null, adminRatingCount: 0 },
+      {
+        ...fightScene,
+        // The new scene is always the most recently created, so it's the
+        // highest round number — one past however many currently exist.
+        roundNumber: prev.length + 1,
+        ratingAverage: null,
+        ratingCount: 0,
+        adminRatingAverage: null,
+        adminRatingCount: 0,
+      },
       ...prev,
     ]);
     setAdding(false);
@@ -316,7 +330,12 @@ export function FightSceneSection({
       setError(body.error ?? "Something went wrong.");
       return;
     }
-    setScenes((prev) => prev.filter((s) => s.id !== id));
+    setScenes((prev) => {
+      const deleted = prev.find((s) => s.id === id);
+      return prev
+        .filter((s) => s.id !== id)
+        .map((s) => (deleted && s.roundNumber > deleted.roundNumber ? { ...s, roundNumber: s.roundNumber - 1 } : s));
+    });
   }
 
   async function handleRate(id: string, score: number) {
@@ -444,11 +463,8 @@ export function FightSceneSection({
               }}
             >
               <div className="flex items-center justify-between text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
-                <span>Ticket No. {scene.id.slice(-6)}</span>
-                <div className="flex items-center gap-2">
-                  <span>Admit One</span>
-                  <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
-                </div>
+                <span>Round No. {scene.roundNumber}</span>
+                <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
               </div>
 
               <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -219,7 +219,7 @@ function RatingRow({ label, score, onRate, disabled }: { label: string; score: n
               style={{
                 borderColor: TICKET_INK,
                 background: active ? TICKET_INK : "transparent",
-                color: active ? "#e8dcc4" : TICKET_INK,
+                color: active ? "#f2c94c" : TICKET_INK,
               }}
             >
               {value}
@@ -436,7 +436,7 @@ export function FightSceneSection({
           return (
             <li
               key={scene.id}
-              className="relative bg-[#e8dcc4] p-4 font-mono"
+              className="relative bg-[#f2c94c] p-4 font-mono"
               style={{
                 color: TICKET_INK,
                 clipPath:
@@ -451,7 +451,7 @@ export function FightSceneSection({
                 </div>
               </div>
 
-              <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>
+              <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#c9a227" }}>
                 {/* Smaller inset "photo" rather than a full-width player, to read as a ticket detail. */}
                 <div className="mx-auto aspect-video w-1/2 max-w-[220px] overflow-hidden border-[3px]" style={{ borderColor: TICKET_INK, background: TICKET_INK }}>
                   <iframe
@@ -480,7 +480,7 @@ export function FightSceneSection({
                   </span>
                 ))}
                 {scene.isVerified && (
-                  <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#e8dcc4" }}>
+                  <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#f2c94c" }}>
                     ✓ Verified
                   </span>
                 )}
@@ -541,7 +541,7 @@ export function FightSceneSection({
               )}
 
               {isAdmin && (
-                <div className="mt-3 border-t pt-3" style={{ borderColor: "#b8ab8c" }}>
+                <div className="mt-3 border-t pt-3" style={{ borderColor: "#c9a227" }}>
                   <RatingRow
                     label="Editors' rating (admin only)"
                     score={adminRatings[scene.id] ?? null}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -407,7 +407,7 @@ export function FightSceneSection({
         </div>
       )}
 
-      <ul className="flex flex-col gap-6">
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {scenes.map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;
@@ -415,7 +415,7 @@ export function FightSceneSection({
 
           if (editingId === scene.id) {
             return (
-              <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+              <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3 sm:col-span-2 lg:col-span-3">
                 <FightSceneForm
                   castOptions={castOptions}
                   tagOptions={tagOptions}
@@ -453,7 +453,7 @@ export function FightSceneSection({
 
               <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>
                 {/* Smaller inset "photo" rather than a full-width player, to read as a ticket detail. */}
-                <div className="mx-auto aspect-video w-1/2 max-w-[220px] overflow-hidden border-[3px]" style={{ borderColor: TICKET_INK, background: TICKET_INK }}>
+                <div className="mx-auto aspect-video w-2/3 max-w-[180px] overflow-hidden border-[3px]" style={{ borderColor: TICKET_INK, background: TICKET_INK }}>
                   <iframe
                     src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
                     title={scene.title}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -219,7 +219,7 @@ function RatingRow({ label, score, onRate, disabled }: { label: string; score: n
               style={{
                 borderColor: TICKET_INK,
                 background: active ? TICKET_INK : "transparent",
-                color: active ? "#f2c94c" : TICKET_INK,
+                color: active ? "#e8dcc4" : TICKET_INK,
               }}
             >
               {value}
@@ -436,7 +436,7 @@ export function FightSceneSection({
           return (
             <li
               key={scene.id}
-              className="relative bg-[#f2c94c] p-4 font-mono"
+              className="relative bg-[#e8dcc4] p-4 font-mono"
               style={{
                 color: TICKET_INK,
                 clipPath:
@@ -451,7 +451,7 @@ export function FightSceneSection({
                 </div>
               </div>
 
-              <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#c9a227" }}>
+              <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>
                 {/* Smaller inset "photo" rather than a full-width player, to read as a ticket detail. */}
                 <div className="mx-auto aspect-video w-1/2 max-w-[220px] overflow-hidden border-[3px]" style={{ borderColor: TICKET_INK, background: TICKET_INK }}>
                   <iframe
@@ -480,7 +480,7 @@ export function FightSceneSection({
                   </span>
                 ))}
                 {scene.isVerified && (
-                  <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#f2c94c" }}>
+                  <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#e8dcc4" }}>
                     ✓ Verified
                   </span>
                 )}
@@ -541,7 +541,7 @@ export function FightSceneSection({
               )}
 
               {isAdmin && (
-                <div className="mt-3 border-t pt-3" style={{ borderColor: "#c9a227" }}>
+                <div className="mt-3 border-t pt-3" style={{ borderColor: "#b8ab8c" }}>
                   <RatingRow
                     label="Editors' rating (admin only)"
                     score={adminRatings[scene.id] ?? null}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -367,7 +367,7 @@ export function FightSceneSection({
     <section className="mt-10">
       {heading && (
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-white">{heading}</h2>
+          <h2 className="font-serif text-xl font-bold text-white">{heading}</h2>
           {allowAdd && signedIn && !adding && castOptions.length > 0 && (
             <button
               onClick={() => setAdding(true)}
@@ -436,7 +436,7 @@ export function FightSceneSection({
                   </div>
 
                   <div className="mt-2 flex items-start justify-between gap-2">
-                    <Link href={permalinkPath} className="font-medium text-neutral-100 hover:text-red-400">
+                    <Link href={permalinkPath} className="font-serif text-lg font-medium text-neutral-100 hover:text-red-400">
                       {scene.title}
                     </Link>
                     <ShareButton path={permalinkPath} title={scene.title} variant="icon" />

--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -49,7 +49,7 @@ export function HeroCarousel({ movies }: { movies: FeaturedMovie[] }) {
           Trending this week
         </p>
         <Link href={`/movies/${movie.id}`} className="w-fit">
-          <h2 className="text-2xl font-bold text-white hover:text-red-400 sm:text-4xl">
+          <h2 className="font-serif text-2xl font-bold text-white hover:text-red-400 sm:text-4xl">
             {movie.title} {year && <span className="text-neutral-400">({year})</span>}
           </h2>
         </Link>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,7 +16,7 @@ export async function Navbar() {
     <header className="sticky top-0 z-20 border-b border-neutral-800 bg-neutral-950/95 backdrop-blur">
       {needsVerification && <VerifyEmailBanner />}
       <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-4 px-4 py-3">
-        <Link href="/" className="whitespace-nowrap text-lg font-bold tracking-tight text-red-600">
+        <Link href="/" className="whitespace-nowrap font-serif text-lg font-bold tracking-tight text-red-600">
           師父<span className="text-white">Kung Fu DB</span>
         </Link>
         <div className="order-3 w-full sm:order-2 sm:w-auto sm:flex-1">

--- a/src/lib/fight-scenes.ts
+++ b/src/lib/fight-scenes.ts
@@ -36,6 +36,21 @@ export async function getFightSceneById(movieId: string, fightSceneId: string) {
   return scene;
 }
 
+// "Round No." is a movie-scoped position, not a stored value — the 1st fight
+// scene ever added to a movie is Round 1, the 5th is Round 5, and if one gets
+// deleted the rest shift down automatically since this is recomputed from
+// whichever rows currently survive, ordered by creation time.
+export async function getFightSceneRoundNumbers(movieId: string): Promise<Map<string, number>> {
+  const scenes = await prisma.fightScene.findMany({
+    where: { movieId, isDeleted: false },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  const map = new Map<string, number>();
+  scenes.forEach((scene, index) => map.set(scene.id, index + 1));
+  return map;
+}
+
 export function getFightSceneTags() {
   return prisma.fightSceneTag.findMany({ orderBy: { name: "asc" } });
 }


### PR DESCRIPTION
## Summary

A visual refresh, developed iteratively against screenshots/previews before landing here:

- **Poster House theme** — site-wide palette remap (warm brown-black background, gold + blood-red accents) inspired by vintage Shaw Brothers kung fu poster art. Implemented as a Tailwind `@theme` token override in `globals.css` that remaps the neutral/red/yellow/amber scales the whole app already uses, so the color shift applies everywhere from one file — no per-component edits for color. Serif display type (`font-serif`) added to the main headings (navbar brand, hero title, movie title, section headings, fight scene titles); body text stays on Geist Sans for readability.
- **Fight Ticket card** — the Fight Scenes section's card is restyled as a tournament ticket stub (cream paper, ink-brown text, dashed tear line), deliberately distinct from the rest of the dark site since it's the app's differentiator feature. The YouTube preview is a smaller inset "photo" rather than a full-width player.
- **Responsive grid layout** — Fight Scenes now lay out in a grid (1 column mobile / 2 tablet / 3 desktop) instead of a full-width vertical stack, since a movie can have several scenes (2-6+) and the old stack got very long. The add/edit form spans the full grid width so its pickers aren't cramped into one column.
- **"Round No."** — replaces the previous "Ticket No." (a random ID slice) with a movie-scoped position: the 1st fight scene ever added to a movie is Round 1, the 5th is Round 5. This is computed fresh from creation order among currently-surviving (non-deleted) scenes each time, not stored — so deleting a scene reflows the rest automatically, both server-side (`getFightSceneRoundNumbers` in `src/lib/fight-scenes.ts`) and in the client's optimistic create/delete handlers. "Admit One" removed.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds, no type errors
- [x] Visual review via local screenshots at each iteration (theme colors, ticket card, grid layout at desktop/mobile widths) before settling on this version
- [x] End-to-end round-number verification against a local Postgres instance: created 5 fight scenes for a movie, confirmed Round 1-5 assigned by creation order; deleted the 4th (a middle scene), confirmed the remaining scenes correctly reflowed to Round 1-4 with no gaps, both via server-rendered HTML and the client's local state update
- [x] Confirmed "Admit One" and the old "Ticket No." are fully removed from the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_