### PR TITLE
Admin poster override, fight scenes sorted by round, label tweak

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
         hostname: "image.tmdb.org",
         pathname: "/t/p/**",
       },
+      {
+        protocol: "https",
+        hostname: "*.public.blob.vercel-storage.com",
+      },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@auth/prisma-adapter": "^2.11.3",
         "@prisma/adapter-pg": "^7.9.0",
         "@prisma/client": "^7.9.0",
+        "@vercel/blob": "^2.6.1",
         "bcryptjs": "^3.0.3",
         "next": "16.2.12",
         "next-auth": "^5.0.0-beta.32",
@@ -3222,6 +3223,77 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.1.tgz",
+      "integrity": "sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.1.tgz",
+      "integrity": "sha512-ufdalm2MWOYksyj8KVpWjoOFPJO6zoYpuyvIggIQ2bB0CFCjTCiTkGXHqAKwG77GVRjOaN3/8S5ITlZpXWmqOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.1",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@visx/curve": {
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
@@ -3611,6 +3683,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -5035,6 +5125,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -5397,6 +5516,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -5622,6 +5753,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
@@ -5768,6 +5908,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-bun-module": {
@@ -5958,6 +6121,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6037,6 +6206,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -6676,6 +6857,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6698,6 +6885,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -6940,6 +7136,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/oauth4webapi": {
       "version": "3.8.6",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
@@ -7078,6 +7286,21 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7094,6 +7317,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -8269,6 +8501,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8350,6 +8591,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -8625,6 +8878,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -8836,6 +9098,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@auth/prisma-adapter": "^2.11.3",
     "@prisma/adapter-pg": "^7.9.0",
     "@prisma/client": "^7.9.0",
+    "@vercel/blob": "^2.6.1",
     "bcryptjs": "^3.0.3",
     "next": "16.2.12",
     "next-auth": "^5.0.0-beta.32",

