### PR TITLE
Sync README with recent features; add CLAUDE.md and PR template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ CRON_SECRET=""
 # with Resend (or swap in your own provider in src/lib/email.ts).
 RESEND_API_KEY=""
 EMAIL_FROM=""
+
+# Vercel Blob (for admin poster overrides) — optional. Create a Blob store in
+# your Vercel project's Storage tab, then `vercel env pull` to get this
+# locally. See README for details.
+BLOB_READ_WRITE_TOKEN=""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Checklist
+
+- [ ] `README.md` updated to reflect this change (or not applicable — no
+      user-facing feature, env var, setup step, or seed data changed)
+- [ ] `.env.example` updated if a new environment variable was added
+- [ ] `npm run lint` and `npm run build` pass locally
+
+## Test plan
+
+<!-- How did you verify this works? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# Working on this repo
+
+This is a Next.js + Prisma + Auth.js app (Kung Fu Movie Database). Multiple
+conversations work on this repo in parallel, each usually on its own feature
+branch and PR, so a few conventions keep things from drifting apart.
+
+## Keep README.md in sync
+
+If your changes in this conversation add or change any of the following,
+update the relevant section of `README.md` in the **same PR**, not as a
+follow-up:
+
+- A user-facing feature or capability (new page, new thing a member/admin can
+  do, a changed permission rule)
+- A new or changed environment variable (also update `.env.example`)
+- A new setup/deploy step (a new external service to configure, a new CLI
+  command to run)
+- A change to the data model that affects `prisma/seed.ts` or how the app is
+  set up locally
+
+Small internal refactors, bug fixes, or styling tweaks that don't change what
+the app does or how it's set up don't need a README update.
+
+When updating README.md, verify your description against the actual code you
+just wrote (or read), not just your intent for it — this keeps the docs
+accurate rather than aspirational.
+
+## Code integrity across parallel conversations
+
+- Keep Prisma schema changes, migrations, seed data, and any TypeScript types
+  derived from them in sync within the same PR — don't let a schema change
+  land without updating what depends on it.
+- Prefer deriving component prop types from Prisma-generated types (e.g.
+  `Pick<Movie, "id" | "title">`) instead of hand-duplicating shapes, so they
+  can't silently drift from the schema.
+- Soft-delete (an `isDeleted` boolean) is the established pattern for
+  user-generated content with dependents (discussion posts, fight scenes) —
+  prefer it over hard deletes so referential integrity and thread structure
+  aren't broken by another conversation's assumptions.
+- If your change touches the Prisma schema, flag that clearly in the PR
+  description — schema-touching PRs should be merged and pulled before
+  another schema-touching PR starts, to avoid migration conflicts.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 
 - Landing page with a weekly-rotating "trending" carousel (top 5 most-active movies over the last 7 days) and a recently-added grid
 - Search by movie title or actor name
-- Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation)
+- Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", an admin-authored editorial review, and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation)
+- **Fight Scenes**: members tag specific fight scenes within a movie — YouTube clip (with an optional start timestamp), the actors involved (picked from that movie's cast), and category tags (e.g. "Weapon Duel", "One vs. Many") — with their own member rating, a separate admin rating, admin verification, and a shareable permalink page (see [Fight Scenes](#fight-scenes) below)
 - Member accounts via email/password (with email verification) or Google sign-in
-- Member capabilities: rate movies, maintain a Favorites list and a Watchlist, post/reply in movie discussions
-- Admin-only TMDB import tool to curate the catalog (`/admin/import`)
+- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, post/reply in movie discussions, submit fight scenes
+- Admin capabilities: TMDB import tool (`/admin/import`), Editors' Score, editorial reviews, fight scene verification, fight scene tag management (`/admin/fight-scene-tags`), poster overrides
+- Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 
 ## Tech Stack
 
@@ -17,6 +19,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - [Prisma ORM](https://www.prisma.io/) 7 + PostgreSQL (via the `@prisma/adapter-pg` driver adapter)
 - [Auth.js (NextAuth) v5](https://authjs.dev/) — Credentials (email/password) + Google OAuth
 - [TMDB API](https://developer.themoviedb.org/docs) for movie/person data
+- [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) for admin-uploaded poster overrides
 
 ## Getting Set Up
 
@@ -57,7 +60,7 @@ Pick one:
 cp .env.example .env
 ```
 
-Fill in `DATABASE_URL`, `TMDB_API_KEY`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, and generate an `AUTH_SECRET`. `RESEND_API_KEY`/`EMAIL_FROM` are optional — see [Email Verification](#email-verification) below.
+Fill in `DATABASE_URL`, `TMDB_API_KEY`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, and generate an `AUTH_SECRET`. `RESEND_API_KEY`/`EMAIL_FROM` are optional — see [Email Verification](#email-verification) below. `BLOB_READ_WRITE_TOKEN` is optional too — see [Admin Poster Overrides](#admin-poster-overrides).
 
 ```bash
 npx auth secret
@@ -99,6 +102,34 @@ Without `RESEND_API_KEY` configured, the verification link is logged to the serv
 - Wrap text in `[spoiler]...[/spoiler]` to hide it behind a "click to reveal" toggle — useful for plot twists/endings discussed on the movie's own page. Note this is a client-side reveal (like most forum spoiler tags): the text is present in the page's data, just not shown until clicked, so it isn't a substitute for redacting genuinely secret data.
 - Authors can edit or delete their own posts; admins can delete anyone's post. Deletion is a soft-delete — the row and any replies underneath it are kept (so a thread doesn't fall apart when one comment in it is removed), but the content is blanked and the post renders as `[deleted]`.
 
+## Fight Scenes
+
+Below the cast list on every movie page, members can catalog individual fight scenes from that film:
+
+- **Add a scene**: paste a YouTube URL (any watch/shorts/embed/`youtu.be`/live link, with an optional `t=`/`start=` timestamp), give it a title (the submitter can auto-fill from the video's public oEmbed title), tag which of the movie's own cast members are in it, and optionally attach up to 10 category tags. Requires a verified email.
+- **Round numbers** aren't stored — they're computed on read as the scene's position, by creation order, among that movie's non-deleted scenes. Delete scene 2 of 3 and the old scene 3 becomes Round 2 automatically.
+- **Ratings**: members rate a scene 1–10 (one rating per member, editable); admins have a separate rating with an optional note, mirroring the movie-level Editors' Score.
+- **Verification**: admins can mark a scene "Verified" as a quality signal. Editing a scene's content clears verification, since an admin's earlier check no longer vouches for what's there now.
+- **Editing/deleting**: the submitter can edit or delete their own scene; admins can delete anyone's. Deletion is a soft-delete (like discussion posts) so ratings tied to a scene aren't orphaned.
+- **Tags**: the tag list itself (e.g. "Weapon Duel", "One vs. Many") is admin-curated at `/admin/fight-scene-tags` — members choose from it but can't create new tags.
+- **Permalinks**: each fight scene has its own page at `/movies/[id]/fight-scenes/[fightSceneId]` with dynamic Open Graph metadata (title, rating summary, YouTube thumbnail) for clean link previews when shared.
+
+## Editorial Reviews
+
+Admins can write a long-form review (up to 10,000 characters) for any movie, shown alongside the cast list. There's one review per movie — any admin can write or update it, and the page just tracks who last touched it.
+
+## Admin Poster Overrides
+
+If a movie's TMDB poster is missing, low-quality, or wrong, admins can upload a replacement (JPEG/PNG/WebP, 5MB max) directly on the movie page. The override is stored in [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) and always takes priority over the TMDB poster when set; admins can remove it to fall back to TMDB's image again.
+
+To enable this locally or in your own deployment, create a Blob store in your Vercel project's **Storage** tab and connect it — Vercel injects `BLOB_READ_WRITE_TOKEN` automatically for deployed environments, and you can run `vercel env pull` to get it into your local `.env`. Without this token, poster uploads will fail, but the rest of the app is unaffected.
+
+## Visual Theme
+
+The site's base look (backgrounds, text, accents) is defined once in `src/app/globals.css` as a Tailwind `@theme` override of the neutral/red/yellow/amber color scales, so it applies everywhere those Tailwind classes are used. This palette has changed once already (from a dark neutral theme to a warmer ink-and-paper "Poster House" palette) — check `src/app/globals.css` for the current definition and its inline comment before assuming a specific look when building new UI.
+
+Fight Scene cards ("Fight Ticket" styling) are the one exception: they use hardcoded hex colors rather than the shared Tailwind scale, so they deliberately keep their ink-on-cream, ticket-stub look regardless of whatever the site-wide theme is set to.
+
 ## Weekly Trending Carousel
 
 `/api/cron/weekly-featured` recomputes the top 5 most-active movies (by ratings + discussion activity in the last 7 days) and is protected by the `CRON_SECRET` env var (sent as `Authorization: Bearer <CRON_SECRET>`). `vercel.json` schedules this to run weekly via [Vercel Cron](https://vercel.com/docs/cron-jobs) — Vercel automatically attaches that header when `CRON_SECRET` is set as a project environment variable.
@@ -116,12 +147,12 @@ Without `RESEND_API_KEY` configured, the verification link is logged to the serv
 
 ## Project Structure
 
-- `src/app` — pages and API routes (App Router)
-- `src/components` — UI components
-- `src/lib` — Prisma client, Auth.js config, TMDB client, rating/weekly-featured/verification helpers, email sender
+- `src/app` — pages and API routes (App Router), including admin pages (`/admin/import`, `/admin/fight-scene-tags`) and the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`)
+- `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, etc.)
+- `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene helpers, email sender
 - `prisma/schema.prisma` — data model
-- `prisma/seed.ts` — sample/dev seed data
+- `prisma/seed.ts` — sample/dev seed data, including a sample fight scene and editorial review
 
 ## Out of Scope (for now)
 
-Person/actor detail pages, catalog-wide pagination, rate limiting, reply notifications, a user-facing "report post" flow, and "related movies" recommendations are not yet implemented.
+Person/actor detail pages, catalog-wide pagination, rate limiting, reply notifications, a user-facing "report post" flow, "related movies" recommendations, and fight scene moderation beyond owner/admin delete are not yet implemented.


### PR DESCRIPTION
## Summary

- Updates `README.md` to document everything merged since the original MVP docs: Fight Scenes (tagging, ratings, verification, round numbering, permalinks), Editorial Reviews, admin poster overrides (Vercel Blob), and the current site-wide visual theme. Adds `BLOB_READ_WRITE_TOKEN` to `.env.example`.
- Adds `CLAUDE.md` so every future conversation working on this repo automatically knows to update `README.md`/`.env.example` in the same PR as a feature change, plus the existing cross-conversation conventions (Prisma schema sync, derived prop types, soft-delete pattern).
- Adds `.github/pull_request_template.md` with a checklist (README updated, `.env.example` updated, lint/build passing) as a visible backstop at review time.

No application code changed — this is a documentation/process-only PR.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes (all routes generate successfully, including the fight scene, editorial review, and poster override routes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7q6UaTzPPFpwCCssdZLQV)_