### PR TITLE
Theme the movie rail scrollbar

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -18,7 +18,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-10 sm:flex-row">
-      <nav className="flex shrink-0 gap-1 overflow-x-auto sm:w-48 sm:flex-col sm:overflow-visible">
+      <nav className="rail-scrollbar flex shrink-0 gap-1 overflow-x-auto sm:w-48 sm:flex-col sm:overflow-visible">
         {NAV_LINKS.map((link) => (
           <Link
             key={link.href}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,10 +35,11 @@
 }
 
 @layer utilities {
-  /* Themed scrollbar for horizontally-scrolling movie rails, replacing the
-     default OS scrollbar so it matches the dark palette instead of clashing
-     with it. Falls back silently to the default bar in browsers that
-     support neither property (still fully scrollable either way). */
+  /* Themed scrollbar for horizontally-scrolling strips (movie rails, cast
+     list, admin nav), replacing the default OS scrollbar so it matches the
+     dark palette instead of clashing with it. Falls back silently to the
+     default bar in browsers that support neither property (still fully
+     scrollable either way). */
   .rail-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: var(--color-neutral-600) transparent;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,3 +33,27 @@
   --color-amber-800: #5c4420;
   --color-amber-500: #cf9a3e;
 }
+
+@layer utilities {
+  /* Themed scrollbar for horizontally-scrolling movie rails, replacing the
+     default OS scrollbar so it matches the dark palette instead of clashing
+     with it. Falls back silently to the default bar in browsers that
+     support neither property (still fully scrollable either way). */
+  .rail-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-neutral-600) transparent;
+  }
+  .rail-scrollbar::-webkit-scrollbar {
+    height: 6px;
+  }
+  .rail-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .rail-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--color-neutral-600);
+    border-radius: 9999px;
+  }
+  .rail-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-neutral-500);
+  }
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -249,7 +249,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         {movie.cast.length > 0 && (
           <section className="mb-8">
             <h2 className="mb-4 font-serif text-xl font-bold text-white">Cast</h2>
-            <div className="flex gap-4 overflow-x-auto pb-2">
+            <div className="rail-scrollbar flex gap-4 overflow-x-auto pb-2">
               {movie.cast.map((credit) => (
                 <div key={credit.id} className="w-28 shrink-0 text-center">
                   <div className="relative mb-1 aspect-square overflow-hidden rounded-full bg-neutral-800">

--- a/src/components/movie-rail.tsx
+++ b/src/components/movie-rail.tsx
@@ -87,7 +87,7 @@ export function MovieRail({
         <div
           ref={scrollerRef}
           onScroll={updateEdges}
-          className="flex gap-4 overflow-x-auto scroll-smooth pb-2"
+          className="rail-scrollbar flex gap-4 overflow-x-auto scroll-smooth pb-2"
         >
           {movies.map((movie) => (
             <MovieCard key={movie.id} movie={movie} />


### PR DESCRIPTION
## Summary

Replaces the default OS scrollbar on the homepage's horizontally-scrolling movie rails ("Recently Added", "Top Rated by the Community") with a thin, dark-themed one matching the "Poster House" palette, instead of the browser's default gray scrollbar clashing with the dark UI.

- `scrollbar-width: thin` + `scrollbar-color` (Firefox, modern Chromium/Edge)
- `::-webkit-scrollbar` pseudo-elements (Safari/older WebKit)
- Applied via a new `.rail-scrollbar` utility class in `globals.css`, added inside `@layer utilities` (kept layered intentionally — an earlier bug in this app came from unlayered CSS unexpectedly winning over Tailwind utilities)
- Kept alongside the existing hover arrow buttons and edge fades, not a replacement for them

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed) — not applicable, pure styling tweak
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via computed styles in a real browser session against a local Postgres instance that `scrollbar-width: thin` and the themed `scrollbar-color` are correctly applied to the rail's scroll container, and that horizontal scrolling still functions correctly (`scrollLeft` responds to wheel input).
- User confirmed visually in their own browser via the Vercel preview deployment that the themed scrollbar renders as expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_