### PR TITLE
Rename nav links: Movies, Fights, Lists

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -23,13 +23,13 @@ export async function Navbar() {
         </div>
         <nav className="order-2 ml-auto flex items-center gap-4 sm:order-3">
           <Link href="/search" className="text-sm text-neutral-300 hover:text-white">
-            Browse
+            Movies
           </Link>
           <Link href="/search/fight-scenes" className="text-sm text-neutral-300 hover:text-white">
-            Fight Scenes
+            Fights
           </Link>
           <Link href="/leaderboard" className="text-sm text-neutral-300 hover:text-white">
-            Leaderboard
+            Lists
           </Link>
           {session?.user ? (
             <>


### PR DESCRIPTION
## Summary

Renames three top-nav labels for brevity/clarity, no route/behavior changes:

- "Browse" → "Movies" (still links to `/search`)
- "Fight Scenes" → "Fights" (still links to `/search/fight-scenes`)
- "Leaderboard" → "Lists" (still links to `/leaderboard`)

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed) — not applicable, label text only
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified in a local browser session against current `master` that all three new labels render in the nav.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_