### PR TITLE
Rename section label to "Recent Reviews by Editors"

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,7 +91,7 @@ the site.
 
 ## Feature Decisions
 
-### Recent Editor's Reviews shows full review text, clamped, not a short excerpt
+### Recent Reviews by Editors shows full review text, clamped, not a short excerpt
 **PR #23.** Requested alongside a News & Updates feature (not yet
 built); this piece was built first since it needed no schema change —
 `EditorialReview` already had everything required. *Considered:* a
@@ -241,8 +241,8 @@ time.
 
 - **News & Updates (admin blog)** — a new `NewsPost` model, `/admin/news`
   CRUD, a public `/news` list page, a nav link, and a homepage teaser
-  banner for the latest post. Requested alongside Recent Editor's Reviews;
-  Recent Editor's Reviews was built first since it needed no schema change.
+  banner for the latest post. Requested alongside Recent Reviews by Editors;
+  Recent Reviews by Editors was built first since it needed no schema change.
 - **Move the build version indicator off the global footer** — currently
   visible on every page for every visitor; may move to a less prominent
   spot (e.g. an admin-only page) later. Site-wide footer was fine to start.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Below the cast list on every movie page, members can catalog individual fight sc
 
 Admins can write a long-form review (up to 10,000 characters) for any movie, shown alongside the cast list. There's one review per movie — any admin can write or update it, and the page just tracks who last touched it.
 
-The homepage's **Recent Editor's Reviews** section surfaces the 5 most recently written-or-edited reviews (an admin revising an older review counts, not just brand-new ones) as a two-column grid of compact cards — poster thumbnail, title, reviewer, date, and the review's full text clamped to 3 lines with a "Show more" toggle once it's long enough to need one, rather than a short teaser excerpt.
+The homepage's **Recent Reviews by Editors** section surfaces the 5 most recently written-or-edited reviews (an admin revising an older review counts, not just brand-new ones) as a two-column grid of compact cards — poster thumbnail, title, reviewer, date, and the review's full text clamped to 3 lines with a "Show more" toggle once it's long enough to need one, rather than a short teaser excerpt.
 
 ## Admin Poster Overrides
 

--- a/src/components/recent-reviews-feed.tsx
+++ b/src/components/recent-reviews-feed.tsx
@@ -60,7 +60,7 @@ export function RecentReviewsFeed({ reviews }: { reviews: RecentReviewItem[] }) 
 
   return (
     <section className="mx-auto w-full max-w-6xl px-4 py-8">
-      <h2 className="mb-4 font-serif text-xl font-bold text-white">Recent Editor&rsquo;s Reviews</h2>
+      <h2 className="mb-4 font-serif text-xl font-bold text-white">Recent Reviews by Editors</h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {reviews.map((review) => {
           const posterUrl = resolvePosterUrl(review.movie, "w200");


### PR DESCRIPTION
## Summary

Renames the homepage section label from "Recent Editor's Reviews" to "Recent Reviews by Editors" for consistency — no functional/behavior changes.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed) — label text only
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated if this involved a real judgment call, an
      architecture/schema-shaping change, or an explicit deferral — not applicable, pure label rename
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified in a local browser session that the new label renders on the homepage.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_