### PR TITLE
Replace My Lists nav tab with a public Leaderboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, create their own public named lists on a profile page at `/members/[username]` (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
 - A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
+- A public `/leaderboard` page ranking the Most-Liked Lists (members can like each other's public custom lists) and Top Curators (members with the most movies across their own lists) — see [Member Lists & Profiles](#member-lists--profiles) below
 
 ## Tech Stack
 
@@ -129,10 +130,10 @@ Every member has a profile page at `/members/[username]`. Viewing your own shows
 
 Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile.
 
-- **Custom lists are public by design; Favorites/Watchlist are not.** Every custom list has its own shareable permalink at `/lists/[id]` (also reachable via its owner's profile) that anyone can view signed in or not, with no private option — deliberate groundwork for letting members browse each other's lists later without a schema change. Favorites and Watchlist stay exactly as private as they've always been: only the signed-in owner ever sees their own, on their own profile or anywhere else.
+- **Custom lists are public by design; Favorites/Watchlist are not.** Every custom list has its own shareable permalink at `/lists/[id]` (also reachable via its owner's profile) that anyone can view signed in or not, with no private option. Favorites and Watchlist stay exactly as private as they've always been: only the signed-in owner ever sees their own, on their own profile or anywhere else.
 - A member can have at most 25 lists, with unique names per member; list names are capped at 60 characters.
 - A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list/profile view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below.
-- There's no cross-member browsing/discovery page (e.g. "recommended lists") yet — every list already being public and every member already having a profile URL makes that a schema-free follow-up whenever it's wanted.
+- **Liking lists and the leaderboard**: any signed-in, verified member other than the list's own owner can like a public custom list (one like per member per list; self-likes are blocked). `/leaderboard` — reachable via the "Leaderboard" nav link, replacing what used to be a redundant "My Lists" link pointing at the same place as the username link — ranks the Most-Liked Lists and, separately, Top Curators (members with the most total movies across their own lists). Both rankings recompute on every page load rather than being cached/scheduled.
 
 ## Member Movie Submissions
 

--- a/prisma/migrations/20260805021414_add_member_list_likes/migration.sql
+++ b/prisma/migrations/20260805021414_add_member_list_likes/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "MemberListLike" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "listId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MemberListLike_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MemberListLike_listId_idx" ON "MemberListLike"("listId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberListLike_userId_listId_key" ON "MemberListLike"("userId", "listId");
+
+-- AddForeignKey
+ALTER TABLE "MemberListLike" ADD CONSTRAINT "MemberListLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MemberListLike" ADD CONSTRAINT "MemberListLike_listId_fkey" FOREIGN KEY ("listId") REFERENCES "MemberList"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   editorialReviews    EditorialReview[]
   submittedMovies     Movie[]
   memberLists         MemberList[]
+  memberListLikes     MemberListLike[]
 }
 
 model Account {
@@ -338,6 +339,7 @@ model MemberList {
 
   user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   entries MemberListEntry[]
+  likes   MemberListLike[]
 
   @@unique([userId, name])
   @@index([userId])
@@ -353,6 +355,22 @@ model MemberListEntry {
   movie Movie      @relation(fields: [movieId], references: [id], onDelete: Cascade)
 
   @@unique([listId, movieId])
+  @@index([listId])
+}
+
+// One like per member per list, powering the "Most-Liked Lists" leaderboard.
+// Self-likes are blocked at the API layer (not here) so owners can't inflate
+// their own list's ranking.
+model MemberListLike {
+  id        String   @id @default(cuid())
+  userId    String
+  listId    String
+  createdAt DateTime @default(now())
+
+  user User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  list MemberList @relation(fields: [listId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, listId])
   @@index([listId])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -205,6 +205,25 @@ async function main() {
     },
   });
 
+  const ipMan = await prisma.movie.findUniqueOrThrow({ where: { tmdbId: 900002 } });
+  const drunkenMaster = await prisma.movie.findUniqueOrThrow({ where: { tmdbId: 900003 } });
+  const memberList = await prisma.memberList.upsert({
+    where: { userId_name: { userId: member.id, name: "Essential Kung Fu" } },
+    update: {},
+    create: {
+      userId: member.id,
+      name: "Essential Kung Fu",
+      entries: {
+        create: [{ movieId: enterTheDragon.id }, { movieId: ipMan.id }, { movieId: drunkenMaster.id }],
+      },
+    },
+  });
+  await prisma.memberListLike.upsert({
+    where: { userId_listId: { userId: admin.id, listId: memberList.id } },
+    update: {},
+    create: { userId: admin.id, listId: memberList.id },
+  });
+
   console.log("Seed complete.", { admin: admin.email, member: member.email });
 }
 

--- a/src/app/api/lists/[listId]/like/route.ts
+++ b/src/app/api/lists/[listId]/like/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(request: Request, { params }: { params: Promise<{ listId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to like a list." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before liking a list." }, { status: 403 });
+  }
+
+  const { listId } = await params;
+  const list = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!list) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (list.userId === session.user.id) {
+    return NextResponse.json({ error: "You can't like your own list." }, { status: 403 });
+  }
+
+  const existing = await prisma.memberListLike.findUnique({
+    where: { userId_listId: { userId: session.user.id, listId } },
+  });
+
+  if (existing) {
+    await prisma.memberListLike.delete({ where: { id: existing.id } });
+  } else {
+    await prisma.memberListLike.create({ data: { userId: session.user.id, listId } });
+  }
+
+  const likeCount = await prisma.memberListLike.count({ where: { listId } });
+  return NextResponse.json({ active: !existing, likeCount });
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { getMostLikedLists, getTopCurators } from "@/lib/leaderboard";
+
+export default async function LeaderboardPage() {
+  const [mostLikedLists, topCurators] = await Promise.all([getMostLikedLists(), getTopCurators()]);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <h1 className="mb-6 text-2xl font-bold text-white">Leaderboard</h1>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-lg font-semibold text-white">Most-Liked Lists</h2>
+        {mostLikedLists.length === 0 ? (
+          <p className="text-sm text-neutral-400">No liked lists yet — be the first to like one.</p>
+        ) : (
+          <ol className="flex flex-col gap-2">
+            {mostLikedLists.map((list, i) => (
+              <li
+                key={list.id}
+                className="flex items-center gap-4 rounded-md border border-neutral-800 bg-neutral-900 px-4 py-3"
+              >
+                <span className="w-6 shrink-0 text-right text-sm text-neutral-500">{i + 1}</span>
+                <div className="min-w-0 flex-1">
+                  <Link href={`/lists/${list.id}`} className="font-medium text-white hover:text-red-400">
+                    {list.name}
+                  </Link>
+                  <p className="text-xs text-neutral-500">
+                    by {list.username} · {list.movieCount} {list.movieCount === 1 ? "movie" : "movies"}
+                  </p>
+                </div>
+                <span className="shrink-0 text-sm text-neutral-300">
+                  ♥ {list.likeCount}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-white">Top Curators</h2>
+        {topCurators.length === 0 ? (
+          <p className="text-sm text-neutral-400">No member lists yet — create one from a movie&apos;s page.</p>
+        ) : (
+          <ol className="flex flex-col gap-2">
+            {topCurators.map((curator, i) => (
+              <li
+                key={curator.username}
+                className="flex items-center gap-4 rounded-md border border-neutral-800 bg-neutral-900 px-4 py-3"
+              >
+                <span className="w-6 shrink-0 text-right text-sm text-neutral-500">{i + 1}</span>
+                <div className="min-w-0 flex-1">
+                  <Link href={`/members/${curator.username}`} className="font-medium text-white hover:text-red-400">
+                    {curator.username}
+                  </Link>
+                  <p className="text-xs text-neutral-500">
+                    {curator.listCount} {curator.listCount === 1 ? "list" : "lists"}
+                  </p>
+                </div>
+                <span className="shrink-0 text-sm text-neutral-300">
+                  {curator.movieCount} {curator.movieCount === 1 ? "movie" : "movies"}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/lists/[listId]/page.tsx
+++ b/src/app/lists/[listId]/page.tsx
@@ -1,22 +1,33 @@
 import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries } from "@/lib/ratings";
 import { MovieCard } from "@/components/movie-card";
+import { LikeListButton } from "@/components/like-list-button";
 
 export default async function PublicListPage({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
+  const session = await auth();
 
   const list = await prisma.memberList.findUnique({
     where: { id: listId },
     include: {
       user: { select: { username: true } },
       entries: { include: { movie: true }, orderBy: { createdAt: "desc" } },
+      _count: { select: { likes: true } },
     },
   });
 
   if (!list) {
     notFound();
   }
+
+  const isOwnList = session?.user?.id === list.userId;
+  const myLike = session?.user
+    ? await prisma.memberListLike.findUnique({
+        where: { userId_listId: { userId: session.user.id, listId } },
+      })
+    : null;
 
   // A pending movie could only have been added by its own submitter (the
   // only person who can see its page) — exclude it from what anyone else
@@ -27,7 +38,17 @@ export default async function PublicListPage({ params }: { params: Promise<{ lis
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
       <p className="mb-1 text-sm text-neutral-400">List by {list.user.username}</p>
-      <h1 className="mb-6 text-2xl font-bold text-white">{list.name}</h1>
+      <h1 className="mb-4 text-2xl font-bold text-white">{list.name}</h1>
+      {!isOwnList && (
+        <div className="mb-6">
+          <LikeListButton
+            listId={list.id}
+            initialLiked={!!myLike}
+            initialLikeCount={list._count.likes}
+            canLike={!!session?.user}
+          />
+        </div>
+      )}
       {movies.length === 0 ? (
         <p className="text-neutral-400">No movies in this list yet.</p>
       ) : (

--- a/src/components/like-list-button.tsx
+++ b/src/components/like-list-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function LikeListButton({
+  listId,
+  initialLiked,
+  initialLikeCount,
+  canLike,
+}: {
+  listId: string;
+  initialLiked: boolean;
+  initialLikeCount: number;
+  canLike: boolean;
+}) {
+  const [liked, setLiked] = useState(initialLiked);
+  const [likeCount, setLikeCount] = useState(initialLikeCount);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function toggle() {
+    if (!canLike) {
+      window.location.href = "/login";
+      return;
+    }
+    setError(null);
+    const res = await fetch(`/api/lists/${listId}/like`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { active, likeCount: count } = await res.json();
+    setLiked(active);
+    setLikeCount(count);
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={toggle}
+        className={`w-fit rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+          liked
+            ? "border-red-600 bg-red-700 text-white"
+            : "border-neutral-700 text-neutral-200 hover:bg-neutral-800"
+        }`}
+      >
+        {liked ? "♥ Liked" : "♡ Like"} {likeCount > 0 && `(${likeCount})`}
+      </button>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -28,11 +28,11 @@ export async function Navbar() {
           <Link href="/search/fight-scenes" className="text-sm text-neutral-300 hover:text-white">
             Fight Scenes
           </Link>
+          <Link href="/leaderboard" className="text-sm text-neutral-300 hover:text-white">
+            Leaderboard
+          </Link>
           {session?.user ? (
             <>
-              <Link href={`/members/${session.user.username}`} className="text-sm text-neutral-300 hover:text-white">
-                My Lists
-              </Link>
               {session.user.role === "ADMIN" && (
                 <Link href="/admin" className="text-sm text-neutral-300 hover:text-white">
                   Admin

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@/lib/prisma";
+
+const TOP_LISTS_LIMIT = 20;
+const TOP_CURATORS_LIMIT = 10;
+
+export async function getMostLikedLists() {
+  const lists = await prisma.memberList.findMany({
+    where: { entries: { some: {} } },
+    include: {
+      user: { select: { username: true } },
+      _count: { select: { likes: true, entries: true } },
+    },
+    orderBy: { likes: { _count: "desc" } },
+    take: TOP_LISTS_LIMIT,
+  });
+
+  return lists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    username: list.user.username,
+    likeCount: list._count.likes,
+    movieCount: list._count.entries,
+  }));
+}
+
+// No SQL-level aggregate for "total movies across a user's lists" (it spans
+// two joins), so this ranks in memory — fine at this app's scale, same
+// tradeoff already made for fight-scene search sorting.
+export async function getTopCurators() {
+  const users = await prisma.user.findMany({
+    where: { memberLists: { some: {} } },
+    select: {
+      username: true,
+      memberLists: { select: { _count: { select: { entries: true } } } },
+    },
+  });
+
+  return users
+    .map((user) => ({
+      username: user.username,
+      listCount: user.memberLists.length,
+      movieCount: user.memberLists.reduce((sum, list) => sum + list._count.entries, 0),
+    }))
+    .filter((user) => user.movieCount > 0)
+    .sort((a, b) => b.movieCount - a.movieCount)
+    .slice(0, TOP_CURATORS_LIMIT);
+}


### PR DESCRIPTION
## Summary

**⚠️ Schema-touching PR** — adds a new `MemberListLike` model (migration `20260805021414_add_member_list_likes`). Recommend merging/pulling this before starting another schema-touching PR.

The "My Lists" nav link had become redundant: it pointed at `/members/[username]`, the exact same URL as the adjacent username link, ever since personal lists moved to the profile page in a prior PR. This replaces it with a public **Leaderboard** page (`/leaderboard`), reachable by everyone regardless of sign-in state, same as Browse/Fight Scenes.

The leaderboard has two sections:
- **Top Curators** — members ranked by total movies across their own public `MemberList`s. No schema change; ranked in memory (same tradeoff already made for fight-scene search sorting — fine at this app's scale, no SQL aggregate spans the two-join path cleanly).
- **Most-Liked Lists** — members ranked by likes on their public lists. New `MemberListLike` model (`userId` + `listId`, unique pair) and a like button (`LikeListButton`) added to `/lists/[listId]`. Self-likes are blocked at the API layer (`POST /api/lists/[listId]/like` returns 403 if you own the list) so an owner can't inflate their own ranking.

## Checklist

- [x] `README.md` updated — new Features bullet, and the Member Lists & Profiles section now documents liking + the leaderboard (also removed a now-stale line claiming there was no cross-member browsing page yet)
- [x] `.env.example` — not applicable, no new env vars
- [x] `npm run lint` and `npm run build` pass locally
- [x] `prisma/seed.ts` updated with a sample member list + like so the leaderboard is populated out of the box in local dev

## Test plan

- Verified against a real local Postgres instance:
  - Leaderboard page renders both sections correctly from seed data (1 list, 3 movies, 1 like).
  - Like toggle verified directly against `/api/lists/[listId]/like` via authenticated requests: like → unlike → re-like all return the correct `active`/`likeCount`.
  - Self-like correctly blocked with 403 when the list owner attempts to like their own list.
  - Nav no longer shows a redundant "My Lists" link; "Leaderboard" link shows for signed-in and signed-out visitors alike.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_