### PR TITLE
Let admins retime a fight scene's clip without re-pasting the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ If a member searches and can't find a movie, `/movies/submit` (linked from a "no
 
 Below the cast list on every movie page, members can catalog individual fight scenes from that film:
 
-- **Add a scene**: paste a YouTube URL (any watch/shorts/embed/`youtu.be`/live link, with an optional `t=`/`start=` timestamp), give it a title (the submitter can auto-fill from the video's public oEmbed title), tag which of the movie's own cast members are in it, and optionally attach up to 10 category tags. Requires a verified email.
+- **Add a scene**: paste a YouTube URL (any watch/shorts/embed/`youtu.be`/live link, with an optional `t=`/`start=` timestamp used as the clip's initial start time), give it a title (the submitter can auto-fill from the video's public oEmbed title), tag which of the movie's own cast members are in it, and optionally attach up to 10 category tags. Requires a verified email.
+- **Adjusting the start time**: only admins can set or change where a clip starts playing, via a "Start at" mm:ss control shown inline on each scene — no need to re-paste the YouTube link to retime it. A submitter's own edits (title, cast, tags, or even swapping the link) never touch the start time; it's admin-managed independently once the scene exists.
 - **Round numbers** aren't stored — they're computed on read as the scene's position, by creation order, among that movie's non-deleted scenes. Delete scene 2 of 3 and the old scene 3 becomes Round 2 automatically.
 - **Ratings**: members rate a scene 1–10 (one rating per member, editable); admins have a separate rating with an optional note, mirroring the movie-level Editors' Score.
 - **Verification**: admins can mark a scene "Verified" as a quality signal. Editing a scene's content clears verification, since an admin's earlier check no longer vouches for what's there now.

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/route.ts
@@ -26,7 +26,7 @@ export async function PATCH(
   if ("error" in result) {
     return NextResponse.json({ error: result.error }, { status: result.status });
   }
-  const { title, videoId, startSeconds, personIds, tagIds } = result;
+  const { title, videoId, personIds, tagIds } = result;
 
   const fightScene = await prisma.$transaction(async (tx) => {
     await tx.fightSceneCast.deleteMany({ where: { fightSceneId } });
@@ -35,7 +35,9 @@ export async function PATCH(
       data: {
         title,
         youtubeVideoId: videoId,
-        youtubeStartSeconds: startSeconds,
+        // Start time is admin-only (set via the separate start-time
+        // endpoint) — a submitter's edit here must not clobber it back to
+        // whatever timestamp happens to be embedded in the pasted URL.
         // Content changed, so an earlier admin verification no longer
         // vouches for what's actually there — require re-review.
         isVerified: false,

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/start-time/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/start-time/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await requireAdminSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+  const existing = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!existing || existing.movieId !== movieId || existing.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const { startSeconds } = await request.json();
+  if (startSeconds !== null && (!Number.isInteger(startSeconds) || startSeconds < 0)) {
+    return NextResponse.json({ error: "startSeconds must be a non-negative integer or null." }, { status: 400 });
+  }
+
+  const fightScene = await prisma.fightScene.update({
+    where: { id: fightSceneId },
+    data: { youtubeStartSeconds: startSeconds },
+  });
+
+  return NextResponse.json({ fightScene });
+}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -49,6 +49,25 @@ function embedUrl(videoId: string, startSeconds: number | null) {
   return `https://www.youtube-nocookie.com/embed/${videoId}${query ? `?${query}` : ""}`;
 }
 
+// Accepts "ss", "mm:ss", or "hh:mm:ss" — whatever an admin is used to typing
+// for a video timestamp. Returns null for blank input (clears the start
+// time) or `undefined` for unparseable input, so callers can tell the two
+// apart.
+function parseMmSs(input: string): number | null | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(":");
+  if (parts.length > 3 || parts.some((p) => !/^\d+$/.test(p))) return undefined;
+  return parts.reduce((total, part) => total * 60 + parseInt(part, 10), 0);
+}
+
+function formatMmSs(totalSeconds: number | null): string {
+  if (totalSeconds === null) return "";
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 function ChipPicker({
   options,
   selected,
@@ -93,6 +112,7 @@ function FightSceneForm({
   submitting,
   onCancel,
   onSubmit,
+  isEditing = false,
 }: {
   castOptions: CastOption[];
   tagOptions: TagOption[];
@@ -104,6 +124,7 @@ function FightSceneForm({
   submitting: boolean;
   onCancel?: () => void;
   onSubmit: (title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) => void;
+  isEditing?: boolean;
 }) {
   const [title, setTitle] = useState(initialTitle);
   const [url, setUrl] = useState(initialUrl);
@@ -161,8 +182,9 @@ function FightSceneForm({
         className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
       />
       <p className="text-xs text-neutral-500">
-        Tip: include a timestamp in the link (e.g. ?t=1m35s or ?t=95) to start the clip at the fight instead of the
-        beginning of the video.
+        {isEditing
+          ? "Tip: an admin can set or adjust exactly where the clip starts after you submit — no need to re-paste the link for that."
+          : "Tip: include a timestamp in the link (e.g. ?t=1m35s or ?t=95) to start the clip at the fight instead of the beginning of the video."}
       </p>
       <input
         type="text"
@@ -274,6 +296,7 @@ export function FightSceneSection({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [adminNoteDrafts, setAdminNoteDrafts] = useState<Record<string, string>>({});
+  const [startTimeDrafts, setStartTimeDrafts] = useState<Record<string, string>>({});
 
   async function handleCreate(title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) {
     setSubmitting(true);
@@ -375,6 +398,33 @@ export function FightSceneSection({
     router.refresh();
   }
 
+  async function handleSetStartTime(id: string) {
+    const scene = scenes.find((s) => s.id === id);
+    const draft = startTimeDrafts[id] ?? formatMmSs(scene?.youtubeStartSeconds ?? null);
+    const startSeconds = parseMmSs(draft);
+    if (startSeconds === undefined) {
+      setError("Start time must look like mm:ss (e.g. 1:23), or blank to clear it.");
+      return;
+    }
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}/start-time`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startSeconds }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setScenes((prev) => prev.map((s) => (s.id === id ? { ...s, youtubeStartSeconds: startSeconds } : s)));
+    setStartTimeDrafts((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+
   async function handleVerifyToggle(id: string, verified: boolean) {
     setError(null);
     const res = await fetch(`/api/movies/${movieId}/fight-scenes/${id}/verify`, {
@@ -458,6 +508,7 @@ export function FightSceneSection({
                   submitting={submitting}
                   onCancel={() => setEditingId(null)}
                   onSubmit={(title, url, personIds, tagIds) => handleEdit(scene.id, title, url, personIds, tagIds)}
+                  isEditing
                 />
               </li>
             );
@@ -491,6 +542,22 @@ export function FightSceneSection({
                     allowFullScreen
                   />
                 </div>
+                {isAdmin && (
+                  <div className="mt-2 flex items-center justify-center gap-1.5 text-[10px]" style={{ color: TICKET_MUTED }}>
+                    <span className="uppercase tracking-wide">Start at</span>
+                    <input
+                      type="text"
+                      value={startTimeDrafts[scene.id] ?? formatMmSs(scene.youtubeStartSeconds)}
+                      onChange={(e) => setStartTimeDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))}
+                      placeholder="mm:ss"
+                      className="w-14 border bg-transparent px-1 py-0.5 text-center focus:outline-none"
+                      style={{ borderColor: TICKET_INK, color: TICKET_INK }}
+                    />
+                    <button onClick={() => handleSetStartTime(scene.id)} className="underline hover:opacity-70">
+                      Save
+                    </button>
+                  </div>
+                )}
               </div>
 
               <Link href={permalinkPath} className="mt-3 block text-lg font-bold hover:opacity-70" style={{ fontFamily: "Georgia, serif" }}>


### PR DESCRIPTION
## Summary

Adds a "Start at" mm:ss control on each fight scene ticket, admin-only, backed by a new `POST .../fight-scenes/[fightSceneId]/start-time` endpoint — mirrors the existing admin-only "verify" route pattern (`requireAdminSession()`, 403 if not admin).

Previously the only way to change where a clip starts playing was pasting a brand-new YouTube URL with a `t=`/`start=` param baked in — a real problem for scenes members added without a timestamp. Now an admin can set/adjust it directly, in place.

- New endpoint validates `startSeconds` as a non-negative integer or `null` (to clear it).
- The existing submitter-edit route (`PATCH .../fight-scenes/[fightSceneId]`) no longer writes `youtubeStartSeconds` at all — previously, any edit (even just adding a tag) silently re-derived the start time from whatever was in the currently-pasted URL, which would have clobbered an admin's manual adjustment on the next unrelated edit.
- Edit-form tip text updated to reflect that timing is now admin-managed after a scene exists, rather than something the submitter needs to re-encode in the link.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed) — updated the Fight Scenes section with the new admin-only start-time control
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Verified end-to-end against a real local Postgres instance and browser session, not just lint/build:
- Signed in as admin, set an existing untimed scene's start to `1:23` via the new control — confirmed the DB row updated to `youtubeStartSeconds: 83` and the embed `<iframe>` src updated to `...?start=83` immediately.
- Confirmed an unauthenticated request to the new endpoint is rejected with `403 Forbidden` and the DB value is left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_