### PR TITLE
Add member-created public lists, movie submissions with admin review, and member profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", an admin-authored editorial review, and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation)
 - **Fight Scenes**: members tag specific fight scenes within a movie — YouTube clip (with an optional start timestamp), the actors involved (picked from that movie's cast), and category tags (e.g. "Weapon Duel", "One vs. Many") — with their own member rating, a separate admin rating, admin verification, and a shareable permalink page (see [Fight Scenes](#fight-scenes) below)
 - Member accounts via email/password (with email verification) or Google sign-in, identified publicly by a chosen username rather than their email or real name (see [Usernames](#usernames) below)
-- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, post/reply in movie discussions, submit fight scenes
-- A unified `/admin` dashboard (Movies management incl. permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
+- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, create their own public named lists (see [Member Lists](#member-lists) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
+- A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 
 ## Tech Stack
@@ -123,6 +123,23 @@ Without `RESEND_API_KEY` configured, the verification link is logged to the serv
   - `with_origin_country` isn't in TMDB's official (outdated) API docs, though it's confirmed working and referenced by TMDB's own support — worth knowing if it ever needs debugging.
 - **Bulk CSV upload** — for when you already have a list of titles in hand rather than needing to discover them; see [Admin Area](#admin-area) below for the format.
 
+## Member Lists
+
+Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them (create, rename, delete) from `/my-lists`.
+
+- **Public by design** — every list has a shareable permalink at `/lists/[id]` that anyone can view, whether or not they're signed in. There's no private option; this is deliberate groundwork for letting members browse each other's lists later without a schema change, not an oversight.
+- A member can have at most 25 lists, with unique names per member; list names are capped at 60 characters.
+- A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below.
+- There's no cross-member browsing or "recommended lists" page yet — every list already being public makes that a schema-free follow-up whenever it's wanted.
+
+## Member Movie Submissions
+
+If a member searches and can't find a movie, `/movies/submit` (linked from a "no results" search) lets them search TMDB and submit a match directly — the same underlying TMDB import used by `/admin/import`, but scoped to one title at a time and requiring a verified email.
+
+- **Submissions start `PENDING`**, not live: hidden from the homepage, search (including the navbar's), autocomplete director/actor filters, and the weekly-trending computation, and its own movie page 404s for everyone except the submitter and admins. This mirrors fight-scene verification's "member-created content, admin-gated visibility" pattern rather than admin imports' "goes live immediately" one, since anyone can trigger this path, not just a trusted admin.
+- Submitting a `tmdbId` that's already in the catalog (approved or still pending) is rejected with a specific error rather than silently re-importing it — re-running the shared import logic on an existing row would otherwise reset an already-approved movie back to pending.
+- Admins review submissions in a **Pending Submissions** section at the top of `/admin/movies` — Approve moves it to the catalog immediately; Reject permanently deletes it, same as deleting any other catalog entry.
+
 ## Fight Scenes
 
 Below the cast list on every movie page, members can catalog individual fight scenes from that film:
@@ -155,7 +172,7 @@ Fight Scene cards ("Fight Ticket" styling) are the one exception: they use hardc
 
 Signed-in admins get an "Admin" link in the navbar to `/admin` &mdash; a dashboard linking every admin section that lives on its own page, all guarded by the same `requireAdminSession()` check in `src/app/admin/layout.tsx`:
 
-- **Movies** (`/admin/movies`) &mdash; browse the catalog and permanently delete a movie entry (type the title to confirm). Deleting cascades through everything attached to it: cast credits, ratings, discussion posts, fight scenes (and their own casts/ratings), the editorial review, and weekly-featured entries.
+- **Movies** (`/admin/movies`) &mdash; a **Pending Submissions** section (see [Member Movie Submissions](#member-movie-submissions) above) to approve or reject member-submitted movies, plus the catalog itself: browse and permanently delete a movie entry (type the title to confirm). Deleting cascades through everything attached to it: cast credits, ratings, discussion posts, fight scenes (and their own casts/ratings), the editorial review, and weekly-featured entries.
 - **Import from TMDB** (`/admin/import`) &mdash; search-and-import by title or by keyword (see [TMDB Import](#tmdb-import) above), plus a bulk-upload section: a CSV with a `title` column (optionally `year` to disambiguate identically-titled results, or `tmdb_id` to skip the search entirely) imports up to 25 movies in one request. Each row is resolved and imported independently, so one bad row (no TMDB match, a transient TMDB error) doesn't fail the rest of the batch &mdash; the response reports created/updated/error per row. CSV parsing uses `papaparse` rather than the `xlsx` npm package, whose published version has known unpatched advisories (SheetJS fixed them only on their own CDN, not on the npm registry).
 - **Fight Scene Tags** (`/admin/fight-scene-tags`) &mdash; manage the category vocabulary members tag fight scenes with (see [Fight Scenes](#fight-scenes) above).
 - **Account** (`/admin/account`) &mdash; change your own admin sign-in email or password (previously only possible via direct SQL). Changing your email re-triggers the normal email-verification flow on the new address; changing your password requires your current one (unless you signed up via Google and have never set one, in which case you can set an initial password). Either change signs you out immediately, since the session is JWT-based and won't otherwise pick up the new credentials until you sign back in.
@@ -181,9 +198,9 @@ Not every admin capability lives in this dashboard — Editors' Score, editorial
 
 ## Project Structure
 
-- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)) and the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`)
-- `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, etc.)
-- `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene/username helpers, email sender
+- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), and public member lists (`/lists/[listId]`)
+- `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, `member-list-manager.tsx`, `add-to-list-control.tsx`, etc.)
+- `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene/username/member-list helpers, email sender
 - `prisma/schema.prisma` — data model
 - `prisma/seed.ts` — sample/dev seed data, including a sample fight scene and editorial review
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", an admin-authored editorial review, and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation)
 - **Fight Scenes**: members tag specific fight scenes within a movie — YouTube clip (with an optional start timestamp), the actors involved (picked from that movie's cast), and category tags (e.g. "Weapon Duel", "One vs. Many") — with their own member rating, a separate admin rating, admin verification, and a shareable permalink page (see [Fight Scenes](#fight-scenes) below)
 - Member accounts via email/password (with email verification) or Google sign-in, identified publicly by a chosen username rather than their email or real name (see [Usernames](#usernames) below)
-- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, create their own public named lists (see [Member Lists](#member-lists) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
+- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, create their own public named lists on a profile page at `/members/[username]` (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
 - A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 
@@ -123,14 +123,16 @@ Without `RESEND_API_KEY` configured, the verification link is logged to the serv
   - `with_origin_country` isn't in TMDB's official (outdated) API docs, though it's confirmed working and referenced by TMDB's own support — worth knowing if it ever needs debugging.
 - **Bulk CSV upload** — for when you already have a list of titles in hand rather than needing to discover them; see [Admin Area](#admin-area) below for the format.
 
-## Member Lists
+## Member Lists & Profiles
 
-Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them (create, rename, delete) from `/my-lists`.
+Every member has a profile page at `/members/[username]`. Viewing your own shows Favorites, Watchlist, and your custom lists with full management controls (create/rename/delete); viewing someone else's shows only their public custom lists, read-only. `/my-lists` still works as a link — it just redirects to your own profile.
 
-- **Public by design** — every list has a shareable permalink at `/lists/[id]` that anyone can view, whether or not they're signed in. There's no private option; this is deliberate groundwork for letting members browse each other's lists later without a schema change, not an oversight.
+Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile.
+
+- **Custom lists are public by design; Favorites/Watchlist are not.** Every custom list has its own shareable permalink at `/lists/[id]` (also reachable via its owner's profile) that anyone can view signed in or not, with no private option — deliberate groundwork for letting members browse each other's lists later without a schema change. Favorites and Watchlist stay exactly as private as they've always been: only the signed-in owner ever sees their own, on their own profile or anywhere else.
 - A member can have at most 25 lists, with unique names per member; list names are capped at 60 characters.
-- A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below.
-- There's no cross-member browsing or "recommended lists" page yet — every list already being public makes that a schema-free follow-up whenever it's wanted.
+- A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list/profile view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below.
+- There's no cross-member browsing/discovery page (e.g. "recommended lists") yet — every list already being public and every member already having a profile URL makes that a schema-free follow-up whenever it's wanted.
 
 ## Member Movie Submissions
 
@@ -198,7 +200,7 @@ Not every admin capability lives in this dashboard — Editors' Score, editorial
 
 ## Project Structure
 
-- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), and public member lists (`/lists/[listId]`)
+- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), and public list permalinks (`/lists/[listId]`)
 - `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, `member-list-manager.tsx`, `add-to-list-control.tsx`, etc.)
 - `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene/username/member-list helpers, email sender
 - `prisma/schema.prisma` — data model

--- a/prisma/migrations/20260805120000_movie_review_and_member_lists/migration.sql
+++ b/prisma/migrations/20260805120000_movie_review_and_member_lists/migration.sql
@@ -1,0 +1,44 @@
+-- Movie approval workflow: member-submitted movies start PENDING and are
+-- hidden from public discovery until an admin approves them. Existing rows
+-- (all admin-imported so far) default to APPROVED, matching current behavior.
+ALTER TABLE "Movie" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'APPROVED';
+ALTER TABLE "Movie" ADD COLUMN "submittedById" TEXT;
+
+CREATE INDEX "Movie_status_idx" ON "Movie"("status");
+
+ALTER TABLE "Movie" ADD CONSTRAINT "Movie_submittedById_fkey"
+  FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Member-created public lists, separate from the built-in Favorites/Watchlist.
+CREATE TABLE "MemberList" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "MemberList_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MemberList_userId_name_key" ON "MemberList"("userId", "name");
+CREATE INDEX "MemberList_userId_idx" ON "MemberList"("userId");
+
+ALTER TABLE "MemberList" ADD CONSTRAINT "MemberList_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "MemberListEntry" (
+  "id" TEXT NOT NULL,
+  "listId" TEXT NOT NULL,
+  "movieId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "MemberListEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MemberListEntry_listId_movieId_key" ON "MemberListEntry"("listId", "movieId");
+CREATE INDEX "MemberListEntry_listId_idx" ON "MemberListEntry"("listId");
+
+ALTER TABLE "MemberListEntry" ADD CONSTRAINT "MemberListEntry_listId_fkey"
+  FOREIGN KEY ("listId") REFERENCES "MemberList"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "MemberListEntry" ADD CONSTRAINT "MemberListEntry_movieId_fkey"
+  FOREIGN KEY ("movieId") REFERENCES "Movie"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,8 @@ model User {
   fightSceneRatings   FightSceneRating[]
   fightSceneAdminRatings FightSceneAdminRating[]
   editorialReviews    EditorialReview[]
+  submittedMovies     Movie[]
+  memberLists         MemberList[]
 }
 
 model Account {
@@ -90,6 +92,13 @@ model Movie {
   createdAt      DateTime @default(now())
   lastSyncedAt   DateTime @default(now())
 
+  // "PENDING" | "APPROVED" — member-submitted movies (see submittedBy below)
+  // start PENDING and are hidden from every public listing/search until an
+  // admin approves them; admin imports (single-title, keyword, bulk CSV) go
+  // straight to APPROVED, matching existing behavior.
+  status        String  @default("APPROVED")
+  submittedById String?
+
   genres          Genre[]
   cast            CastCredit[]
   ratings         Rating[]
@@ -99,8 +108,11 @@ model Movie {
   weeklyFeatured  WeeklyFeatured[]
   fightScenes     FightScene[]
   editorialReview EditorialReview?
+  memberListEntries MemberListEntry[]
+  submittedBy     User?   @relation(fields: [submittedById], references: [id], onDelete: SetNull)
 
   @@index([title])
+  @@index([status])
 }
 
 model Genre {
@@ -307,6 +319,41 @@ model FightSceneAdminRating {
 
   @@unique([adminId, fightSceneId])
   @@index([fightSceneId])
+}
+
+// --- Member-created lists ---
+//
+// Separate from the built-in Favorites/Watchlist (ListEntry above) — members
+// can create any number of their own named lists. Public by design (the
+// owner chose that): viewable by anyone via /lists/[id], with room to grow
+// into cross-member browsing/"recommended lists" later without a schema
+// change, since every list is already public.
+
+model MemberList {
+  id        String   @id @default(cuid())
+  userId    String
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  entries MemberListEntry[]
+
+  @@unique([userId, name])
+  @@index([userId])
+}
+
+model MemberListEntry {
+  id        String   @id @default(cuid())
+  listId    String
+  movieId   String
+  createdAt DateTime @default(now())
+
+  list  MemberList @relation(fields: [listId], references: [id], onDelete: Cascade)
+  movie Movie      @relation(fields: [movieId], references: [id], onDelete: Cascade)
+
+  @@unique([listId, movieId])
+  @@index([listId])
 }
 
 // --- Weekly featured carousel ---

--- a/src/app/admin/movies/page.tsx
+++ b/src/app/admin/movies/page.tsx
@@ -1,18 +1,36 @@
 import { prisma } from "@/lib/prisma";
 import { AdminMovieList } from "@/components/admin-movie-list";
+import { AdminPendingMovies } from "@/components/admin-pending-movies";
 
 export default async function AdminMoviesPage() {
-  const movies = await prisma.movie.findMany({
-    orderBy: { title: "asc" },
-    select: {
-      id: true,
-      title: true,
-      releaseDate: true,
-      _count: { select: { ratings: true, discussionPosts: true, fightScenes: true } },
-    },
-  });
+  const [movies, pending] = await Promise.all([
+    prisma.movie.findMany({
+      where: { status: "APPROVED" },
+      orderBy: { title: "asc" },
+      select: {
+        id: true,
+        title: true,
+        releaseDate: true,
+        _count: { select: { ratings: true, discussionPosts: true, fightScenes: true } },
+      },
+    }),
+    prisma.movie.findMany({
+      where: { status: "PENDING" },
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        title: true,
+        releaseDate: true,
+        submittedBy: { select: { username: true } },
+      },
+    }),
+  ]);
 
   const serializedMovies = movies.map((movie) => ({
+    ...movie,
+    releaseDate: movie.releaseDate?.toISOString() ?? null,
+  }));
+  const serializedPending = pending.map((movie) => ({
     ...movie,
     releaseDate: movie.releaseDate?.toISOString() ?? null,
   }));
@@ -20,6 +38,19 @@ export default async function AdminMoviesPage() {
   return (
     <div className="max-w-3xl">
       <h1 className="mb-2 text-2xl font-bold text-white">Movies</h1>
+
+      {serializedPending.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-2 text-lg font-semibold text-white">Pending Submissions</h2>
+          <p className="mb-3 text-sm text-neutral-400">
+            Members submitted these from TMDB. Approve to add them to the catalog, or reject to
+            permanently remove them.
+          </p>
+          <AdminPendingMovies initialMovies={serializedPending} />
+        </section>
+      )}
+
+      <h2 className="mb-2 text-lg font-semibold text-white">Catalog</h2>
       <p className="mb-6 text-sm text-neutral-400">
         Deleting a movie permanently removes it and everything attached to it &mdash; ratings,
         discussion posts, and fight scenes included. This can&rsquo;t be undone.

--- a/src/app/api/actors/route.ts
+++ b/src/app/api/actors/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
   const rows = await prisma.person.findMany({
     where: {
       name: { contains: query, mode: "insensitive" },
-      castCredits: { some: {} },
+      castCredits: { some: { movie: { status: "APPROVED" } } },
     },
     distinct: ["name"],
     orderBy: { name: "asc" },

--- a/src/app/api/admin/movies/[id]/approve/route.ts
+++ b/src/app/api/admin/movies/[id]/approve/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId } = await params;
+  const existing = await prisma.movie.findUnique({ where: { id: movieId } });
+  if (!existing) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+
+  const movie = await prisma.movie.update({ where: { id: movieId }, data: { status: "APPROVED" } });
+  return NextResponse.json({ movie });
+}

--- a/src/app/api/directors/route.ts
+++ b/src/app/api/directors/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request) {
   }
 
   const rows = await prisma.movie.findMany({
-    where: { director: { contains: query, mode: "insensitive" } },
+    where: { director: { contains: query, mode: "insensitive" }, status: "APPROVED" },
     distinct: ["director"],
     orderBy: { director: "asc" },
     select: { director: true },

--- a/src/app/api/lists/[listId]/entries/[movieId]/route.ts
+++ b/src/app/api/lists/[listId]/entries/[movieId]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ listId: string; movieId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { listId, movieId } = await params;
+  const list = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!list) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (list.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own lists." }, { status: 403 });
+  }
+
+  await prisma.memberListEntry.deleteMany({ where: { listId, movieId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/lists/[listId]/entries/route.ts
+++ b/src/app/api/lists/[listId]/entries/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(request: Request, { params }: { params: Promise<{ listId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before managing lists." }, { status: 403 });
+  }
+
+  const { listId } = await params;
+  const list = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!list) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (list.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only add to your own lists." }, { status: 403 });
+  }
+
+  const { movieId } = await request.json();
+  if (typeof movieId !== "string") {
+    return NextResponse.json({ error: "movieId is required." }, { status: 400 });
+  }
+  const movie = await prisma.movie.findUnique({ where: { id: movieId } });
+  if (!movie) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+
+  const entry = await prisma.memberListEntry.upsert({
+    where: { listId_movieId: { listId, movieId } },
+    update: {},
+    create: { listId, movieId },
+  });
+  return NextResponse.json({ entry });
+}

--- a/src/app/api/lists/[listId]/route.ts
+++ b/src/app/api/lists/[listId]/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { MEMBER_LIST_NAME_MAX_LENGTH } from "@/lib/member-lists";
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ listId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { listId } = await params;
+  const existing = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!existing) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (existing.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only rename your own lists." }, { status: 403 });
+  }
+
+  const { name } = await request.json();
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "A list name is required." }, { status: 400 });
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > MEMBER_LIST_NAME_MAX_LENGTH) {
+    return NextResponse.json(
+      { error: `List name must be ${MEMBER_LIST_NAME_MAX_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const nameTaken = await prisma.memberList.findUnique({
+    where: { userId_name: { userId: session.user.id, name: trimmedName } },
+  });
+  if (nameTaken && nameTaken.id !== listId) {
+    return NextResponse.json({ error: "You already have a list with that name." }, { status: 409 });
+  }
+
+  const list = await prisma.memberList.update({ where: { id: listId }, data: { name: trimmedName } });
+  return NextResponse.json({ list });
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ listId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { listId } = await params;
+  const existing = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!existing) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (existing.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only delete your own lists." }, { status: 403 });
+  }
+
+  await prisma.memberList.delete({ where: { id: listId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/lists/route.ts
+++ b/src/app/api/lists/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+import { MAX_MEMBER_LISTS, MEMBER_LIST_NAME_MAX_LENGTH } from "@/lib/member-lists";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to create a list." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before creating a list." }, { status: 403 });
+  }
+
+  const { name } = await request.json();
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "A list name is required." }, { status: 400 });
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > MEMBER_LIST_NAME_MAX_LENGTH) {
+    return NextResponse.json(
+      { error: `List name must be ${MEMBER_LIST_NAME_MAX_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const listCount = await prisma.memberList.count({ where: { userId: session.user.id } });
+  if (listCount >= MAX_MEMBER_LISTS) {
+    return NextResponse.json({ error: `You can have at most ${MAX_MEMBER_LISTS} lists.` }, { status: 400 });
+  }
+
+  const existing = await prisma.memberList.findUnique({
+    where: { userId_name: { userId: session.user.id, name: trimmedName } },
+  });
+  if (existing) {
+    return NextResponse.json({ error: "You already have a list with that name." }, { status: 409 });
+  }
+
+  const list = await prisma.memberList.create({ data: { userId: session.user.id, name: trimmedName } });
+  return NextResponse.json({ list });
+}

--- a/src/app/api/movies/search/route.ts
+++ b/src/app/api/movies/search/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { isEmailVerified } from "@/lib/verification";
+import { searchTmdbMoviesForSubmission } from "@/lib/movie-submission";
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a movie." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a movie." }, { status: 403 });
+  }
+
+  const query = new URL(request.url).searchParams.get("q");
+  if (!query) {
+    return NextResponse.json({ error: "Missing query parameter q" }, { status: 400 });
+  }
+
+  try {
+    const results = await searchTmdbMoviesForSubmission(query);
+    return NextResponse.json({ results });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+  }
+}

--- a/src/app/api/movies/submit/route.ts
+++ b/src/app/api/movies/submit/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { isEmailVerified } from "@/lib/verification";
+import { submitMovieForReview } from "@/lib/movie-submission";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a movie." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a movie." }, { status: 403 });
+  }
+
+  const { tmdbId } = await request.json();
+  if (typeof tmdbId !== "number") {
+    return NextResponse.json({ error: "tmdbId must be a number" }, { status: 400 });
+  }
+
+  try {
+    const result = await submitMovieForReview(tmdbId, session.user.id);
+    if ("error" in result) {
+      return NextResponse.json({ error: result.error }, { status: 409 });
+    }
+    return NextResponse.json({ movie: result.movie });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -11,19 +11,22 @@ export async function GET(request: Request) {
 
   const [titleMatches, castMatches, directorMatches] = await Promise.all([
     prisma.movie.findMany({
-      where: { title: { contains: query, mode: "insensitive" } },
+      where: { title: { contains: query, mode: "insensitive" }, status: "APPROVED" },
       orderBy: { tmdbPopularity: "desc" },
       take: RESULT_LIMIT,
       select: { id: true, title: true, releaseDate: true, posterPath: true },
     }),
     prisma.movie.findMany({
-      where: { cast: { some: { person: { name: { contains: query, mode: "insensitive" } } } } },
+      where: {
+        cast: { some: { person: { name: { contains: query, mode: "insensitive" } } } },
+        status: "APPROVED",
+      },
       orderBy: { tmdbPopularity: "desc" },
       take: RESULT_LIMIT,
       select: { id: true, title: true, releaseDate: true, posterPath: true },
     }),
     prisma.movie.findMany({
-      where: { director: { contains: query, mode: "insensitive" } },
+      where: { director: { contains: query, mode: "insensitive" }, status: "APPROVED" },
       orderBy: { tmdbPopularity: "desc" },
       take: RESULT_LIMIT,
       select: { id: true, title: true, releaseDate: true, posterPath: true },

--- a/src/app/lists/[listId]/page.tsx
+++ b/src/app/lists/[listId]/page.tsx
@@ -1,0 +1,52 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { getRatingSummaries } from "@/lib/ratings";
+import { MovieCard } from "@/components/movie-card";
+
+export default async function PublicListPage({ params }: { params: Promise<{ listId: string }> }) {
+  const { listId } = await params;
+
+  const list = await prisma.memberList.findUnique({
+    where: { id: listId },
+    include: {
+      user: { select: { username: true } },
+      entries: { include: { movie: true }, orderBy: { createdAt: "desc" } },
+    },
+  });
+
+  if (!list) {
+    notFound();
+  }
+
+  // A pending movie could only have been added by its own submitter (the
+  // only person who can see its page) — exclude it from what anyone else
+  // views on this public list, same as every other public listing.
+  const movies = list.entries.map((entry) => entry.movie).filter((movie) => movie.status === "APPROVED");
+  const ratingSummaries = await getRatingSummaries(movies.map((m) => m.id));
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <p className="mb-1 text-sm text-neutral-400">List by {list.user.username}</p>
+      <h1 className="mb-6 text-2xl font-bold text-white">{list.name}</h1>
+      {movies.length === 0 ? (
+        <p className="text-neutral-400">No movies in this list yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-4">
+          {movies.map((movie) => {
+            const summary = ratingSummaries.get(movie.id);
+            return (
+              <MovieCard
+                key={movie.id}
+                movie={{
+                  ...movie,
+                  communityAverage: summary?.average ?? null,
+                  communityCount: summary?.count ?? 0,
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -1,0 +1,142 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getRatingSummaries } from "@/lib/ratings";
+import { MovieCard } from "@/components/movie-card";
+import { MemberListManager } from "@/components/member-list-manager";
+import type { Movie } from "@/generated/prisma/client";
+
+async function MovieRow({
+  title,
+  movies,
+  ratingSummaries,
+}: {
+  title: string;
+  movies: Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "posterOverrideUrl" | "tmdbRating">[];
+  ratingSummaries: Awaited<ReturnType<typeof getRatingSummaries>>;
+}) {
+  return (
+    <section className="mb-8">
+      <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>
+      {movies.length === 0 ? (
+        <p className="text-sm text-neutral-400">Nothing here yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-4">
+          {movies.map((movie) => {
+            const summary = ratingSummaries.get(movie.id);
+            return (
+              <MovieCard
+                key={movie.id}
+                movie={{
+                  ...movie,
+                  communityAverage: summary?.average ?? null,
+                  communityCount: summary?.count ?? 0,
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default async function MemberProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+  const session = await auth();
+
+  const profileUser = await prisma.user.findUnique({ where: { username } });
+  if (!profileUser) {
+    notFound();
+  }
+
+  // Favorites/Watchlist have always been private — only the owner ever sees
+  // their own, on this page or anywhere else. Custom lists are public by
+  // design (see README's Member Lists section), so anyone gets those, but a
+  // pending (not yet admin-approved) movie inside one is still hidden from
+  // everyone except the list owner, same as every other public listing.
+  const isOwner = session?.user?.id === profileUser.id;
+
+  const [entries, memberLists] = await Promise.all([
+    isOwner
+      ? prisma.listEntry.findMany({
+          where: { userId: profileUser.id },
+          include: { movie: true },
+          orderBy: { createdAt: "desc" },
+        })
+      : [],
+    prisma.memberList.findMany({
+      where: { userId: profileUser.id },
+      include: { entries: { include: { movie: true }, orderBy: { createdAt: "desc" } } },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
+
+  const favorites = entries.filter((e) => e.listType === "FAVORITE").map((e) => e.movie);
+  const watchlist = entries.filter((e) => e.listType === "WATCHLIST").map((e) => e.movie);
+
+  const visibleMemberLists = memberLists.map((list) => ({
+    ...list,
+    entries: isOwner ? list.entries : list.entries.filter((entry) => entry.movie.status === "APPROVED"),
+  }));
+
+  const allListedMovieIds = [
+    ...favorites,
+    ...watchlist,
+    ...visibleMemberLists.flatMap((list) => list.entries.map((entry) => entry.movie)),
+  ].map((m) => m.id);
+  const ratingSummaries = await getRatingSummaries(allListedMovieIds);
+
+  const withRatings = (movie: Movie) => ({
+    ...movie,
+    communityAverage: ratingSummaries.get(movie.id)?.average ?? null,
+    communityCount: ratingSummaries.get(movie.id)?.count ?? 0,
+  });
+
+  const memberListData = visibleMemberLists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    movies: list.entries.map((entry) => withRatings(entry.movie)),
+  }));
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <h1 className="mb-6 text-2xl font-bold text-white">{profileUser.username}</h1>
+
+      {isOwner && (
+        <>
+          <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
+          <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
+        </>
+      )}
+
+      <h2 className="mb-4 text-xl font-bold text-white">{isOwner ? "Your Lists" : "Lists"}</h2>
+      {isOwner ? (
+        <MemberListManager initialLists={memberListData} />
+      ) : memberListData.length === 0 ? (
+        <p className="text-sm text-neutral-500">No public lists yet.</p>
+      ) : (
+        memberListData.map((list) => (
+          <section key={list.id} className="mb-8">
+            <div className="mb-3 flex items-center gap-3">
+              <h3 className="text-lg font-semibold text-white">{list.name}</h3>
+              <Link href={`/lists/${list.id}`} className="text-xs text-neutral-400 underline hover:text-white">
+                Permalink
+              </Link>
+            </div>
+            {list.movies.length === 0 ? (
+              <p className="text-sm text-neutral-400">No movies in this list yet.</p>
+            ) : (
+              <div className="flex flex-wrap gap-4">
+                {list.movies.map((movie) => (
+                  <MovieCard key={movie.id} movie={movie} />
+                ))}
+              </div>
+            )}
+          </section>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { RatingWidget } from "@/components/rating-widget";
 import { AdminRatingWidget } from "@/components/admin-rating-widget";
 import { ListButtons } from "@/components/list-buttons";
+import { AddToListControl } from "@/components/add-to-list-control";
 import { DiscussionThread } from "@/components/discussion-thread";
 import { FightSceneSection } from "@/components/fight-scene-section";
 import { EditorialReview } from "@/components/editorial-review";
@@ -39,26 +40,60 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     notFound();
   }
 
-  const [communityRating, editorsRating, myRating, myListEntries, discussionPage, fightScenes, fightSceneTags, editorialReview] =
-    await Promise.all([
-      getCommunityRatingSummary(movie.id),
-      getEditorsRatingSummary(movie.id),
-      session?.user
-        ? prisma.rating.findUnique({
-            where: { userId_movieId: { userId: session.user.id, movieId: movie.id } },
-          })
-        : null,
-      session?.user
-        ? prisma.listEntry.findMany({ where: { userId: session.user.id, movieId: movie.id } })
-        : [],
-      getDiscussionPage(movie.id),
-      getFightScenesForMovie(movie.id),
-      getFightSceneTags(),
-      prisma.editorialReview.findUnique({
-        where: { movieId: movie.id },
-        include: { author: { select: { username: true } } },
-      }),
-    ]);
+  // Pending (member-submitted, not yet admin-approved) movies are invisible
+  // to everyone except the person who submitted them and admins — everyone
+  // else gets the same 404 as a nonexistent movie, matching how it's already
+  // hidden from every public listing/search.
+  const isVisible =
+    movie.status === "APPROVED" ||
+    session?.user?.role === "ADMIN" ||
+    session?.user?.id === movie.submittedById;
+  if (!isVisible) {
+    notFound();
+  }
+
+  const [
+    communityRating,
+    editorsRating,
+    myRating,
+    myListEntries,
+    myMemberLists,
+    discussionPage,
+    fightScenes,
+    fightSceneTags,
+    editorialReview,
+  ] = await Promise.all([
+    getCommunityRatingSummary(movie.id),
+    getEditorsRatingSummary(movie.id),
+    session?.user
+      ? prisma.rating.findUnique({
+          where: { userId_movieId: { userId: session.user.id, movieId: movie.id } },
+        })
+      : null,
+    session?.user
+      ? prisma.listEntry.findMany({ where: { userId: session.user.id, movieId: movie.id } })
+      : [],
+    session?.user
+      ? prisma.memberList.findMany({
+          where: { userId: session.user.id },
+          orderBy: { createdAt: "asc" },
+          include: { entries: { where: { movieId: movie.id }, select: { id: true } } },
+        })
+      : [],
+    getDiscussionPage(movie.id),
+    getFightScenesForMovie(movie.id),
+    getFightSceneTags(),
+    prisma.editorialReview.findUnique({
+      where: { movieId: movie.id },
+      include: { author: { select: { username: true } } },
+    }),
+  ]);
+
+  const myMemberListItems = myMemberLists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    hasMovie: list.entries.length > 0,
+  }));
 
   const myAdminRating = session?.user?.role === "ADMIN"
     ? await prisma.adminRating.findUnique({
@@ -216,13 +251,14 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
 
           <p className="mt-4 max-w-2xl text-neutral-300">{movie.overview}</p>
 
-          <div className="mt-4">
+          <div className="mt-4 flex flex-wrap items-start gap-2">
             <ListButtons
               movieId={movie.id}
               initialFavorite={isFavorite}
               initialWatchlist={isOnWatchlist}
               signedIn={!!session?.user}
             />
+            <AddToListControl movieId={movie.id} initialLists={myMemberListItems} signedIn={!!session?.user} />
           </div>
 
           <div className="mt-6 max-w-sm">

--- a/src/app/movies/submit/page.tsx
+++ b/src/app/movies/submit/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { isEmailVerified } from "@/lib/verification";
+import { MovieSubmissionSearch } from "@/components/movie-submission-search";
+
+export default async function SubmitMoviePage() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/movies/submit");
+  }
+  const verified = await isEmailVerified(session.user.id);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-bold text-white">Add a movie</h1>
+      <p className="mb-6 text-sm text-neutral-400">
+        Search TMDB for a movie that&rsquo;s missing from the catalog. It won&rsquo;t appear on the site
+        until an admin reviews and approves it.
+      </p>
+      {verified ? (
+        <MovieSubmissionSearch />
+      ) : (
+        <p className="text-sm text-amber-400">Verify your email before submitting a movie.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/my-lists/page.tsx
+++ b/src/app/my-lists/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries } from "@/lib/ratings";
 import { MovieCard } from "@/components/movie-card";
+import { MemberListManager } from "@/components/member-list-manager";
 import type { Movie } from "@/generated/prisma/client";
 
 async function MovieRow({ title, movies, ratingSummaries }: {
@@ -42,21 +43,49 @@ export default async function MyListsPage() {
     redirect("/login?callbackUrl=/my-lists");
   }
 
-  const entries = await prisma.listEntry.findMany({
-    where: { userId: session.user.id },
-    include: { movie: true },
-    orderBy: { createdAt: "desc" },
-  });
+  const [entries, memberLists] = await Promise.all([
+    prisma.listEntry.findMany({
+      where: { userId: session.user.id },
+      include: { movie: true },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.memberList.findMany({
+      where: { userId: session.user.id },
+      include: { entries: { include: { movie: true }, orderBy: { createdAt: "desc" } } },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
 
   const favorites = entries.filter((e) => e.listType === "FAVORITE").map((e) => e.movie);
   const watchlist = entries.filter((e) => e.listType === "WATCHLIST").map((e) => e.movie);
-  const ratingSummaries = await getRatingSummaries([...favorites, ...watchlist].map((m) => m.id));
+
+  const allListedMovieIds = [
+    ...favorites,
+    ...watchlist,
+    ...memberLists.flatMap((list) => list.entries.map((entry) => entry.movie)),
+  ].map((m) => m.id);
+  const ratingSummaries = await getRatingSummaries(allListedMovieIds);
+
+  const withRatings = (movie: Movie) => ({
+    ...movie,
+    communityAverage: ratingSummaries.get(movie.id)?.average ?? null,
+    communityCount: ratingSummaries.get(movie.id)?.count ?? 0,
+  });
+
+  const memberListData = memberLists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    movies: list.entries.map((entry) => withRatings(entry.movie)),
+  }));
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
       <h1 className="mb-6 text-2xl font-bold text-white">My Lists</h1>
       <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
       <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
+
+      <h2 className="mb-4 text-xl font-bold text-white">Your Lists</h2>
+      <MemberListManager initialLists={memberListData} />
     </div>
   );
 }

--- a/src/app/my-lists/page.tsx
+++ b/src/app/my-lists/page.tsx
@@ -1,91 +1,12 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-import { getRatingSummaries } from "@/lib/ratings";
-import { MovieCard } from "@/components/movie-card";
-import { MemberListManager } from "@/components/member-list-manager";
-import type { Movie } from "@/generated/prisma/client";
 
-async function MovieRow({ title, movies, ratingSummaries }: {
-  title: string;
-  movies: Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "posterOverrideUrl" | "tmdbRating">[];
-  ratingSummaries: Awaited<ReturnType<typeof getRatingSummaries>>;
-}) {
-  return (
-    <section className="mb-8">
-      <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>
-      {movies.length === 0 ? (
-        <p className="text-sm text-neutral-400">Nothing here yet.</p>
-      ) : (
-        <div className="flex flex-wrap gap-4">
-          {movies.map((movie) => {
-            const summary = ratingSummaries.get(movie.id);
-            return (
-              <MovieCard
-                key={movie.id}
-                movie={{
-                  ...movie,
-                  communityAverage: summary?.average ?? null,
-                  communityCount: summary?.count ?? 0,
-                }}
-              />
-            );
-          })}
-        </div>
-      )}
-    </section>
-  );
-}
-
-export default async function MyListsPage() {
+// /my-lists now lives at /members/[username] (your own profile), so
+// existing links/bookmarks to this URL still work.
+export default async function MyListsRedirectPage() {
   const session = await auth();
   if (!session?.user) {
     redirect("/login?callbackUrl=/my-lists");
   }
-
-  const [entries, memberLists] = await Promise.all([
-    prisma.listEntry.findMany({
-      where: { userId: session.user.id },
-      include: { movie: true },
-      orderBy: { createdAt: "desc" },
-    }),
-    prisma.memberList.findMany({
-      where: { userId: session.user.id },
-      include: { entries: { include: { movie: true }, orderBy: { createdAt: "desc" } } },
-      orderBy: { createdAt: "asc" },
-    }),
-  ]);
-
-  const favorites = entries.filter((e) => e.listType === "FAVORITE").map((e) => e.movie);
-  const watchlist = entries.filter((e) => e.listType === "WATCHLIST").map((e) => e.movie);
-
-  const allListedMovieIds = [
-    ...favorites,
-    ...watchlist,
-    ...memberLists.flatMap((list) => list.entries.map((entry) => entry.movie)),
-  ].map((m) => m.id);
-  const ratingSummaries = await getRatingSummaries(allListedMovieIds);
-
-  const withRatings = (movie: Movie) => ({
-    ...movie,
-    communityAverage: ratingSummaries.get(movie.id)?.average ?? null,
-    communityCount: ratingSummaries.get(movie.id)?.count ?? 0,
-  });
-
-  const memberListData = memberLists.map((list) => ({
-    id: list.id,
-    name: list.name,
-    movies: list.entries.map((entry) => withRatings(entry.movie)),
-  }));
-
-  return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10">
-      <h1 className="mb-6 text-2xl font-bold text-white">My Lists</h1>
-      <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
-      <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
-
-      <h2 className="mb-4 text-xl font-bold text-white">Your Lists</h2>
-      <MemberListManager initialLists={memberListData} />
-    </div>
-  );
+  redirect(`/members/${session.user.username}`);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export const revalidate = 3600;
 export default async function HomePage() {
   const [featured, recent, topRated] = await Promise.all([
     getFeaturedMovies(),
-    prisma.movie.findMany({ orderBy: { createdAt: "desc" }, take: 12 }),
+    prisma.movie.findMany({ where: { status: "APPROVED" }, orderBy: { createdAt: "desc" }, take: 12 }),
     getTopRatedMovies(),
   ]);
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries, getEditorsRatingSummaries } from "@/lib/ratings";
 import { findSimilarMovies } from "@/lib/fuzzy-search";
@@ -38,7 +39,7 @@ function buildFilterWhere(
   yearFrom?: number,
   yearTo?: number,
 ) {
-  const where: Prisma.MovieWhereInput = {};
+  const where: Prisma.MovieWhereInput = { status: "APPROVED" };
   if (genre) where.genres = { some: { name: genre } };
   // Contains (not exact) since director/actor are now free-typed with
   // autocomplete suggestions, not chosen from a closed list of options.
@@ -91,7 +92,7 @@ export default async function SearchPage({
   const [genres, countryRows] = await Promise.all([
     prisma.genre.findMany({ orderBy: { name: "asc" } }),
     prisma.movie.findMany({
-      where: { country: { not: null } },
+      where: { country: { not: null }, status: "APPROVED" },
       distinct: ["country"],
       orderBy: { country: "asc" },
       select: { country: true },
@@ -316,7 +317,13 @@ export default async function SearchPage({
         {!searched ? (
           <p className="text-neutral-400">Enter a movie title or actor name, or set a filter, to browse the catalog.</p>
         ) : totalResults === 0 ? (
-          <p className="text-neutral-400">No movies matched your search.</p>
+          <p className="text-neutral-400">
+            No movies matched your search.{" "}
+            <Link href="/movies/submit" className="text-red-500 hover:underline">
+              Can&rsquo;t find it? Add a movie
+            </Link>
+            .
+          </p>
         ) : (
           <>
             {usedFuzzyFallback && (

--- a/src/components/add-to-list-control.tsx
+++ b/src/components/add-to-list-control.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export interface AddToListItem {
+  id: string;
+  name: string;
+  hasMovie: boolean;
+}
+
+export function AddToListControl({
+  movieId,
+  initialLists,
+  signedIn,
+}: {
+  movieId: string;
+  initialLists: AddToListItem[];
+  signedIn: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [lists, setLists] = useState(initialLists);
+  const [newName, setNewName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!signedIn) {
+    return (
+      <Link
+        href="/login"
+        className="rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-800"
+      >
+        + Add to list
+      </Link>
+    );
+  }
+
+  async function toggle(list: AddToListItem) {
+    setBusy(true);
+    setError(null);
+    const res = await fetch(
+      list.hasMovie ? `/api/lists/${list.id}/entries/${movieId}` : `/api/lists/${list.id}/entries`,
+      {
+        method: list.hasMovie ? "DELETE" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: list.hasMovie ? undefined : JSON.stringify({ movieId }),
+      },
+    );
+    setBusy(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setLists((prev) => prev.map((l) => (l.id === list.id ? { ...l, hasMovie: !l.hasMovie } : l)));
+  }
+
+  async function createAndAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setBusy(true);
+    setError(null);
+    const createRes = await fetch("/api/lists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+    const createBody = await createRes.json();
+    if (!createRes.ok) {
+      setBusy(false);
+      setError(createBody.error ?? "Something went wrong.");
+      return;
+    }
+
+    const addRes = await fetch(`/api/lists/${createBody.list.id}/entries`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ movieId }),
+    });
+    setBusy(false);
+    if (!addRes.ok) {
+      const addBody = await addRes.json().catch(() => ({}));
+      setError(addBody.error ?? "Something went wrong.");
+      return;
+    }
+    setLists((prev) => [...prev, { id: createBody.list.id, name: createBody.list.name, hasMovie: true }]);
+    setNewName("");
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-800"
+      >
+        + Add to list
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 w-64 rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl">
+          {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
+          <ul className="mb-3 flex max-h-48 flex-col gap-1 overflow-y-auto">
+            {lists.map((list) => (
+              <li key={list.id}>
+                <label className="flex items-center gap-2 text-sm text-neutral-200">
+                  <input type="checkbox" checked={list.hasMovie} disabled={busy} onChange={() => toggle(list)} />
+                  {list.name}
+                </label>
+              </li>
+            ))}
+            {lists.length === 0 && <p className="text-xs text-neutral-500">No lists yet.</p>}
+          </ul>
+          <form onSubmit={createAndAdd} className="flex gap-1">
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="New list…"
+              className="min-w-0 flex-1 rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 focus:border-red-600 focus:outline-none"
+            />
+            <button
+              type="submit"
+              disabled={busy || !newName.trim()}
+              className="shrink-0 rounded-md bg-red-700 px-2 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              Add
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin-pending-movies.tsx
+++ b/src/components/admin-pending-movies.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import type { Movie } from "@/generated/prisma/client";
+
+type PendingMovieItem = Pick<Movie, "id" | "title"> & {
+  releaseDate: string | null;
+  submittedBy: { username: string } | null;
+};
+
+export function AdminPendingMovies({ initialMovies }: { initialMovies: PendingMovieItem[] }) {
+  const [movies, setMovies] = useState(initialMovies);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function approve(id: string) {
+    setBusyId(id);
+    setError(null);
+    const res = await fetch(`/api/admin/movies/${id}/approve`, { method: "POST" });
+    setBusyId(null);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setMovies((prev) => prev.filter((m) => m.id !== id));
+  }
+
+  async function reject(id: string, title: string) {
+    if (!window.confirm(`Reject and permanently remove "${title}"?`)) return;
+    setBusyId(id);
+    setError(null);
+    const res = await fetch(`/api/admin/movies/${id}`, { method: "DELETE" });
+    setBusyId(null);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setMovies((prev) => prev.filter((m) => m.id !== id));
+  }
+
+  if (movies.length === 0) {
+    return <p className="text-sm text-neutral-500">No pending submissions.</p>;
+  }
+
+  return (
+    <div>
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+      <ul className="flex flex-col gap-2">
+        {movies.map((movie) => {
+          const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
+          return (
+            <li
+              key={movie.id}
+              className="flex items-center justify-between gap-2 rounded-md border border-amber-800/50 bg-amber-950/20 px-3 py-2"
+            >
+              <div>
+                <span className="text-sm text-neutral-100">
+                  {movie.title} {year && <span className="text-neutral-500">({year})</span>}
+                </span>
+                <p className="text-xs text-neutral-500">Submitted by {movie.submittedBy?.username ?? "a member"}</p>
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <button
+                  onClick={() => approve(movie.id)}
+                  disabled={busyId === movie.id}
+                  className="rounded-md bg-green-700 px-3 py-1 text-xs font-medium text-white hover:bg-green-600 disabled:opacity-50"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => reject(movie.id, movie.title)}
+                  disabled={busyId === movie.id}
+                  className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800 disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/member-list-manager.tsx
+++ b/src/components/member-list-manager.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { MovieCard, type MovieCardData } from "@/components/movie-card";
+
+export interface MemberListData {
+  id: string;
+  name: string;
+  movies: MovieCardData[];
+}
+
+export function MemberListManager({ initialLists }: { initialLists: MemberListData[] }) {
+  const [lists, setLists] = useState(initialLists);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+
+  async function createList(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setCreating(true);
+    setError(null);
+    const res = await fetch("/api/lists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+    const body = await res.json();
+    setCreating(false);
+    if (!res.ok) {
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setLists((prev) => [...prev, { id: body.list.id, name: body.list.name, movies: [] }]);
+    setNewName("");
+  }
+
+  async function rename(id: string) {
+    if (!editName.trim()) return;
+    setError(null);
+    const res = await fetch(`/api/lists/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editName.trim() }),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setLists((prev) => prev.map((l) => (l.id === id ? { ...l, name: body.list.name } : l)));
+    setEditingId(null);
+  }
+
+  async function remove(id: string) {
+    if (!window.confirm("Delete this list? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/lists/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setLists((prev) => prev.filter((l) => l.id !== id));
+  }
+
+  return (
+    <div>
+      <form onSubmit={createList} className="mb-6 flex gap-2">
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New list name…"
+          className="w-full max-w-xs rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={creating || !newName.trim()}
+          className="shrink-0 rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+        >
+          {creating ? "Creating…" : "Create list"}
+        </button>
+      </form>
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      {lists.length === 0 && (
+        <p className="text-sm text-neutral-500">
+          You haven&rsquo;t created any lists yet. Lists are public — anyone with the link can view one.
+        </p>
+      )}
+
+      {lists.map((list) => (
+        <section key={list.id} className="mb-8">
+          <div className="mb-3 flex flex-wrap items-center gap-3">
+            {editingId === list.id ? (
+              <>
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                />
+                <button onClick={() => rename(list.id)} className="text-sm text-red-500 hover:underline">
+                  Save
+                </button>
+                <button onClick={() => setEditingId(null)} className="text-sm text-neutral-400 hover:text-white">
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <>
+                <h2 className="text-lg font-semibold text-white">{list.name}</h2>
+                <Link href={`/lists/${list.id}`} className="text-xs text-neutral-400 underline hover:text-white">
+                  Public link
+                </Link>
+                <button
+                  onClick={() => {
+                    setEditingId(list.id);
+                    setEditName(list.name);
+                  }}
+                  className="text-xs text-neutral-400 hover:text-white"
+                >
+                  Rename
+                </button>
+                <button onClick={() => remove(list.id)} className="text-xs text-neutral-400 hover:text-red-400">
+                  Delete
+                </button>
+              </>
+            )}
+          </div>
+          {list.movies.length === 0 ? (
+            <p className="text-sm text-neutral-400">No movies yet — add some from a movie&rsquo;s page.</p>
+          ) : (
+            <div className="flex flex-wrap gap-4">
+              {list.movies.map((movie) => (
+                <MovieCard key={movie.id} movie={movie} />
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/movie-submission-search.tsx
+++ b/src/components/movie-submission-search.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import type { TmdbMovieSearchResult } from "@/lib/tmdb";
+
+type SubmissionResult = TmdbMovieSearchResult & { catalogStatus: string | null };
+
+export function MovieSubmissionSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SubmissionResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [submittedIds, setSubmittedIds] = useState<Set<number>>(new Set());
+  const [submittingId, setSubmittingId] = useState<number | null>(null);
+
+  async function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    const res = await fetch(`/api/movies/search?q=${encodeURIComponent(query)}`);
+    const body = await res.json();
+    setLoading(false);
+    if (!res.ok) {
+      setMessage(body.error ?? "Search failed.");
+      return;
+    }
+    setResults(body.results);
+  }
+
+  async function handleSubmit(tmdbId: number) {
+    setSubmittingId(tmdbId);
+    setMessage(null);
+    const res = await fetch("/api/movies/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tmdbId }),
+    });
+    const body = await res.json();
+    setSubmittingId(null);
+    if (!res.ok) {
+      setMessage(body.error ?? "Submission failed.");
+      return;
+    }
+    setSubmittedIds((prev) => new Set(prev).add(tmdbId));
+    setMessage(`"${body.movie.title}" submitted for review.`);
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSearch} className="mb-6 flex gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search TMDB by title (e.g. Enter the Dragon)"
+          className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="shrink-0 rounded-md bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+        >
+          {loading ? "Searching…" : "Search"}
+        </button>
+      </form>
+
+      {message && <p className="mb-4 text-sm text-neutral-300">{message}</p>}
+
+      <ul className="flex flex-col gap-3">
+        {results.map((movie) => {
+          const alreadySubmitted = submittedIds.has(movie.id);
+          const catalogLabel =
+            movie.catalogStatus === "APPROVED"
+              ? "Already in the catalog"
+              : movie.catalogStatus === "PENDING"
+                ? "Already submitted, awaiting review"
+                : null;
+          const disabled = !!catalogLabel || alreadySubmitted || submittingId === movie.id;
+
+          return (
+            <li
+              key={movie.id}
+              className="flex items-center justify-between gap-4 rounded-md border border-neutral-800 bg-neutral-900 p-3"
+            >
+              <div>
+                <p className="font-medium text-white">
+                  {movie.title}{" "}
+                  <span className="text-neutral-500">
+                    {movie.release_date ? `(${movie.release_date.slice(0, 4)})` : ""}
+                  </span>
+                </p>
+                <p className="line-clamp-2 max-w-xl text-sm text-neutral-400">{movie.overview}</p>
+                {catalogLabel && <p className="mt-1 text-xs text-amber-400">{catalogLabel}</p>}
+              </div>
+              <button
+                onClick={() => handleSubmit(movie.id)}
+                disabled={disabled}
+                className="shrink-0 rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-100 hover:bg-neutral-800 disabled:opacity-50"
+              >
+                {submittingId === movie.id ? "Submitting…" : alreadySubmitted ? "Submitted" : "Submit for review"}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -30,7 +30,7 @@ export async function Navbar() {
           </Link>
           {session?.user ? (
             <>
-              <Link href="/my-lists" className="text-sm text-neutral-300 hover:text-white">
+              <Link href={`/members/${session.user.username}`} className="text-sm text-neutral-300 hover:text-white">
                 My Lists
               </Link>
               {session.user.role === "ADMIN" && (
@@ -38,7 +38,9 @@ export async function Navbar() {
                   Admin
                 </Link>
               )}
-              <span className="text-sm text-neutral-500">{session.user.username}</span>
+              <Link href={`/members/${session.user.username}`} className="text-sm text-neutral-500 hover:text-white">
+                {session.user.username}
+              </Link>
               <SignOutButton />
             </>
           ) : (

--- a/src/lib/fuzzy-search.ts
+++ b/src/lib/fuzzy-search.ts
@@ -16,8 +16,9 @@ export async function findSimilarMovies(query: string, limit = 8): Promise<Movie
   return prisma.$queryRaw<Movie[]>`
     SELECT "Movie".*
     FROM "Movie"
-    WHERE similarity(lower("title"), lower(${trimmed})) > ${SIMILARITY_THRESHOLD}
-       OR similarity(lower(COALESCE("director", '')), lower(${trimmed})) > ${SIMILARITY_THRESHOLD}
+    WHERE "status" = 'APPROVED'
+      AND (similarity(lower("title"), lower(${trimmed})) > ${SIMILARITY_THRESHOLD}
+       OR similarity(lower(COALESCE("director", '')), lower(${trimmed})) > ${SIMILARITY_THRESHOLD})
     ORDER BY GREATEST(
       similarity(lower("title"), lower(${trimmed})),
       similarity(lower(COALESCE("director", '')), lower(${trimmed}))

--- a/src/lib/member-lists.ts
+++ b/src/lib/member-lists.ts
@@ -1,0 +1,2 @@
+export const MEMBER_LIST_NAME_MAX_LENGTH = 60;
+export const MAX_MEMBER_LISTS = 25;

--- a/src/lib/movie-submission.ts
+++ b/src/lib/movie-submission.ts
@@ -1,0 +1,33 @@
+import { prisma } from "@/lib/prisma";
+import { searchTmdbMovies } from "@/lib/tmdb";
+import { importMovieFromTmdb } from "@/lib/tmdb-import";
+
+export async function searchTmdbMoviesForSubmission(query: string) {
+  const results = await searchTmdbMovies(query);
+  const existing = await prisma.movie.findMany({
+    where: { tmdbId: { in: results.map((r) => r.id) } },
+    select: { tmdbId: true, status: true },
+  });
+  const statusByTmdbId = new Map(existing.map((m) => [m.tmdbId, m.status]));
+  return results.map((r) => ({ ...r, catalogStatus: statusByTmdbId.get(r.id) ?? null }));
+}
+
+// Guards against the member-submission path ever calling
+// importMovieFromTmdb's upsert on a tmdbId that already exists — that upsert
+// always applies whatever status it's given, so submitting an already-live
+// movie again would silently demote it back to PENDING and pull it off the
+// site until an admin re-approves it.
+export async function submitMovieForReview(tmdbId: number, submittedById: string) {
+  const existing = await prisma.movie.findUnique({ where: { tmdbId }, select: { status: true } });
+  if (existing) {
+    return {
+      error:
+        existing.status === "PENDING"
+          ? "This movie has already been submitted and is awaiting admin review."
+          : "This movie is already in the catalog.",
+    };
+  }
+
+  const movie = await importMovieFromTmdb(tmdbId, { status: "PENDING", submittedById });
+  return { movie };
+}

--- a/src/lib/ratings.ts
+++ b/src/lib/ratings.ts
@@ -73,7 +73,9 @@ export async function getTopRatedMovies(limit = 12) {
 
   if (ranked.length === 0) return [];
 
-  const movies = await prisma.movie.findMany({ where: { id: { in: ranked.map((r) => r.movieId) } } });
+  const movies = await prisma.movie.findMany({
+    where: { id: { in: ranked.map((r) => r.movieId) }, status: "APPROVED" },
+  });
   const byId = new Map(movies.map((m) => [m.id, m]));
 
   return ranked

--- a/src/lib/tmdb-import.ts
+++ b/src/lib/tmdb-import.ts
@@ -3,11 +3,23 @@ import { getTmdbMovieDetails } from "@/lib/tmdb";
 
 const MAX_CAST = 15;
 
-export async function importMovieFromTmdb(tmdbId: number) {
+export interface ImportMovieOptions {
+  // Admin imports (single-title, keyword, bulk CSV) go straight to APPROVED
+  // by omitting this. Member submissions pass "PENDING" so the movie is
+  // hidden from public discovery until an admin approves it. Note: an
+  // existing movie re-imported by an admin always resets to APPROVED, since
+  // an admin action is itself an approval — see submitMovieForReview, which
+  // guards against calling this at all for a tmdbId that already exists.
+  status?: "PENDING" | "APPROVED";
+  submittedById?: string;
+}
+
+export async function importMovieFromTmdb(tmdbId: number, options: ImportMovieOptions = {}) {
   const details = await getTmdbMovieDetails(tmdbId);
   const director = details.credits.crew.find((c) => c.job === "Director")?.name ?? null;
   const country = details.production_countries[0]?.name ?? null;
   const topCast = [...details.credits.cast].sort((a, b) => a.order - b.order).slice(0, MAX_CAST);
+  const status = options.status ?? "APPROVED";
 
   const movie = await prisma.movie.upsert({
     where: { tmdbId: details.id },
@@ -24,6 +36,7 @@ export async function importMovieFromTmdb(tmdbId: number) {
       tmdbPopularity: details.popularity,
       tmdbRating: details.vote_average,
       lastSyncedAt: new Date(),
+      status,
       genres: {
         connectOrCreate: details.genres.map((genre) => ({
           where: { tmdbId: genre.id },
@@ -44,6 +57,8 @@ export async function importMovieFromTmdb(tmdbId: number) {
       country,
       tmdbPopularity: details.popularity,
       tmdbRating: details.vote_average,
+      status,
+      submittedById: options.submittedById,
       genres: {
         connectOrCreate: details.genres.map((genre) => ({
           where: { tmdbId: genre.id },

--- a/src/lib/weekly-featured.ts
+++ b/src/lib/weekly-featured.ts
@@ -36,14 +36,22 @@ export async function computeWeeklyFeatured() {
     activity.set(row.movieId, (activity.get(row.movieId) ?? 0) + row._count._all);
   }
 
-  let topMovieIds = [...activity.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, FEATURED_COUNT)
-    .map(([movieId]) => movieId);
+  const rankedByActivity = [...activity.entries()].sort((a, b) => b[1] - a[1]).map(([movieId]) => movieId);
+
+  // Activity is computed from Rating/DiscussionPost rows directly, which
+  // doesn't know about a movie's approval status — cross-check against
+  // approved movies so a still-pending submission (even one its own
+  // submitter rated or commented on) can never surface here.
+  const approvedActivityMovies = await prisma.movie.findMany({
+    where: { id: { in: rankedByActivity }, status: "APPROVED" },
+    select: { id: true },
+  });
+  const approvedActivityIds = new Set(approvedActivityMovies.map((m) => m.id));
+  let topMovieIds = rankedByActivity.filter((id) => approvedActivityIds.has(id)).slice(0, FEATURED_COUNT);
 
   if (topMovieIds.length < FEATURED_COUNT) {
     const fallback = await prisma.movie.findMany({
-      where: { id: { notIn: topMovieIds } },
+      where: { id: { notIn: topMovieIds }, status: "APPROVED" },
       orderBy: { tmdbPopularity: "desc" },
       take: FEATURED_COUNT - topMovieIds.length,
       select: { id: true },
@@ -78,6 +86,7 @@ export async function getFeaturedMovies() {
   }
 
   return prisma.movie.findMany({
+    where: { status: "APPROVED" },
     orderBy: { tmdbPopularity: "desc" },
     take: FEATURED_COUNT,
   });


### PR DESCRIPTION
## Summary

**⚠️ Schema-touching PR** — please merge/pull before starting another schema-touching PR, per `CLAUDE.md`. Adds `Movie.status`/`submittedById` and two new models (`MemberList`, `MemberListEntry`).

Three related member-account expansions:

- **Member Lists** — members can create their own named lists (beyond the built-in Favorites/Watchlist) from a "+ Add to list" control on any movie page. Public by design, per explicit direction: every list has a shareable `/lists/[id]` permalink viewable by anyone, whether signed in or not — deliberate groundwork for cross-member list browsing/"recommended lists" later without a schema change, not an oversight. Capped at 25 lists/member, 60-char names, unique per member.
- **Member Movie Submissions** — `/movies/submit` (linked from `/search`'s empty-results state) lets a verified member search TMDB and submit a single title, reusing the same import logic `/admin/import` already uses. Submissions start `PENDING` and are invisible everywhere public until an admin approves them from a new **Pending Submissions** section on `/admin/movies` (Approve → live immediately; Reject → permanently deleted, same as any other catalog delete).
- **Member profiles** (`/members/[username]`) — added in a follow-up commit after the site owner pointed out lists should live somewhere a member's list is discoverable by other members, not just via a link someone already has. Viewing your own profile shows Favorites, Watchlist, and full list management (create/rename/delete); viewing someone else's shows only their public custom lists, read-only. Favorites/Watchlist stay exactly as private as they've always been — never shown to anyone but the signed-in owner. `/my-lists` now just redirects to your own profile so existing links keep working.

The pending-movie visibility gate touches every public discovery surface, not just the movie's own page — homepage "Recently Added", search page (including the fuzzy "did you mean" raw-SQL fallback), navbar typeahead search, director/actor autocomplete filters, and the weekly-trending computation (including its own activity-ranking pass, which is computed from Rating/DiscussionPost rows and doesn't itself know about approval status) all now filter to `status: "APPROVED"`. The movie's own page 404s for anyone but its submitter and admins, identical to a nonexistent movie. The same approval check applies to a movie inside a public list/profile page — an entry only its submitter can currently see stays invisible to everyone else viewing that list.

Also guards a correctness issue: submitting a `tmdbId` that's already in the catalog (approved *or* still pending) is rejected with a specific error rather than silently re-running the shared upsert-based import — that upsert always applies whatever status it's given, so without this guard, "submitting" an already-live movie again would demote it back to pending and pull it off the site.

## Checklist

- [x] `README.md` updated — new [Member Lists & Profiles](../blob/master/README.md#member-lists--profiles) and [Member Movie Submissions](../blob/master/README.md#member-movie-submissions) sections, Features bullets, Admin Area's Movies entry, Project Structure
- [x] `.env.example` — not applicable, no new env vars
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Ran a real local Postgres + dev server (not just typechecking) with multiple distinct signed-in accounts:

- Applied the migration against both a fresh database and one with existing rows; confirmed the resulting schema and defaults.
- Created a pending movie and confirmed it's absent from: homepage, `/search` results, the navbar's `/api/search`, and the fuzzy-search fallback.
- Confirmed direct `/movies/[id]` access: 404 for an anonymous visitor and for a signed-in member who is neither the submitter nor an admin; 200 for the submitter and for an admin.
- Confirmed it appears in `/admin/movies`'s Pending Submissions section; approving it via the API immediately made it appear in search/navbar-search/direct-access for everyone.
- Created a public list as one member, added an approved movie to it, and confirmed an entirely unauthenticated `curl` (no cookies at all) could view the list's name, owner username, and movie.
- Confirmed list ownership enforcement: a non-owner gets 403 on rename/delete; the owner succeeds; duplicate list names for the same owner are rejected with 409.
- Confirmed a pending movie added to a member's own public list stays hidden from the public list view (shows "No movies in this list yet" to everyone but the submitter).
- Confirmed `/my-lists` redirects correctly for both signed-in members (→ their own profile) and anonymous visitors (→ login).
- Confirmed profile privacy with three distinct viewers (owner, a different signed-in member, anonymous): Favorites/Watchlist only ever appear to the owner; the public "Classics" list appears identically to all three.
- Visually verified the "+ Add to list" dropdown, the profile page's list management UI (own vs. someone else's), `/movies/submit` search UI, and the admin Pending Submissions queue via Playwright screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG
