### PR TITLE
Add build version footer (deployed commit SHA)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,6 +91,17 @@ the site.
 
 ## Feature Decisions
 
+### Build version footer: commit SHA, not semantic versioning
+**No PR yet.** A visible "which deploy is this" indicator was worth adding
+after this project's own Vercel-duplicate-project confusion earlier
+(different preview URLs looked interchangeable). Chose the short git commit
+SHA read from Vercel's built-in `VERCEL_GIT_COMMIT_SHA`/`VERCEL_ENV` env
+vars over a `v1.2.3`-style version number — semantic versioning needs a
+manual tagging/release discipline this project doesn't have anywhere else
+(continuous merges to `master`, no release process), while the commit SHA
+is accurate for free and directly answers the question that caused the
+original confusion.
+
 ### Fight scene start time is admin-only, decoupled from submitter edits
 **PR #20.** Members often add clips without a timestamp, and the only fix
 used to be re-pasting a whole new YouTube link. A submitter's own edits

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -92,7 +92,7 @@ the site.
 ## Feature Decisions
 
 ### Build version footer: commit SHA, not semantic versioning
-**No PR yet.** A visible "which deploy is this" indicator was worth adding
+**PR #22.** A visible "which deploy is this" indicator was worth adding
 after this project's own Vercel-duplicate-project confusion earlier
 (different preview URLs looked interchangeable). Chose the short git commit
 SHA read from Vercel's built-in `VERCEL_GIT_COMMIT_SHA`/`VERCEL_ENV` env
@@ -219,6 +219,9 @@ time.
 
 ## Deferred & Backlog
 
+- **Move the build version indicator off the global footer** — currently
+  visible on every page for every visitor; may move to a less prominent
+  spot (e.g. an admin-only page) later. Site-wide footer was fine to start.
 - **Pagination on the per-movie fight scene list** — only the dedicated
   `/search/fight-scenes` page paginates today; a single movie's own scene
   list is still unbounded. Explicitly deferred: "not needed now."

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ Each slide prefers a fight scene clip over the static TMDB backdrop:
 3. Run `npx prisma migrate deploy` against the production database (Vercel's build step, or manually).
 4. Update the Google OAuth redirect URI to your production domain.
 
+## Build Version Footer
+
+Every page shows a small `Build <short commit SHA>` line in the footer (with
+a `· preview`/`· development` suffix on non-production deploys), reading
+Vercel's built-in `VERCEL_GIT_COMMIT_SHA`/`VERCEL_ENV` system environment
+variables — no setup or manual version bump needed. It exists to make "is
+this the deploy I think it is?" a glance instead of a debugging session.
+Locally (no Vercel env), it shows "Local dev build" instead.
+
 ## Project Structure
 
 - `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), and public list permalinks (`/lists/[listId]`)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { Navbar } from "@/components/navbar";
+import { BuildVersion } from "@/components/build-version";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -34,6 +35,7 @@ export default function RootLayout({
         <Providers>
           <Navbar />
           <main className="flex flex-1 flex-col">{children}</main>
+          <BuildVersion />
         </Providers>
       </body>
     </html>

--- a/src/components/build-version.tsx
+++ b/src/components/build-version.tsx
@@ -1,0 +1,20 @@
+// Vercel injects these as System Environment Variables at build time (no
+// setup needed beyond the project default), so this is nearly free to keep
+// accurate — no manual version bump, no release process this project
+// doesn't otherwise have. Renders nothing meaningful locally (no Vercel env),
+// which is fine: this exists to answer "which deploy am I looking at" on a
+// live site, not to be a local dev indicator.
+export function BuildVersion() {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA;
+  const env = process.env.VERCEL_ENV;
+
+  const label = sha
+    ? `Build ${sha.slice(0, 7)}${env && env !== "production" ? ` · ${env}` : ""}`
+    : "Local dev build";
+
+  return (
+    <footer className="border-t border-neutral-800 px-4 py-3 text-center font-mono text-[11px] text-neutral-600">
+      {label}
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a small `Build <short commit SHA>` line in the site footer, so "which deploy is this?" is a glance instead of a debugging session — directly motivated by this project's own earlier duplicate-Vercel-project confusion.

- Reads Vercel's built-in `VERCEL_GIT_COMMIT_SHA`/`VERCEL_ENV` system environment variables — no manual setup, no version-bump discipline needed.
- Shows a `· preview`/`· development` suffix on non-production deploys, nothing extra on production.
- Falls back to "Local dev build" when running outside Vercel (verified locally — no Vercel env vars are set in local dev).
- Commit SHA over semantic versioning: this project has no release/tagging process anywhere else (continuous merges to `master`), so a manual `v1.2.3` scheme would be the first place that discipline is required. The SHA is accurate for free.

Per user feedback mid-build: logged as a `DECISIONS.md` backlog item that the footer placement may move later (e.g. to an admin-only page) — global footer was the right starting point, not necessarily the final spot.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed) — new "Build Version Footer" section added
- [x] `.env.example` updated if a new environment variable was added — not applicable (Vercel's built-in system env vars, nothing to configure)
- [x] `DECISIONS.md` updated if this involved a real judgment call, an
      architecture/schema-shaping change, or an explicit deferral — yes, new Feature Decision entry + backlog item
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Verified in a real browser against all three states, not just build/lint:
- No Vercel env vars (plain local dev) → renders "Local dev build".
- `VERCEL_GIT_COMMIT_SHA` + `VERCEL_ENV=production` → renders "Build abc1234" with no suffix.
- `VERCEL_GIT_COMMIT_SHA` + `VERCEL_ENV=preview` → renders "Build abc1234 · preview".
- Screenshotted the footer to confirm it reads as a subtle, unobtrusive line, not a prominent UI element.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_