--- a/prisma/migrations/20260801234323_movie_poster_override/migration.sql
+++ b/prisma/migrations/20260801234323_movie_poster_override/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Movie" ADD COLUMN     "posterOverrideUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,10 @@ model Movie {
   overview       String?  @db.Text
   releaseDate    DateTime?
   posterPath     String?
+  // Admin-uploaded poster (Vercel Blob URL) that takes precedence over the
+  // TMDB-sourced posterPath above when set — lets an admin swap in a
+  // different poster without depending on what TMDB happens to have.
+  posterOverrideUrl String?
   backdropPath   String?
   runtime        Int?
   director       String?

--- a/src/app/api/admin/movies/[id]/poster/route.ts
+++ b/src/app/api/admin/movies/[id]/poster/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { put, del } from "@vercel/blob";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId } = await params;
+  const movie = await prisma.movie.findUnique({ where: { id: movieId } });
+  if (!movie) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required." }, { status: 400 });
+  }
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json({ error: "Poster must be a JPEG, PNG, or WebP image." }, { status: 400 });
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: "Poster must be 5MB or smaller." }, { status: 400 });
+  }
+
+  const blob = await put(`movie-posters/${movieId}-${Date.now()}`, file, {
+    access: "public",
+    contentType: file.type,
+  });
+
+  // Best-effort cleanup of the previous override so replacing a poster
+  // doesn't silently accumulate orphaned blobs — not worth failing the
+  // request over if it errors.
+  if (movie.posterOverrideUrl) {
+    await del(movie.posterOverrideUrl).catch(() => {});
+  }
+
+  const updated = await prisma.movie.update({
+    where: { id: movieId },
+    data: { posterOverrideUrl: blob.url },
+  });
+
+  return NextResponse.json({ posterOverrideUrl: updated.posterOverrideUrl });
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId } = await params;
+  const movie = await prisma.movie.findUnique({ where: { id: movieId } });
+  if (!movie) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+
+  if (movie.posterOverrideUrl) {
+    await del(movie.posterOverrideUrl).catch(() => {});
+  }
+
+  await prisma.movie.update({ where: { id: movieId }, data: { posterOverrideUrl: null } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { tmdbImageUrl } from "@/lib/tmdb";
+import { tmdbImageUrl, resolvePosterUrl } from "@/lib/tmdb";
 import { getCommunityRatingSummary, getEditorsRatingSummary } from "@/lib/ratings";
 import { getDiscussionPage } from "@/lib/discussion";
 import {
@@ -18,6 +18,7 @@ import { ListButtons } from "@/components/list-buttons";
 import { DiscussionThread } from "@/components/discussion-thread";
 import { FightSceneSection } from "@/components/fight-scene-section";
 import { EditorialReview } from "@/components/editorial-review";
+import { PosterOverrideControl } from "@/components/poster-override-control";
 
 export default async function MovieDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -89,7 +90,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   ]);
 
   const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
-  const posterUrl = tmdbImageUrl(movie.posterPath, "w342");
+  const posterUrl = resolvePosterUrl(movie, "w342");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
   const isFavorite = myListEntries.some((e) => e.listType === "FAVORITE");
   const isOnWatchlist = myListEntries.some((e) => e.listType === "WATCHLIST");
@@ -155,13 +156,18 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       </div>
 
       <div className="mx-auto -mt-24 flex w-full max-w-6xl flex-col gap-6 px-4 sm:flex-row">
-        <div className="relative aspect-2/3 w-40 shrink-0 overflow-hidden rounded-md bg-neutral-800 shadow-xl sm:w-56">
-          {posterUrl ? (
-            <Image src={posterUrl} alt={movie.title} fill sizes="224px" className="object-cover" />
-          ) : (
-            <div className="flex h-full items-center justify-center px-2 text-center text-xs text-neutral-500">
-              {movie.title}
-            </div>
+        <div className="w-40 shrink-0 sm:w-56">
+          <div className="relative aspect-2/3 overflow-hidden rounded-md bg-neutral-800 shadow-xl">
+            {posterUrl ? (
+              <Image src={posterUrl} alt={movie.title} fill sizes="224px" className="object-cover" />
+            ) : (
+              <div className="flex h-full items-center justify-center px-2 text-center text-xs text-neutral-500">
+                {movie.title}
+              </div>
+            )}
+          </div>
+          {session?.user?.role === "ADMIN" && (
+            <PosterOverrideControl movieId={movie.id} hasOverride={!!movie.posterOverrideUrl} />
           )}
         </div>
 

--- a/src/app/my-lists/page.tsx
+++ b/src/app/my-lists/page.tsx
@@ -7,7 +7,7 @@ import type { Movie } from "@/generated/prisma/client";
 
 async function MovieRow({ title, movies, ratingSummaries }: {
   title: string;
-  movies: Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "tmdbRating">[];
+  movies: Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "posterOverrideUrl" | "tmdbRating">[];
   ratingSummaries: Awaited<ReturnType<typeof getRatingSummaries>>;
 }) {
   return (

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -287,6 +287,7 @@ export function FightSceneSection({
     }
     const { fightScene } = await res.json();
     setScenes((prev) => [
+      ...prev,
       {
         ...fightScene,
         // The new scene is always the most recently created, so it's the
@@ -297,7 +298,6 @@ export function FightSceneSection({
         adminRatingAverage: null,
         adminRatingCount: 0,
       },
-      ...prev,
     ]);
     setAdding(false);
   }
@@ -427,7 +427,9 @@ export function FightSceneSection({
       )}
 
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {scenes.map((scene) => {
+        {/* Always sorted by round number left-to-right/top-to-bottom, regardless
+            of insertion order from create/edit/delete. */}
+        {[...scenes].sort((a, b) => a.roundNumber - b.roundNumber).map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;
           const permalinkPath = `/movies/${movieId}/fight-scenes/${scene.id}`;

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -465,7 +465,7 @@ export function FightSceneSection({
               }}
             >
               <div className="flex items-center justify-between text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
-                <span>Round No. {scene.roundNumber}</span>
+                <span>Round {scene.roundNumber}</span>
                 <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
               </div>
 

--- a/src/components/movie-card.tsx
+++ b/src/components/movie-card.tsx
@@ -1,15 +1,18 @@
 import Image from "next/image";
 import Link from "next/link";
-import { tmdbImageUrl } from "@/lib/tmdb";
+import { resolvePosterUrl } from "@/lib/tmdb";
 import type { Movie } from "@/generated/prisma/client";
 
-export type MovieCardData = Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "tmdbRating"> & {
+export type MovieCardData = Pick<
+  Movie,
+  "id" | "title" | "releaseDate" | "posterPath" | "posterOverrideUrl" | "tmdbRating"
+> & {
   communityAverage?: number | null;
   communityCount?: number;
 };
 
 export function MovieCard({ movie }: { movie: MovieCardData }) {
-  const posterUrl = tmdbImageUrl(movie.posterPath, "w342");
+  const posterUrl = resolvePosterUrl(movie, "w342");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
 
   return (

--- a/src/components/poster-override-control.tsx
+++ b/src/components/poster-override-control.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function PosterOverrideControl({
+  movieId,
+  hasOverride,
+}: {
+  movieId: string;
+  hasOverride: boolean;
+}) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+    const res = await fetch(`/api/admin/movies/${movieId}/poster`, { method: "POST", body: formData });
+    setUploading(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    router.refresh();
+  }
+
+  async function handleRemove() {
+    if (!window.confirm("Remove the custom poster and fall back to the TMDB one?")) return;
+    setError(null);
+    const res = await fetch(`/api/admin/movies/${movieId}/poster`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="mt-2 flex flex-col items-start gap-1">
+      <div className="flex items-center gap-2">
+        <label className="cursor-pointer rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-800">
+          {uploading ? "Uploading…" : hasOverride ? "Replace poster" : "Upload custom poster"}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={handleFileChange}
+            disabled={uploading}
+            className="hidden"
+          />
+        </label>
+        {hasOverride && (
+          <button onClick={handleRemove} className="text-xs text-neutral-400 hover:text-red-400">
+            Remove
+          </button>
+        )}
+      </div>
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/lib/fight-scenes.ts
+++ b/src/lib/fight-scenes.ts
@@ -20,9 +20,11 @@ const fightSceneInclude = {
 };
 
 export async function getFightScenesForMovie(movieId: string) {
+  // Ascending so scenes render Round 1, 2, 3… left to right — matches
+  // getFightSceneRoundNumbers' own ordering below.
   return prisma.fightScene.findMany({
     where: { movieId, isDeleted: false },
-    orderBy: { createdAt: "desc" },
+    orderBy: { createdAt: "asc" },
     include: fightSceneInclude,
   });
 }

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -31,6 +31,14 @@ export function tmdbImageUrl(path: string | null | undefined, size: "w200" | "w3
   return `${TMDB_IMAGE_BASE_URL}/${size}${path}`;
 }
 
+// An admin-uploaded poster always wins over whatever TMDB happens to have.
+export function resolvePosterUrl(
+  movie: { posterPath: string | null; posterOverrideUrl: string | null },
+  size: "w200" | "w342" | "w500" | "w780" | "original" = "w500",
+) {
+  return movie.posterOverrideUrl || tmdbImageUrl(movie.posterPath, size);
+}
+
 export interface TmdbMovieSearchResult {
   id: number;
   title: string;


### PR DESCRIPTION
## Summary

- **Admin poster override** — admins can upload a custom poster for any movie (`POST`/`DELETE /api/admin/movies/[id]/poster`), stored via Vercel Blob, taking precedence over the TMDB-sourced poster wherever posters render (`resolvePosterUrl` in `src/lib/tmdb.ts`, used by `MovieCard`, `my-lists`, and the movie detail page). Upload control shown next to the poster on the movie detail page, admin-only.
  - Simple server-side upload route (`put()` from `@vercel/blob`) rather than Vercel Blob's client-direct-upload pattern — posters are small images, well within serverless body limits, and a plain route avoids that pattern's webhook-reachability requirement (which breaks in local dev).
  - Replacing or removing a poster best-effort deletes the previous blob so overrides don't silently accumulate orphaned storage.
- **Fight scenes always sorted by round number** — previously sorted newest-first (`createdAt desc`), which put the highest round number first, not lowest. Now always Round 1, 2, 3… left to right / top to bottom, fixed both at the query level (`getFightScenesForMovie` orders `createdAt asc`) and, more importantly, at render time in `FightSceneSection` (explicit sort by `roundNumber` immediately before mapping), so ordering holds regardless of how client-side state gets mutated by create/edit/delete.
- **"Round No." → "Round"** — shortened label on the Fight Ticket card (e.g. "Round 3").

## Setup required before poster uploads work in production

This project's Vercel deployment needs Blob storage enabled (one-time):
1. Vercel dashboard → this project → **Storage** tab → **Create Database** → **Blob**.
2. Connect it — Vercel adds `BLOB_READ_WRITE_TOKEN` to the project's environment variables automatically.
3. Redeploy (or it applies on the next deploy).

Without this, the upload route will fail with a clear "No blob credentials found" error rather than silently misbehaving.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds, no type errors
- [x] Poster override auth gating verified: 403 for signed-out and non-admin members on both `POST` and `DELETE`; as admin, confirmed the request reaches the actual `put()` call (fails only on "No blob credentials found," expected in this sandbox with no real token — the full Blob round-trip needs testing against a real deployment)
- [x] Fight scene round-number ordering verified against a local Postgres instance: created multiple scenes, confirmed Round 1-4 render left to right in that exact order after the sort fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_