### PR TITLE
Save fight scenes to member lists and favorites

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,6 +91,89 @@ the site.
 
 ## Feature Decisions
 
+### Actor pages browse-only for now, not wired into the search actor filter
+**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** New `/actors/[personId]`
+pages (filmography + every tagged fight scene, reusing existing card
+components) needed entry points. Linked from a movie's Cast section and a
+fight scene's "Featuring" line, both of which already show one specific
+person. *Considered:* also linking out from `/search/fight-scenes`'s actor
+filter — passed on it, since that filter is `AutocompleteFilterInput`, a
+plain name-string autocomplete shared with the unrelated director filter;
+it returns names for filling the search form, not person IDs, and has no
+per-suggestion click target. Reworking a shared component for one of its
+two use cases wasn't worth it for a filter whose job (narrow results to
+one actor) is already satisfied without a profile link. No actor search of
+its own exists yet either — browsing via Cast/Featuring links is the only
+way in for now.
+
+### Per-movie fight scene pagination is a client-side "Show more," not URL-based paging
+**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** `/search/fight-scenes`
+already paginates via `?page=` and a server round-trip per page — the
+per-movie list on a movie's own page didn't. *Considered:* the same
+URL-based pattern — rejected because `FightSceneSection` is a client
+component holding a lot of local mutable state (create/edit/delete,
+in-place round-number reflow, draft inputs), and a `?page=` navigation
+would either reset all of that or need it threaded through the URL for no
+real benefit — a movie's scene count is small enough that fetching all of
+them up front (as it already did) isn't a backend concern; the only goal
+was not dumping dozens of ticket cards on the page at once. So the fetch
+stays as-is and a `visibleCount` client state slices the already-sorted
+list, revealed 6 at a time via a "Show more" button — no route change, no
+loss of in-progress edits when a page is revealed.
+
+### Fight scenes get a one-tap Favorite, deliberately no Watchlist
+**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** After building
+custom-list saving for fight scenes (see the `MemberListFightSceneEntry`
+entry below), a follow-up question was whether to also extend movies'
+one-tap Favorite/Watchlist toggle (`ListEntry`, `listType:
+"FAVORITE"|"WATCHLIST"`, distinct from custom lists) to fight scenes for
+UI consistency. *Considered and initially built:* the full pair, mirroring
+`ListEntry` as `FightSceneListEntry` with the same `listType` split —
+reverted after further thought: a Watchlist is "something to get to later,"
+which fits a two-hour movie but not a clip that takes thirty seconds to
+watch right where it's already linked, so the *scene* version of Watchlist
+had no real use case, and *Favorite* — a one-tap toggle for the two-second
+"I like this specific fight," a genuinely different interaction from
+picking from a multi-select list — is the one worth keeping. Modeled as
+`FightSceneFavorite` (`userId`, `fightSceneId`, unique on the pair, no
+`listType` column since there's only ever one kind, unlike `ListEntry`).
+A standalone `FavoriteButton` component (a single heart icon, red when
+active) replaced routing fight scenes through `ListButtons` — forcing a
+single-button case through a component built for a pair would have been
+more awkward than the small duplication of a heart icon button.
+`ListButtons` itself stayed movie-only. Wired into the same six places
+`MemberListFightSceneEntry` was, plus a "Favorite Fight Scenes" section on
+the member's own profile page below the existing movie Favorites/Watchlist
+rows (no "Fight Scene Watchlist" counterpart, per the above). The heart
+shape (not a star) and its red active color were an explicit request,
+carried back to the movie-level Favorite button's own icon/text for
+consistency in the other direction.
+
+### Saved fight scenes get their own MemberListFightSceneEntry model, not a nullable column on MemberListEntry
+**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** Extending member
+lists to hold fight scenes needed a schema decision: add nullable
+`movieId`/`fightSceneId` columns to the existing `MemberListEntry` with an
+app-level "exactly one is set" rule, or a separate mirrored entry model.
+*Considered:* the nullable-column approach — rejected in favor of a second
+model (`MemberListFightSceneEntry`, unique on `[listId, fightSceneId]`),
+matching the established convention of mirroring shapes for a new content
+type (see Fight Scenes' own PR #4 entry above) rather than inventing a
+polymorphic one; it keeps both foreign keys required and avoids a
+CHECK-constraint or XOR-validation layer just to keep one row from having
+both or neither reference set. `AddToListControl` was generalized instead
+of duplicated — it now takes a `target: {type: "movie"|"fightScene", id}`
+discriminated prop and picks the right endpoint/body key, since the
+dropdown/create-list UI is otherwise identical between the two. It also
+gained a compact `variant="icon"` (a bookmark icon, same treatment as
+`ShareButton`'s existing icon variant) so it fits in the Fight Ticket
+card's top row next to the share icon without disrupting that card's
+compact layout. Wired into every page that renders a fight scene card —
+a movie's own Fight Scenes section, a scene's permalink page, fight scene
+search results, a public list page, and a member's own list-management
+view — each fetching the *viewing* member's own lists (not the page
+subject's), so anyone can bookmark a scene into their own list regardless
+of whose page they found it on.
+
 ### Recent Reviews by Editors shows full review text, clamped, not a short excerpt
 **PR #23.** Requested alongside a News & Updates feature (not yet
 built); this piece was built first since it needed no schema change —
@@ -264,9 +347,6 @@ time.
 - **Move the build version indicator off the global footer** — currently
   visible on every page for every visitor; may move to a less prominent
   spot (e.g. an admin-only page) later. Site-wide footer was fine to start.
-- **Pagination on the per-movie fight scene list** — only the dedicated
-  `/search/fight-scenes` page paginates today; a single movie's own scene
-  list is still unbounded. Explicitly deferred: "not needed now."
 - **Editor's Picks rail** — homepage rail surfacing highest editor-rated
   movies; the data model already supports it, the homepage doesn't surface it.
 - **Top Rated Fight Scenes rail** — homepage rail using existing fight-scene

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Search by movie title, actor, or director name, with filters (genre, director, actor, country, release-year range, minimum community rating, minimum editor rating), sorting (relevance, highest rated, newest, oldest), pagination, and a typo-tolerant "did you mean" fallback when nothing matches exactly — plus a dedicated fight-scene search at `/search/fight-scenes` (filter by tag, actor, member/editor rating) — see [Search](#search) below
 - Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", an admin-authored editorial review, and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation)
 - **Fight Scenes**: members tag specific fight scenes within a movie — YouTube clip (with an optional start timestamp), the actors involved (picked from that movie's cast), and category tags (e.g. "Weapon Duel", "One vs. Many") — with their own member rating, a separate admin rating, admin verification, and a shareable permalink page (see [Fight Scenes](#fight-scenes) below)
+- Actor pages (`/actors/[personId]`) showing an actor's filmography and every fight scene they're tagged in, linked from a movie's cast list and a scene's "Featuring" line (see [Actor Pages](#actor-pages) below)
 - Member accounts via email/password (with email verification) or Google sign-in, identified publicly by a chosen username rather than their email or real name (see [Usernames](#usernames) below)
-- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist, create their own public named lists on a profile page at `/members/[username]` (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
+- Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist for movies (fight scenes get a Favorite only — see below), create their own public named lists on a profile page at `/members/[username]` and save both movies and fight scenes to them (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
 - A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 - A public `/leaderboard` page ranking the Most-Liked Lists (members can like each other's public custom lists) and Top Curators (members with the most movies across their own lists) — see [Member Lists & Profiles](#member-lists--profiles) below
@@ -119,7 +120,7 @@ Without `RESEND_API_KEY` configured, the verification link is logged to the serv
 Two dedicated search pages, both with a vertical sidebar of filters, pagination, and sort options — split apart because a fight-scene result is the scene itself, not "a movie that happens to contain one."
 
 - **`/search`** (movies) — filters: genre, director (autocomplete), actor (autocomplete), country, release-year range, minimum community rating, minimum editor rating. Sort by relevance, highest rated, newest, or oldest. A typo-tolerant "did you mean" fallback (via Postgres `pg_trgm`, see [Getting Set Up](#getting-set-up)) kicks in when nothing matches exactly.
-- **`/search/fight-scenes`** — filters: category tag (multi-select, matches any selected), actor (autocomplete, scoped to people actually tagged in a fight scene — not just anyone in a movie's cast), minimum member rating, minimum editor rating. Sort by newest, highest member rated, or highest editor rated.
+- **`/search/fight-scenes`** — filters: category tag (multi-select, matches any selected), actor (autocomplete, scoped to people actually tagged in a fight scene — not just anyone in a movie's cast), minimum member rating, minimum editor rating. Sort by newest, highest member rated, highest editor rated, or most favorited.
 - The navbar's search box submits to `/search` in "browse" mode (no filters) when submitted empty, rather than doing nothing — both pages are also reachable directly via the "Browse" and "Fight Scenes" nav links.
 
 ## TMDB Import
@@ -135,13 +136,14 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
 
 ## Member Lists & Profiles
 
-Every member has a profile page at `/members/[username]`. Viewing your own shows Favorites, Watchlist, and your custom lists with full management controls (create/rename/delete); viewing someone else's shows only their public custom lists, read-only. `/my-lists` still works as a link — it just redirects to your own profile.
+Every member has a profile page at `/members/[username]`. Viewing your own shows Favorites, Watchlist, Favorite Fight Scenes, and your custom lists with full management controls (create/rename/delete); viewing someone else's shows only their public custom lists, read-only. `/my-lists` still works as a link — it just redirects to your own profile.
 
-Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile.
+Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile. Lists hold fight scenes as well as movies — every fight scene card, wherever it appears (a movie page, its own permalink, fight scene search results, or another member's list), has its own bookmark-icon "save to list" control alongside the share icon.
 
-- **Custom lists are public by design; Favorites/Watchlist are not.** Every custom list has its own shareable permalink at `/lists/[id]` (also reachable via its owner's profile) that anyone can view signed in or not, with no private option. Favorites and Watchlist stay exactly as private as they've always been: only the signed-in owner ever sees their own, on their own profile or anywhere else.
+- **Fight scenes get a one-tap Favorite, same red heart icon movies use, but no Watchlist** — a scene is a short clip you can watch right where it's linked, not something to queue up for later the way a full movie is. Every fight scene card has its own heart icon, independent of the movie it belongs to and independent of custom lists — you can favorite a scene without favoriting its movie, or vice versa.
+- **Custom lists are public by design; Favorites/Watchlist are not.** Every custom list has its own shareable permalink at `/lists/[id]` (also reachable via its owner's profile) that anyone can view signed in or not, with no private option. Favorites and Watchlist (for both movies and fight scenes) stay exactly as private as they've always been: only the signed-in owner ever sees their own, on their own profile or anywhere else.
 - A member can have at most 25 lists, with unique names per member; list names are capped at 60 characters.
-- A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list/profile view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below.
+- A pending (not yet admin-approved) movie can only be added to a list by its own submitter, and is excluded from the public list/profile view for everyone else, the same as it's excluded from every other public listing — see [Member Movie Submissions](#member-movie-submissions) below. A soft-deleted fight scene is excluded from a public list view the same way.
 - **Liking lists and the leaderboard**: any signed-in, verified member other than the list's own owner can like a public custom list (one like per member per list; self-likes are blocked). `/leaderboard` — reachable via the "Leaderboard" nav link, replacing what used to be a redundant "My Lists" link pointing at the same place as the username link — ranks the Most-Liked Lists and, separately, Top Curators (members with the most total movies across their own lists). Both rankings recompute on every page load rather than being cached/scheduled.
 
 ## Member Movie Submissions
@@ -164,6 +166,11 @@ Below the cast list on every movie page, members can catalog individual fight sc
 - **Editing/deleting**: the submitter can edit or delete their own scene; admins can delete anyone's. Deletion is a soft-delete (like discussion posts) so ratings tied to a scene aren't orphaned.
 - **Tags**: the tag list itself (e.g. "Weapon Duel", "One vs. Many") is admin-curated at `/admin/fight-scene-tags` — members choose from it but can't create new tags.
 - **Permalinks**: each fight scene has its own page at `/movies/[id]/fight-scenes/[fightSceneId]` with dynamic Open Graph metadata (title, rating summary, YouTube thumbnail) for clean link previews when shared.
+- **Saving to a list**: any member can save a fight scene to one of their own custom lists, or one-tap Favorite it — see [Member Lists & Profiles](#member-lists--profiles).
+
+## Actor Pages
+
+Every credited person has a page at `/actors/[personId]` showing their Filmography (movies in the catalog, excluding any still-pending submission) and every Fight Scene they're tagged in across the whole catalog, sorted by most favorited, reusing the same movie/fight-scene cards used everywhere else. Linked from a movie's Cast section and from the "Featuring" line on a fight scene card — there's no dedicated actor search yet, so browsing there is the only way in for now.
 
 ## Editorial Reviews
 
@@ -248,7 +255,7 @@ It needs to be turned on per-project after deploying: **Vercel dashboard → thi
 
 ## Project Structure
 
-- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), and public list permalinks (`/lists/[listId]`)
+- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), public list permalinks (`/lists/[listId]`), and actor pages (`/actors/[personId]`)
 - `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, `member-list-manager.tsx`, `add-to-list-control.tsx`, etc.)
 - `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene/username/member-list helpers, email sender
 - `prisma/schema.prisma` — data model

--- a/prisma/migrations/20260811020802_add_member_list_fight_scene_entry/migration.sql
+++ b/prisma/migrations/20260811020802_add_member_list_fight_scene_entry/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "MemberListFightSceneEntry" (
+    "id" TEXT NOT NULL,
+    "listId" TEXT NOT NULL,
+    "fightSceneId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MemberListFightSceneEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MemberListFightSceneEntry_listId_idx" ON "MemberListFightSceneEntry"("listId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberListFightSceneEntry_listId_fightSceneId_key" ON "MemberListFightSceneEntry"("listId", "fightSceneId");
+
+-- AddForeignKey
+ALTER TABLE "MemberListFightSceneEntry" ADD CONSTRAINT "MemberListFightSceneEntry_listId_fkey" FOREIGN KEY ("listId") REFERENCES "MemberList"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MemberListFightSceneEntry" ADD CONSTRAINT "MemberListFightSceneEntry_fightSceneId_fkey" FOREIGN KEY ("fightSceneId") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260811024440_add_fight_scene_favorite/migration.sql
+++ b/prisma/migrations/20260811024440_add_fight_scene_favorite/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "FightSceneFavorite" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "fightSceneId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FightSceneFavorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FightSceneFavorite_userId_idx" ON "FightSceneFavorite"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FightSceneFavorite_userId_fightSceneId_key" ON "FightSceneFavorite"("userId", "fightSceneId");
+
+-- AddForeignKey
+ALTER TABLE "FightSceneFavorite" ADD CONSTRAINT "FightSceneFavorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FightSceneFavorite" ADD CONSTRAINT "FightSceneFavorite_fightSceneId_fkey" FOREIGN KEY ("fightSceneId") REFERENCES "FightScene"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   ratings       Rating[]
   adminRatings  AdminRating[]
   listEntries   ListEntry[]
+  fightSceneFavorites FightSceneFavorite[]
   discussionPosts DiscussionPost[]
   fightScenes         FightScene[]
   fightSceneRatings   FightSceneRating[]
@@ -216,6 +217,22 @@ model ListEntry {
   @@index([userId])
 }
 
+// Fight scenes only get a Favorite, not a Watchlist — unlike a movie, a
+// scene is a short clip, not something to queue up for later. No listType
+// discriminator, unlike ListEntry, since there's only ever one kind.
+model FightSceneFavorite {
+  id           String   @id @default(cuid())
+  userId       String
+  fightSceneId String
+  createdAt    DateTime @default(now())
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fightScene FightScene @relation(fields: [fightSceneId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, fightSceneId])
+  @@index([userId])
+}
+
 // --- Discussion ---
 
 model DiscussionPost {
@@ -263,6 +280,8 @@ model FightScene {
   tags        FightSceneTag[]
   ratings     FightSceneRating[]
   adminRatings FightSceneAdminRating[]
+  memberListEntries MemberListFightSceneEntry[]
+  favorites FightSceneFavorite[]
 
   @@index([movieId])
 }
@@ -339,6 +358,7 @@ model MemberList {
 
   user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   entries MemberListEntry[]
+  fightSceneEntries MemberListFightSceneEntry[]
   likes   MemberListLike[]
 
   @@unique([userId, name])
@@ -355,6 +375,23 @@ model MemberListEntry {
   movie Movie      @relation(fields: [movieId], references: [id], onDelete: Cascade)
 
   @@unique([listId, movieId])
+  @@index([listId])
+}
+
+// Mirrors MemberListEntry but for fight scenes, rather than adding a
+// nullable fightSceneId to that model — keeps both content types' foreign
+// keys required and each query shape simple, matching how FightScene's own
+// models mirror Movie's instead of a polymorphic entry type.
+model MemberListFightSceneEntry {
+  id           String   @id @default(cuid())
+  listId       String
+  fightSceneId String
+  createdAt    DateTime @default(now())
+
+  list       MemberList @relation(fields: [listId], references: [id], onDelete: Cascade)
+  fightScene FightScene @relation(fields: [fightSceneId], references: [id], onDelete: Cascade)
+
+  @@unique([listId, fightSceneId])
   @@index([listId])
 }
 

--- a/src/app/actors/[personId]/page.tsx
+++ b/src/app/actors/[personId]/page.tsx
@@ -1,0 +1,125 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { tmdbImageUrl } from "@/lib/tmdb";
+import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries, getFightSceneFavoriteCounts } from "@/lib/fight-scenes";
+import { MovieCard } from "@/components/movie-card";
+import { FightSceneResultCard } from "@/components/fight-scene-result-card";
+import { getRatingSummaries } from "@/lib/ratings";
+
+export default async function ActorPage({ params }: { params: Promise<{ personId: string }> }) {
+  const { personId } = await params;
+  const session = await auth();
+
+  const person = await prisma.person.findUnique({
+    where: { id: personId },
+    include: {
+      castCredits: { include: { movie: true }, orderBy: { movie: { releaseDate: "desc" } } },
+      fightSceneAppearances: {
+        include: { fightScene: { include: { movie: { select: { id: true, title: true, releaseDate: true } }, tags: true } } },
+        orderBy: { fightScene: { createdAt: "desc" } },
+      },
+    },
+  });
+  if (!person) {
+    notFound();
+  }
+
+  // A pending (not yet admin-approved) movie is excluded the same way it's
+  // excluded from every other public listing.
+  const movies = person.castCredits.map((c) => c.movie).filter((m) => m.status === "APPROVED");
+  const ratingSummaries = await getRatingSummaries(movies.map((m) => m.id));
+
+  const fightScenes = person.fightSceneAppearances
+    .map((a) => a.fightScene)
+    .filter((s) => !s.isDeleted && s.movie);
+
+  const [memberSummaries, editorSummaries, favoriteCounts] = await Promise.all([
+    getFightSceneRatingSummaries(fightScenes.map((s) => s.id)),
+    getFightSceneAdminRatingSummaries(fightScenes.map((s) => s.id)),
+    getFightSceneFavoriteCounts(fightScenes.map((s) => s.id)),
+  ]);
+
+  const myMemberLists = session?.user
+    ? await prisma.memberList.findMany({
+        where: { userId: session.user.id },
+        orderBy: { createdAt: "asc" },
+        include: {
+          fightSceneEntries: { where: { fightSceneId: { in: fightScenes.map((s) => s.id) } }, select: { fightSceneId: true } },
+        },
+      })
+    : [];
+  const myMemberListItems = myMemberLists.map((l) => ({ id: l.id, name: l.name }));
+
+  const myFightSceneFavorites = session?.user
+    ? await prisma.fightSceneFavorite.findMany({
+        where: { userId: session.user.id, fightSceneId: { in: fightScenes.map((s) => s.id) } },
+      })
+    : [];
+
+  const sortedFightScenes = [...fightScenes].sort(
+    (a, b) => (favoriteCounts.get(b.id) ?? 0) - (favoriteCounts.get(a.id) ?? 0),
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <div className="mb-8 flex items-center gap-4">
+        <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-full bg-neutral-800">
+          {person.profilePath && (
+            <Image src={tmdbImageUrl(person.profilePath, "w200") ?? ""} alt={person.name} fill sizes="96px" className="object-cover" />
+          )}
+        </div>
+        <h1 className="text-2xl font-bold text-white">{person.name}</h1>
+      </div>
+
+      <h2 className="mb-4 text-xl font-bold text-white">Filmography</h2>
+      {movies.length === 0 ? (
+        <p className="mb-8 text-sm text-neutral-400">No movies in the catalog yet.</p>
+      ) : (
+        <div className="mb-10 flex flex-wrap gap-4">
+          {movies.map((movie) => {
+            const summary = ratingSummaries.get(movie.id);
+            return (
+              <MovieCard
+                key={movie.id}
+                movie={{ ...movie, communityAverage: summary?.average ?? null, communityCount: summary?.count ?? 0 }}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <h2 className="mb-4 text-xl font-bold text-white">Fight Scenes</h2>
+      {sortedFightScenes.length === 0 ? (
+        <p className="text-sm text-neutral-400">No fight scenes tagged with this actor yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-4">
+          {sortedFightScenes.map((scene) => {
+            const memberSummary = memberSummaries.get(scene.id);
+            const editorSummary = editorSummaries.get(scene.id);
+            const initialLists = myMemberListItems.map((l) => {
+              const listRow = myMemberLists.find((row) => row.id === l.id)!;
+              return { ...l, hasItem: listRow.fightSceneEntries.some((e) => e.fightSceneId === scene.id) };
+            });
+            return (
+              <FightSceneResultCard
+                key={scene.id}
+                scene={{
+                  ...scene,
+                  memberRatingAverage: memberSummary?.average ?? null,
+                  memberRatingCount: memberSummary?.count ?? 0,
+                  editorRatingAverage: editorSummary?.average ?? null,
+                  editorRatingCount: editorSummary?.count ?? 0,
+                }}
+                initialLists={initialLists}
+                signedIn={!!session?.user}
+                initialFavorite={myFightSceneFavorites.some((e) => e.fightSceneId === scene.id)}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/lists/[listId]/fight-scene-entries/[fightSceneId]/route.ts
+++ b/src/app/api/lists/[listId]/fight-scene-entries/[fightSceneId]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ listId: string; fightSceneId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { listId, fightSceneId } = await params;
+  const list = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!list) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (list.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own lists." }, { status: 403 });
+  }
+
+  await prisma.memberListFightSceneEntry.deleteMany({ where: { listId, fightSceneId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/lists/[listId]/fight-scene-entries/route.ts
+++ b/src/app/api/lists/[listId]/fight-scene-entries/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(request: Request, { params }: { params: Promise<{ listId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before managing lists." }, { status: 403 });
+  }
+
+  const { listId } = await params;
+  const list = await prisma.memberList.findUnique({ where: { id: listId } });
+  if (!list) {
+    return NextResponse.json({ error: "List not found." }, { status: 404 });
+  }
+  if (list.userId !== session.user.id) {
+    return NextResponse.json({ error: "You can only add to your own lists." }, { status: 403 });
+  }
+
+  const { fightSceneId } = await request.json();
+  if (typeof fightSceneId !== "string") {
+    return NextResponse.json({ error: "fightSceneId is required." }, { status: 400 });
+  }
+  const scene = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!scene || scene.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const entry = await prisma.memberListFightSceneEntry.upsert({
+    where: { listId_fightSceneId: { listId, fightSceneId } },
+    update: {},
+    create: { listId, fightSceneId },
+  });
+  return NextResponse.json({ entry });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/favorite/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/favorite/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fightSceneId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to manage your favorites." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before managing favorites." }, { status: 403 });
+  }
+
+  const { id: movieId, fightSceneId } = await params;
+
+  const scene = await prisma.fightScene.findUnique({ where: { id: fightSceneId } });
+  if (!scene || scene.movieId !== movieId || scene.isDeleted) {
+    return NextResponse.json({ error: "Fight scene not found." }, { status: 404 });
+  }
+
+  const existing = await prisma.fightSceneFavorite.findUnique({
+    where: { userId_fightSceneId: { userId: session.user.id, fightSceneId } },
+  });
+
+  if (existing) {
+    await prisma.fightSceneFavorite.delete({ where: { id: existing.id } });
+    return NextResponse.json({ active: false });
+  }
+
+  await prisma.fightSceneFavorite.create({ data: { userId: session.user.id, fightSceneId } });
+  return NextResponse.json({ active: true });
+}

--- a/src/app/lists/[listId]/page.tsx
+++ b/src/app/lists/[listId]/page.tsx
@@ -2,7 +2,9 @@ import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries } from "@/lib/ratings";
+import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries } from "@/lib/fight-scenes";
 import { MovieCard } from "@/components/movie-card";
+import { FightSceneResultCard } from "@/components/fight-scene-result-card";
 import { LikeListButton } from "@/components/like-list-button";
 
 export default async function PublicListPage({ params }: { params: Promise<{ listId: string }> }) {
@@ -14,6 +16,10 @@ export default async function PublicListPage({ params }: { params: Promise<{ lis
     include: {
       user: { select: { username: true } },
       entries: { include: { movie: true }, orderBy: { createdAt: "desc" } },
+      fightSceneEntries: {
+        include: { fightScene: { include: { movie: { select: { id: true, title: true, releaseDate: true } }, tags: true } } },
+        orderBy: { createdAt: "desc" },
+      },
       _count: { select: { likes: true } },
     },
   });
@@ -35,6 +41,34 @@ export default async function PublicListPage({ params }: { params: Promise<{ lis
   const movies = list.entries.map((entry) => entry.movie).filter((movie) => movie.status === "APPROVED");
   const ratingSummaries = await getRatingSummaries(movies.map((m) => m.id));
 
+  // Same reasoning as pending movies: a soft-deleted fight scene shouldn't
+  // linger visibly just because it was saved before deletion.
+  const fightScenes = list.fightSceneEntries.map((entry) => entry.fightScene).filter((scene) => !scene.isDeleted);
+  const [memberSummaries, editorSummaries] = await Promise.all([
+    getFightSceneRatingSummaries(fightScenes.map((s) => s.id)),
+    getFightSceneAdminRatingSummaries(fightScenes.map((s) => s.id)),
+  ]);
+
+  // Not the list owner's saved-state — the *current viewer's own* lists, so
+  // they can bookmark a scene they found here into one of their own lists,
+  // same as every other page a fight scene card appears on.
+  const myMemberLists = session?.user
+    ? await prisma.memberList.findMany({
+        where: { userId: session.user.id },
+        orderBy: { createdAt: "asc" },
+        include: {
+          fightSceneEntries: { where: { fightSceneId: { in: fightScenes.map((s) => s.id) } }, select: { fightSceneId: true } },
+        },
+      })
+    : [];
+  const myMemberListItems = myMemberLists.map((l) => ({ id: l.id, name: l.name }));
+
+  const myFightSceneFavorites = session?.user
+    ? await prisma.fightSceneFavorite.findMany({
+        where: { userId: session.user.id, fightSceneId: { in: fightScenes.map((s) => s.id) } },
+      })
+    : [];
+
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
       <p className="mb-1 text-sm text-neutral-400">List by {list.user.username}</p>
@@ -49,24 +83,58 @@ export default async function PublicListPage({ params }: { params: Promise<{ lis
           />
         </div>
       )}
-      {movies.length === 0 ? (
-        <p className="text-neutral-400">No movies in this list yet.</p>
+      {movies.length === 0 && fightScenes.length === 0 ? (
+        <p className="text-neutral-400">Nothing in this list yet.</p>
       ) : (
-        <div className="flex flex-wrap gap-4">
-          {movies.map((movie) => {
-            const summary = ratingSummaries.get(movie.id);
-            return (
-              <MovieCard
-                key={movie.id}
-                movie={{
-                  ...movie,
-                  communityAverage: summary?.average ?? null,
-                  communityCount: summary?.count ?? 0,
-                }}
-              />
-            );
-          })}
-        </div>
+        <>
+          {movies.length > 0 && (
+            <div className="flex flex-wrap gap-4">
+              {movies.map((movie) => {
+                const summary = ratingSummaries.get(movie.id);
+                return (
+                  <MovieCard
+                    key={movie.id}
+                    movie={{
+                      ...movie,
+                      communityAverage: summary?.average ?? null,
+                      communityCount: summary?.count ?? 0,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          )}
+          {fightScenes.length > 0 && (
+            <div className={movies.length > 0 ? "mt-8" : ""}>
+              {movies.length > 0 && <h2 className="mb-4 font-serif text-lg font-bold text-white">Fight Scenes</h2>}
+              <div className="flex flex-wrap gap-4">
+                {fightScenes.map((scene) => {
+                  const memberSummary = memberSummaries.get(scene.id);
+                  const editorSummary = editorSummaries.get(scene.id);
+                  const initialLists = myMemberListItems.map((l) => {
+                    const listRow = myMemberLists.find((row) => row.id === l.id)!;
+                    return { ...l, hasItem: listRow.fightSceneEntries.some((e) => e.fightSceneId === scene.id) };
+                  });
+                  return (
+                    <FightSceneResultCard
+                      key={scene.id}
+                      scene={{
+                        ...scene,
+                        memberRatingAverage: memberSummary?.average ?? null,
+                        memberRatingCount: memberSummary?.count ?? 0,
+                        editorRatingAverage: editorSummary?.average ?? null,
+                        editorRatingCount: editorSummary?.count ?? 0,
+                      }}
+                      initialLists={initialLists}
+                      signedIn={!!session?.user}
+                      initialFavorite={myFightSceneFavorites.some((e) => e.fightSceneId === scene.id)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -3,7 +3,10 @@ import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries } from "@/lib/ratings";
+import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries } from "@/lib/fight-scenes";
 import { MovieCard } from "@/components/movie-card";
+import { FightSceneResultCard, type FightSceneResult } from "@/components/fight-scene-result-card";
+import type { AddToListItem } from "@/components/add-to-list-control";
 import { MemberListManager } from "@/components/member-list-manager";
 import type { Movie } from "@/generated/prisma/client";
 
@@ -42,6 +45,37 @@ async function MovieRow({
   );
 }
 
+function FightSceneRow({
+  title,
+  scenes,
+  signedIn,
+}: {
+  title: string;
+  scenes: (FightSceneResult & { initialLists: AddToListItem[]; initialFavorite: boolean })[];
+  signedIn: boolean;
+}) {
+  return (
+    <section className="mb-8">
+      <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>
+      {scenes.length === 0 ? (
+        <p className="text-sm text-neutral-400">Nothing here yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-4">
+          {scenes.map((scene) => (
+            <FightSceneResultCard
+              key={scene.id}
+              scene={scene}
+              initialLists={scene.initialLists}
+              signedIn={signedIn}
+              initialFavorite={scene.initialFavorite}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export default async function MemberProfilePage({ params }: { params: Promise<{ username: string }> }) {
   const { username } = await params;
   const session = await auth();
@@ -58,7 +92,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   // everyone except the list owner, same as every other public listing.
   const isOwner = session?.user?.id === profileUser.id;
 
-  const [entries, memberLists] = await Promise.all([
+  const [entries, fightSceneFavoriteEntries, memberLists] = await Promise.all([
     isOwner
       ? prisma.listEntry.findMany({
           where: { userId: profileUser.id },
@@ -66,9 +100,22 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
           orderBy: { createdAt: "desc" },
         })
       : [],
+    isOwner
+      ? prisma.fightSceneFavorite.findMany({
+          where: { userId: profileUser.id },
+          include: { fightScene: { include: { movie: { select: { id: true, title: true, releaseDate: true } }, tags: true } } },
+          orderBy: { createdAt: "desc" },
+        })
+      : [],
     prisma.memberList.findMany({
       where: { userId: profileUser.id },
-      include: { entries: { include: { movie: true }, orderBy: { createdAt: "desc" } } },
+      include: {
+        entries: { include: { movie: true }, orderBy: { createdAt: "desc" } },
+        fightSceneEntries: {
+          include: { fightScene: { include: { movie: { select: { id: true, title: true, releaseDate: true } }, tags: true } } },
+          orderBy: { createdAt: "desc" },
+        },
+      },
       orderBy: { createdAt: "asc" },
     }),
   ]);
@@ -76,9 +123,18 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   const favorites = entries.filter((e) => e.listType === "FAVORITE").map((e) => e.movie);
   const watchlist = entries.filter((e) => e.listType === "WATCHLIST").map((e) => e.movie);
 
+  // Same reasoning as pending movies: a soft-deleted fight scene shouldn't
+  // linger visibly just because it was favorited before deletion.
+  const favoriteFightScenes = fightSceneFavoriteEntries
+    .filter((e) => !e.fightScene.isDeleted)
+    .map((e) => e.fightScene);
+
   const visibleMemberLists = memberLists.map((list) => ({
     ...list,
     entries: isOwner ? list.entries : list.entries.filter((entry) => entry.movie.status === "APPROVED"),
+    // Same reasoning as pending movies: a soft-deleted fight scene shouldn't
+    // linger visibly just because it was saved before deletion.
+    fightSceneEntries: list.fightSceneEntries.filter((entry) => !entry.fightScene.isDeleted),
   }));
 
   const allListedMovieIds = [
@@ -94,11 +150,71 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
     communityCount: ratingSummaries.get(movie.id)?.count ?? 0,
   });
 
+  const allListedFightScenesById = new Map(
+    [...visibleMemberLists.flatMap((list) => list.fightSceneEntries.map((e) => e.fightScene)), ...favoriteFightScenes].map(
+      (scene) => [scene.id, scene],
+    ),
+  );
+  const allListedFightScenes = [...allListedFightScenesById.values()];
+  const [memberSceneSummaries, editorSceneSummaries] = await Promise.all([
+    getFightSceneRatingSummaries(allListedFightScenes.map((s) => s.id)),
+    getFightSceneAdminRatingSummaries(allListedFightScenes.map((s) => s.id)),
+  ]);
+
+  // Not profileUser's own lists — the *viewer's* lists, so they can bookmark
+  // a scene found here into one of their own, same as every other page a
+  // fight scene card appears on.
+  const viewerMemberLists = session?.user
+    ? await prisma.memberList.findMany({
+        where: { userId: session.user.id },
+        orderBy: { createdAt: "asc" },
+        include: {
+          fightSceneEntries: {
+            where: { fightSceneId: { in: allListedFightScenes.map((s) => s.id) } },
+            select: { fightSceneId: true },
+          },
+        },
+      })
+    : [];
+  const viewerMemberListItems = viewerMemberLists.map((l) => ({ id: l.id, name: l.name }));
+
+  // Same "viewer's own state, not the profile owner's" reasoning as
+  // viewerMemberLists above — the favorite icon reflects who's looking,
+  // regardless of whose profile the scene is shown on.
+  const viewerFightSceneFavorites = session?.user
+    ? await prisma.fightSceneFavorite.findMany({
+        where: { userId: session.user.id, fightSceneId: { in: allListedFightScenes.map((s) => s.id) } },
+      })
+    : [];
+
+  const withSceneRatings = (scene: (typeof allListedFightScenes)[number]) => ({
+    ...scene,
+    memberRatingAverage: memberSceneSummaries.get(scene.id)?.average ?? null,
+    memberRatingCount: memberSceneSummaries.get(scene.id)?.count ?? 0,
+    editorRatingAverage: editorSceneSummaries.get(scene.id)?.average ?? null,
+    editorRatingCount: editorSceneSummaries.get(scene.id)?.count ?? 0,
+  });
+
+  const sceneInitialLists = (sceneId: string) =>
+    viewerMemberListItems.map((l) => {
+      const listRow = viewerMemberLists.find((row) => row.id === l.id)!;
+      return { ...l, hasItem: listRow.fightSceneEntries.some((e) => e.fightSceneId === sceneId) };
+    });
+
+  const withSceneListState = (scene: (typeof allListedFightScenes)[number]) => ({
+    ...withSceneRatings(scene),
+    initialLists: sceneInitialLists(scene.id),
+    initialFavorite: viewerFightSceneFavorites.some((e) => e.fightSceneId === scene.id),
+  });
+
   const memberListData = visibleMemberLists.map((list) => ({
     id: list.id,
     name: list.name,
     movies: list.entries.map((entry) => withRatings(entry.movie)),
+    fightScenes: list.fightSceneEntries.map((entry) => withSceneListState(entry.fightScene)),
   }));
+
+  const favoriteFightSceneData = favoriteFightScenes.map(withSceneListState);
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
@@ -108,12 +224,13 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
         <>
           <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
           <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
+          <FightSceneRow title="Favorite Fight Scenes" scenes={favoriteFightSceneData} signedIn={!!session?.user} />
         </>
       )}
 
       <h2 className="mb-4 text-xl font-bold text-white">{isOwner ? "Your Lists" : "Lists"}</h2>
       {isOwner ? (
-        <MemberListManager initialLists={memberListData} />
+        <MemberListManager initialLists={memberListData} viewerSignedIn={!!session?.user} />
       ) : memberListData.length === 0 ? (
         <p className="text-sm text-neutral-500">No public lists yet.</p>
       ) : (
@@ -125,12 +242,21 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
                 Permalink
               </Link>
             </div>
-            {list.movies.length === 0 ? (
-              <p className="text-sm text-neutral-400">No movies in this list yet.</p>
+            {list.movies.length === 0 && list.fightScenes.length === 0 ? (
+              <p className="text-sm text-neutral-400">Nothing in this list yet.</p>
             ) : (
               <div className="flex flex-wrap gap-4">
                 {list.movies.map((movie) => (
                   <MovieCard key={movie.id} movie={movie} />
+                ))}
+                {list.fightScenes.map((scene) => (
+                  <FightSceneResultCard
+                    key={scene.id}
+                    scene={scene}
+                    initialLists={scene.initialLists}
+                    signedIn={!!session?.user}
+                    initialFavorite={scene.initialFavorite}
+                  />
                 ))}
               </div>
             )}

--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -46,7 +46,7 @@ export default async function FightScenePage({ params }: { params: Promise<Param
     notFound();
   }
 
-  const [movieCast, tagOptions, ratingSummaries, adminRatingSummaries, myRating, myAdminRating, roundNumbers] =
+  const [movieCast, tagOptions, ratingSummaries, adminRatingSummaries, myRating, myAdminRating, roundNumbers, myMemberLists, myFightSceneFavorites] =
     await Promise.all([
       prisma.castCredit.findMany({ where: { movieId }, include: { person: true } }),
       getFightSceneTags(),
@@ -63,6 +63,16 @@ export default async function FightScenePage({ params }: { params: Promise<Param
           })
         : null,
       getFightSceneRoundNumbers(movieId),
+      session?.user
+        ? prisma.memberList.findMany({
+            where: { userId: session.user.id },
+            orderBy: { createdAt: "asc" },
+            include: { fightSceneEntries: { where: { fightSceneId: scene.id }, select: { id: true } } },
+          })
+        : [],
+      session?.user
+        ? prisma.fightSceneFavorite.findMany({ where: { userId: session.user.id, fightSceneId: scene.id } })
+        : [],
     ]);
 
   const summary = ratingSummaries.get(scene.id);
@@ -88,6 +98,11 @@ export default async function FightScenePage({ params }: { params: Promise<Param
   };
 
   const castOptions = movieCast.map((credit) => ({ id: credit.person.id, name: credit.person.name }));
+  const myMemberListItems = myMemberLists.map((list) => ({ id: list.id, name: list.name }));
+  const mySavedListIdsByScene = {
+    [scene.id]: myMemberLists.filter((list) => list.fightSceneEntries.length > 0).map((list) => list.id),
+  };
+  const myFavoriteSceneIds = myFightSceneFavorites.map((e) => e.fightSceneId);
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-8">
@@ -108,6 +123,9 @@ export default async function FightScenePage({ params }: { params: Promise<Param
         isAdmin={session?.user?.role === "ADMIN"}
         myRatings={myRating ? { [scene.id]: myRating.score } : {}}
         myAdminRatings={myAdminRating ? { [scene.id]: myAdminRating.score } : {}}
+        myMemberLists={myMemberListItems}
+        mySavedListIdsByScene={mySavedListIdsByScene}
+        myFavoriteSceneIds={myFavoriteSceneIds}
         heading={null}
         allowAdd={false}
       />

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -58,6 +59,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     myRating,
     myListEntries,
     myMemberLists,
+    myFightSceneFavorites,
     discussionPage,
     fightScenes,
     fightSceneTags,
@@ -77,7 +79,15 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       ? prisma.memberList.findMany({
           where: { userId: session.user.id },
           orderBy: { createdAt: "asc" },
-          include: { entries: { where: { movieId: movie.id }, select: { id: true } } },
+          include: {
+            entries: { where: { movieId: movie.id }, select: { id: true } },
+            fightSceneEntries: { select: { fightSceneId: true } },
+          },
+        })
+      : [],
+    session?.user
+      ? prisma.fightSceneFavorite.findMany({
+          where: { userId: session.user.id, fightScene: { movieId: movie.id } },
         })
       : [],
     getDiscussionPage(movie.id),
@@ -92,8 +102,19 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   const myMemberListItems = myMemberLists.map((list) => ({
     id: list.id,
     name: list.name,
-    hasMovie: list.entries.length > 0,
+    hasItem: list.entries.length > 0,
   }));
+
+  const myFavoriteFightSceneIds = myFightSceneFavorites.map((e) => e.fightSceneId);
+
+  // Per fight scene, which of the member's lists already contain it — a
+  // scene-scoped view of the same myMemberLists rows fetched above.
+  const mySavedFightSceneListIds: Record<string, string[]> = {};
+  for (const scene of fightScenes) {
+    mySavedFightSceneListIds[scene.id] = myMemberLists
+      .filter((list) => list.fightSceneEntries.some((e) => e.fightSceneId === scene.id))
+      .map((list) => list.id);
+  }
 
   const myAdminRating = session?.user?.role === "ADMIN"
     ? await prisma.adminRating.findUnique({
@@ -258,7 +279,11 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
               initialWatchlist={isOnWatchlist}
               signedIn={!!session?.user}
             />
-            <AddToListControl movieId={movie.id} initialLists={myMemberListItems} signedIn={!!session?.user} />
+            <AddToListControl
+              target={{ type: "movie", id: movie.id }}
+              initialLists={myMemberListItems}
+              signedIn={!!session?.user}
+            />
           </div>
 
           <div className="mt-6 max-w-sm">
@@ -287,7 +312,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             <h2 className="mb-4 font-serif text-xl font-bold text-white">Cast</h2>
             <div className="rail-scrollbar flex gap-4 overflow-x-auto pb-2">
               {movie.cast.map((credit) => (
-                <div key={credit.id} className="w-28 shrink-0 text-center">
+                <Link key={credit.id} href={`/actors/${credit.person.id}`} className="w-28 shrink-0 text-center hover:opacity-80">
                   <div className="relative mb-1 aspect-square overflow-hidden rounded-full bg-neutral-800">
                     {credit.person.profilePath ? (
                       <Image
@@ -303,7 +328,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
                   {credit.characterName && (
                     <p className="truncate text-xs text-neutral-500">{credit.characterName}</p>
                   )}
-                </div>
+                </Link>
               ))}
             </div>
           </section>
@@ -325,6 +350,9 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           isAdmin={session?.user?.role === "ADMIN"}
           myRatings={myFightSceneRatingMap}
           myAdminRatings={myFightSceneAdminRatingMap}
+          myMemberLists={myMemberLists.map((list) => ({ id: list.id, name: list.name }))}
+          mySavedListIdsByScene={mySavedFightSceneListIds}
+          myFavoriteSceneIds={myFavoriteFightSceneIds}
         />
 
         <DiscussionThread

--- a/src/app/search/fight-scenes/page.tsx
+++ b/src/app/search/fight-scenes/page.tsx
@@ -1,5 +1,6 @@
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries } from "@/lib/fight-scenes";
+import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries, getFightSceneFavoriteCounts } from "@/lib/fight-scenes";
 import { parseRatingFilter } from "@/lib/rating-filter";
 import { FightSceneResultCard } from "@/components/fight-scene-result-card";
 import { RatingStarInput } from "@/components/rating-star-input";
@@ -20,6 +21,7 @@ const SORT_OPTIONS = [
   { value: "newest", label: "Newest" },
   { value: "memberRating", label: "Highest Member Rated" },
   { value: "editorRating", label: "Highest Editor Rated" },
+  { value: "mostFavorited", label: "Most Favorited" },
 ] as const;
 
 const PAGE_SIZE = 24;
@@ -45,6 +47,7 @@ export default async function FightSceneSearchPage({
   searchParams: Promise<FightSceneSearchParams>;
 }) {
   const params = await searchParams;
+  const session = await auth();
   const query = params.q?.trim() ?? "";
   const selectedTags = Array.isArray(params.tag) ? params.tag : params.tag ? [params.tag] : [];
   const actor = params.actor?.trim() ?? "";
@@ -83,9 +86,10 @@ export default async function FightSceneSearchPage({
     });
   }
 
-  const [memberSummaries, editorSummaries] = await Promise.all([
+  const [memberSummaries, editorSummaries, favoriteCounts] = await Promise.all([
     getFightSceneRatingSummaries(scenes.map((s) => s.id)),
     getFightSceneAdminRatingSummaries(scenes.map((s) => s.id)),
+    getFightSceneFavoriteCounts(scenes.map((s) => s.id)),
   ]);
 
   if (memberRating !== undefined) {
@@ -103,6 +107,8 @@ export default async function FightSceneSearchPage({
     scenes = [...scenes].sort(
       (a, b) => (editorSummaries.get(b.id)?.average ?? -1) - (editorSummaries.get(a.id)?.average ?? -1),
     );
+  } else if (sort === "mostFavorited") {
+    scenes = [...scenes].sort((a, b) => (favoriteCounts.get(b.id) ?? 0) - (favoriteCounts.get(a.id) ?? 0));
   }
   // "newest" is already the fetch order (createdAt desc), so no re-sort needed.
 
@@ -110,6 +116,23 @@ export default async function FightSceneSearchPage({
   const totalPages = Math.max(1, Math.ceil(totalResults / PAGE_SIZE));
   const page = Math.min(Math.max(1, Number(params.page) || 1), totalPages);
   const pagedScenes = scenes.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const myMemberLists = session?.user
+    ? await prisma.memberList.findMany({
+        where: { userId: session.user.id },
+        orderBy: { createdAt: "asc" },
+        include: {
+          fightSceneEntries: { where: { fightSceneId: { in: pagedScenes.map((s) => s.id) } }, select: { fightSceneId: true } },
+        },
+      })
+    : [];
+  const myMemberListItems = myMemberLists.map((list) => ({ id: list.id, name: list.name }));
+
+  const myFightSceneFavorites = session?.user
+    ? await prisma.fightSceneFavorite.findMany({
+        where: { userId: session.user.id, fightSceneId: { in: pagedScenes.map((s) => s.id) } },
+      })
+    : [];
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:flex-row">
@@ -222,6 +245,10 @@ export default async function FightSceneSearchPage({
               {pagedScenes.map((scene) => {
                 const memberSummary = memberSummaries.get(scene.id);
                 const editorSummary = editorSummaries.get(scene.id);
+                const initialLists = myMemberListItems.map((list) => {
+                  const listRow = myMemberLists.find((l) => l.id === list.id)!;
+                  return { ...list, hasItem: listRow.fightSceneEntries.some((e) => e.fightSceneId === scene.id) };
+                });
                 return (
                   <FightSceneResultCard
                     key={scene.id}
@@ -232,6 +259,9 @@ export default async function FightSceneSearchPage({
                       editorRatingAverage: editorSummary?.average ?? null,
                       editorRatingCount: editorSummary?.count ?? 0,
                     }}
+                    initialLists={initialLists}
+                    signedIn={!!session?.user}
+                    initialFavorite={myFightSceneFavorites.some((e) => e.fightSceneId === scene.id)}
                   />
                 );
               })}

--- a/src/components/add-to-list-control.tsx
+++ b/src/components/add-to-list-control.tsx
@@ -6,17 +6,41 @@ import Link from "next/link";
 export interface AddToListItem {
   id: string;
   name: string;
-  hasMovie: boolean;
+  hasItem: boolean;
+}
+
+export type ListTarget = { type: "movie"; id: string } | { type: "fightScene"; id: string };
+
+function entriesEndpoint(listId: string, target: ListTarget) {
+  return target.type === "movie" ? `/api/lists/${listId}/entries` : `/api/lists/${listId}/fight-scene-entries`;
+}
+
+function entryBodyKey(target: ListTarget) {
+  return target.type === "movie" ? "movieId" : "fightSceneId";
+}
+
+const ICON_BUTTON_CLASS =
+  "flex h-8 w-8 items-center justify-center rounded-md border border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:text-white";
+const TEXT_BUTTON_CLASS = "rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-800";
+
+function BookmarkIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+      <path d="M6 3.5h12a1 1 0 011 1V21l-7-4-7 4V4.5a1 1 0 011-1z" />
+    </svg>
+  );
 }
 
 export function AddToListControl({
-  movieId,
+  target,
   initialLists,
   signedIn,
+  variant = "button",
 }: {
-  movieId: string;
+  target: ListTarget;
   initialLists: AddToListItem[];
   signedIn: boolean;
+  variant?: "button" | "icon";
 }) {
   const [open, setOpen] = useState(false);
   const [lists, setLists] = useState(initialLists);
@@ -26,11 +50,8 @@ export function AddToListControl({
 
   if (!signedIn) {
     return (
-      <Link
-        href="/login"
-        className="rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-800"
-      >
-        + Add to list
+      <Link href="/login" title="Save to list" className={variant === "icon" ? ICON_BUTTON_CLASS : TEXT_BUTTON_CLASS}>
+        {variant === "icon" ? <BookmarkIcon /> : "+ Add to list"}
       </Link>
     );
   }
@@ -39,11 +60,11 @@ export function AddToListControl({
     setBusy(true);
     setError(null);
     const res = await fetch(
-      list.hasMovie ? `/api/lists/${list.id}/entries/${movieId}` : `/api/lists/${list.id}/entries`,
+      list.hasItem ? `${entriesEndpoint(list.id, target)}/${target.id}` : entriesEndpoint(list.id, target),
       {
-        method: list.hasMovie ? "DELETE" : "POST",
+        method: list.hasItem ? "DELETE" : "POST",
         headers: { "Content-Type": "application/json" },
-        body: list.hasMovie ? undefined : JSON.stringify({ movieId }),
+        body: list.hasItem ? undefined : JSON.stringify({ [entryBodyKey(target)]: target.id }),
       },
     );
     setBusy(false);
@@ -52,7 +73,7 @@ export function AddToListControl({
       setError(body.error ?? "Something went wrong.");
       return;
     }
-    setLists((prev) => prev.map((l) => (l.id === list.id ? { ...l, hasMovie: !l.hasMovie } : l)));
+    setLists((prev) => prev.map((l) => (l.id === list.id ? { ...l, hasItem: !l.hasItem } : l)));
   }
 
   async function createAndAdd(e: React.FormEvent) {
@@ -72,10 +93,10 @@ export function AddToListControl({
       return;
     }
 
-    const addRes = await fetch(`/api/lists/${createBody.list.id}/entries`, {
+    const addRes = await fetch(entriesEndpoint(createBody.list.id, target), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ movieId }),
+      body: JSON.stringify({ [entryBodyKey(target)]: target.id }),
     });
     setBusy(false);
     if (!addRes.ok) {
@@ -83,26 +104,23 @@ export function AddToListControl({
       setError(addBody.error ?? "Something went wrong.");
       return;
     }
-    setLists((prev) => [...prev, { id: createBody.list.id, name: createBody.list.name, hasMovie: true }]);
+    setLists((prev) => [...prev, { id: createBody.list.id, name: createBody.list.name, hasItem: true }]);
     setNewName("");
   }
 
   return (
     <div className="relative inline-block">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="rounded-md border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-800"
-      >
-        + Add to list
+      <button onClick={() => setOpen((v) => !v)} title="Save to list" className={variant === "icon" ? ICON_BUTTON_CLASS : TEXT_BUTTON_CLASS}>
+        {variant === "icon" ? <BookmarkIcon /> : "+ Add to list"}
       </button>
       {open && (
-        <div className="absolute z-10 mt-2 w-64 rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl">
+        <div className="absolute right-0 z-10 mt-2 w-64 rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl">
           {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
           <ul className="mb-3 flex max-h-48 flex-col gap-1 overflow-y-auto">
             {lists.map((list) => (
               <li key={list.id}>
                 <label className="flex items-center gap-2 text-sm text-neutral-200">
-                  <input type="checkbox" checked={list.hasMovie} disabled={busy} onChange={() => toggle(list)} />
+                  <input type="checkbox" checked={list.hasItem} disabled={busy} onChange={() => toggle(list)} />
                   {list.name}
                 </label>
               </li>

--- a/src/components/favorite-button.tsx
+++ b/src/components/favorite-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+function HeartIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  );
+}
+
+// A fight scene only ever gets a Favorite, not a Watchlist — unlike a
+// movie, a scene is a short clip, not something to queue up for later.
+export function FavoriteButton({
+  movieId,
+  fightSceneId,
+  initialFavorite,
+  signedIn,
+}: {
+  movieId: string;
+  fightSceneId: string;
+  initialFavorite: boolean;
+  signedIn: boolean;
+}) {
+  const [favorite, setFavorite] = useState(initialFavorite);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle() {
+    if (!signedIn) {
+      window.location.href = "/login";
+      return;
+    }
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fight-scenes/${fightSceneId}/favorite`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { active } = await res.json();
+    setFavorite(active);
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={toggle}
+        title={favorite ? "Favorited" : "Favorite"}
+        className={`flex h-8 w-8 items-center justify-center rounded-md border text-neutral-400 hover:border-neutral-500 hover:text-white ${
+          favorite ? "border-red-600 bg-red-700 text-white hover:text-white" : "border-neutral-700"
+        }`}
+      >
+        <HeartIcon filled={favorite} />
+      </button>
+      {error && <p className="absolute right-0 top-full z-10 mt-1 w-40 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/fight-scene-result-card.tsx
+++ b/src/components/fight-scene-result-card.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import type { FightScene, FightSceneTag, Movie } from "@/generated/prisma/client";
+import { AddToListControl, type AddToListItem } from "@/components/add-to-list-control";
+import { FavoriteButton } from "@/components/favorite-button";
 
 // Same "Fight Ticket" palette as fight-scene-section.tsx — kept in sync
 // manually since this is a read-only result card, not the interactive one.
@@ -19,7 +21,17 @@ export type FightSceneResult = Pick<
   editorRatingCount: number;
 };
 
-export function FightSceneResultCard({ scene }: { scene: FightSceneResult }) {
+export function FightSceneResultCard({
+  scene,
+  initialLists = [],
+  signedIn = false,
+  initialFavorite = false,
+}: {
+  scene: FightSceneResult;
+  initialLists?: AddToListItem[];
+  signedIn?: boolean;
+  initialFavorite?: boolean;
+}) {
   const year = scene.movie.releaseDate ? new Date(scene.movie.releaseDate).getFullYear() : null;
   const permalink = `/movies/${scene.movieId}/fight-scenes/${scene.id}`;
   const memberLabel = scene.memberRatingAverage ? scene.memberRatingAverage.toFixed(1) : "—";
@@ -33,10 +45,24 @@ export function FightSceneResultCard({ scene }: { scene: FightSceneResult }) {
           "polygon(0 10px, 10px 0, calc(100% - 10px) 0, 100% 10px, 100% calc(100% - 10px), calc(100% - 10px) 100%, 10px 100%, 0 calc(100% - 10px))",
       }}
     >
-      <div className="flex items-center justify-between text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
+      <div className="flex items-center justify-between gap-2 text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
         <Link href={`/movies/${scene.movieId}`} className="truncate hover:opacity-70">
           {scene.movie.title} {year && `(${year})`}
         </Link>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <FavoriteButton
+            movieId={scene.movieId}
+            fightSceneId={scene.id}
+            initialFavorite={initialFavorite}
+            signedIn={signedIn}
+          />
+          <AddToListControl
+            target={{ type: "fightScene", id: scene.id }}
+            initialLists={initialLists}
+            signedIn={signedIn}
+            variant="icon"
+          />
+        </div>
       </div>
 
       <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -5,9 +5,14 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { FightSceneCast, FightSceneTag, Person, User } from "@/generated/prisma/client";
 import { ShareButton } from "@/components/share-button";
+import { AddToListControl, type AddToListItem } from "@/components/add-to-list-control";
+import { FavoriteButton } from "@/components/favorite-button";
 
 const SCORES = Array.from({ length: 10 }, (_, i) => i + 1);
 const MAX_NOTE_LENGTH = 2000;
+// How many scenes render before a "Show more" click is needed — enough for
+// two full rows on the widest (3-column) layout.
+const SCENES_PAGE_SIZE = 6;
 const MAX_TITLE_LENGTH = 200;
 
 export type CastOption = Pick<Person, "id" | "name">;
@@ -272,6 +277,9 @@ export function FightSceneSection({
   isAdmin,
   myRatings,
   myAdminRatings,
+  myMemberLists = [],
+  mySavedListIdsByScene = {},
+  myFavoriteSceneIds = [],
   heading = "Fight Scenes",
   allowAdd = true,
 }: {
@@ -284,6 +292,12 @@ export function FightSceneSection({
   isAdmin: boolean;
   myRatings: Record<string, number>;
   myAdminRatings: Record<string, number>;
+  // The signed-in member's public lists, and which of those already contain
+  // each scene — used to seed the "save to list" control per card.
+  myMemberLists?: { id: string; name: string }[];
+  mySavedListIdsByScene?: Record<string, string[]>;
+  // Which scenes the signed-in member has already favorited.
+  myFavoriteSceneIds?: string[];
   heading?: string | null;
   allowAdd?: boolean;
 }) {
@@ -297,6 +311,7 @@ export function FightSceneSection({
   const [error, setError] = useState<string | null>(null);
   const [adminNoteDrafts, setAdminNoteDrafts] = useState<Record<string, string>>({});
   const [startTimeDrafts, setStartTimeDrafts] = useState<Record<string, string>>({});
+  const [visibleCount, setVisibleCount] = useState(SCENES_PAGE_SIZE);
 
   async function handleCreate(title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) {
     setSubmitting(true);
@@ -327,6 +342,7 @@ export function FightSceneSection({
       },
     ]);
     setAdding(false);
+    setVisibleCount((prev) => prev + 1);
   }
 
   async function handleEdit(id: string, title: string, youtubeUrl: string, personIds: string[], tagIds: string[]) {
@@ -440,6 +456,14 @@ export function FightSceneSection({
     setScenes((prev) => prev.map((s) => (s.id === id ? { ...s, isVerified: verified } : s)));
   }
 
+  // Always sorted by round number left-to-right/top-to-bottom, regardless of
+  // insertion order from create/edit/delete. Only the first page's worth
+  // renders until "Show more" is clicked, so a movie with many scenes
+  // doesn't dump them all on the page at once.
+  const sortedScenes = [...scenes].sort((a, b) => a.roundNumber - b.roundNumber);
+  const visibleScenes = sortedScenes.slice(0, visibleCount);
+  const remainingSceneCount = sortedScenes.length - visibleScenes.length;
+
   return (
     <section className="mt-10">
       {heading && (
@@ -488,9 +512,7 @@ export function FightSceneSection({
       )}
 
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {/* Always sorted by round number left-to-right/top-to-bottom, regardless
-            of insertion order from create/edit/delete. */}
-        {[...scenes].sort((a, b) => a.roundNumber - b.roundNumber).map((scene) => {
+        {visibleScenes.map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;
           const permalinkPath = `/movies/${movieId}/fight-scenes/${scene.id}`;
@@ -515,6 +537,12 @@ export function FightSceneSection({
           }
 
           const avgLabel = scene.ratingAverage ? scene.ratingAverage.toFixed(1) : "—";
+          const savedListIds = mySavedListIdsByScene[scene.id] ?? [];
+          const listItems: AddToListItem[] = myMemberLists.map((list) => ({
+            id: list.id,
+            name: list.name,
+            hasItem: savedListIds.includes(list.id),
+          }));
 
           return (
             <li
@@ -528,7 +556,21 @@ export function FightSceneSection({
             >
               <div className="flex items-center justify-between text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
                 <span>Round {scene.roundNumber}</span>
-                <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
+                <div className="flex items-center gap-1.5">
+                  <FavoriteButton
+                    movieId={movieId}
+                    fightSceneId={scene.id}
+                    initialFavorite={myFavoriteSceneIds.includes(scene.id)}
+                    signedIn={signedIn}
+                  />
+                  <AddToListControl
+                    target={{ type: "fightScene", id: scene.id }}
+                    initialLists={listItems}
+                    signedIn={signedIn}
+                    variant="icon"
+                  />
+                  <ShareButton path={permalinkPath} title={scene.title} variant="icon" />
+                </div>
               </div>
 
               <div className="mt-3 border-t-2 border-dashed pt-3" style={{ borderColor: "#b8ab8c" }}>
@@ -565,7 +607,15 @@ export function FightSceneSection({
               </Link>
               {scene.cast.length > 0 && (
                 <p className="mt-0.5 text-[11px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
-                  Featuring {scene.cast.map((c) => c.person.name).join(", ")}
+                  Featuring{" "}
+                  {scene.cast.map((c, i) => (
+                    <span key={c.person.id}>
+                      {i > 0 && ", "}
+                      <Link href={`/actors/${c.person.id}`} className="hover:underline">
+                        {c.person.name}
+                      </Link>
+                    </span>
+                  ))}
                 </p>
               )}
 
@@ -663,6 +713,14 @@ export function FightSceneSection({
           <p className="text-sm text-neutral-500">No fight scenes added yet.</p>
         )}
       </ul>
+      {remainingSceneCount > 0 && (
+        <button
+          onClick={() => setVisibleCount((prev) => prev + SCENES_PAGE_SIZE)}
+          className="mt-4 w-full rounded-md border border-neutral-700 py-2 text-sm text-neutral-300 hover:bg-neutral-800"
+        >
+          Show more ({remainingSceneCount} more)
+        </button>
+      )}
     </section>
   );
 }

--- a/src/components/list-buttons.tsx
+++ b/src/components/list-buttons.tsx
@@ -52,7 +52,7 @@ export function ListButtons({
               : "border-neutral-700 text-neutral-200 hover:bg-neutral-800"
           }`}
         >
-          {favorite ? "★ Favorited" : "☆ Favorite"}
+          {favorite ? "♥ Favorited" : "♡ Favorite"}
         </button>
         <button
           onClick={() => toggle("WATCHLIST")}

--- a/src/components/member-list-manager.tsx
+++ b/src/components/member-list-manager.tsx
@@ -3,14 +3,23 @@
 import { useState } from "react";
 import Link from "next/link";
 import { MovieCard, type MovieCardData } from "@/components/movie-card";
+import { FightSceneResultCard, type FightSceneResult } from "@/components/fight-scene-result-card";
+import type { AddToListItem } from "@/components/add-to-list-control";
 
 export interface MemberListData {
   id: string;
   name: string;
   movies: MovieCardData[];
+  fightScenes: (FightSceneResult & { initialLists: AddToListItem[]; initialFavorite: boolean })[];
 }
 
-export function MemberListManager({ initialLists }: { initialLists: MemberListData[] }) {
+export function MemberListManager({
+  initialLists,
+  viewerSignedIn,
+}: {
+  initialLists: MemberListData[];
+  viewerSignedIn: boolean;
+}) {
   const [lists, setLists] = useState(initialLists);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
@@ -34,7 +43,7 @@ export function MemberListManager({ initialLists }: { initialLists: MemberListDa
       setError(body.error ?? "Something went wrong.");
       return;
     }
-    setLists((prev) => [...prev, { id: body.list.id, name: body.list.name, movies: [] }]);
+    setLists((prev) => [...prev, { id: body.list.id, name: body.list.name, movies: [], fightScenes: [] }]);
     setNewName("");
   }
 
@@ -132,12 +141,23 @@ export function MemberListManager({ initialLists }: { initialLists: MemberListDa
               </>
             )}
           </div>
-          {list.movies.length === 0 ? (
-            <p className="text-sm text-neutral-400">No movies yet — add some from a movie&rsquo;s page.</p>
+          {list.movies.length === 0 && list.fightScenes.length === 0 ? (
+            <p className="text-sm text-neutral-400">
+              Nothing here yet — add movies or fight scenes from their own pages.
+            </p>
           ) : (
             <div className="flex flex-wrap gap-4">
               {list.movies.map((movie) => (
                 <MovieCard key={movie.id} movie={movie} />
+              ))}
+              {list.fightScenes.map((scene) => (
+                <FightSceneResultCard
+                  key={scene.id}
+                  scene={scene}
+                  initialLists={scene.initialLists}
+                  signedIn={viewerSignedIn}
+                  initialFavorite={scene.initialFavorite}
+                />
               ))}
             </div>
           )}

--- a/src/lib/fight-scenes.ts
+++ b/src/lib/fight-scenes.ts
@@ -95,6 +95,18 @@ export async function getFightSceneAdminRatingSummaries(
   return map;
 }
 
+export async function getFightSceneFavoriteCounts(fightSceneIds: string[]): Promise<Map<string, number>> {
+  if (fightSceneIds.length === 0) return new Map();
+
+  const rows = await prisma.fightSceneFavorite.groupBy({
+    by: ["fightSceneId"],
+    where: { fightSceneId: { in: fightSceneIds } },
+    _count: { _all: true },
+  });
+
+  return new Map(rows.map((row) => [row.fightSceneId, row._count._all]));
+}
+
 // Picks one verified fight scene per movie to preview as a hero clip:
 // highest member rating, falling back to editor rating, falling back to
 // whichever was tagged first (stable rather than random across page loads).


### PR DESCRIPTION
## Summary

Extends member lists to hold fight scenes alongside movies, and adds a one-tap Favorite toggle for fight scenes (distinct from the movie-level Favorite/Watchlist pair). Fight scenes can now be:

1. **Saved to custom member lists** — via a "Add to list" control on fight scene cards, mirroring the movie list-saving UX
2. **Favorited** — via a heart icon button, a simpler interaction than picking from a multi-select list, since scenes are short clips not queued for later viewing
3. **Browsed on actor pages** — new `/actors/[personId]` pages show an actor's filmography and all tagged fight scenes, with full card interactivity (list-saving, favoriting)
4. **Displayed on member profiles** — a "Favorite Fight Scenes" section below the existing movie Favorites/Watchlist rows
5. **Included in public member lists** — fight scenes appear alongside movies on list detail pages

### Schema & Data Model

- **`MemberListFightSceneEntry`** — new model mirroring `MemberListEntry` but for fight scenes, keeping both content types' foreign keys required and queries separate (avoids nullable columns and union-type complexity)
- **`FightSceneFavorite`** — new model for the one-tap favorite (no `listType` discriminator since there's only one kind, unlike `ListEntry`)
- Both models soft-delete gracefully (deleted scenes don't linger on lists/profiles)

### UI & Components

- **`FightSceneResultCard`** — enhanced to accept `initialLists`, `signedIn`, and `initialFavorite` props, enabling full interactivity on any page
- **`AddToListControl`** — refactored to support both movies and fight scenes via a `target` prop (`{ type: "movie" | "fightScene"; id }`) and a `variant` prop for icon vs. button rendering
- **`FavoriteButton`** — new component for the heart icon toggle (red when active, distinct from the star-based movie favorite)
- **`FightSceneSection`** — client-side pagination via "Show more" (6 scenes per page) to avoid dumping dozens of cards on a movie page; preserves in-progress edits when pages are revealed
- **`MemberListManager`** — updated to display fight scenes within each list

### API Routes

- `POST /api/lists/[listId]/fight-scene-entries` — add a scene to a list
- `DELETE /api/lists/[listId]/fight-scene-entries/[fightSceneId]` — remove a scene from a list
- `POST /api/movies/[id]/fight-scenes/[fightSceneId]/favorite` — toggle favorite (returns `{ active: boolean }`)

### Pages Updated

- `/members/[username]` — shows favorite fight scenes, includes scenes in member lists, wires up list-saving and favoriting
- `/lists/[listId]` — displays fight scenes alongside movies, with full interactivity for the current viewer
- `/search/fight-scenes` — added "Most Favorited" sort option, displays favorite counts
- `/movies/[id]` — passes scene list/favorite state to `FightSceneSection`
- `/movies/[id]/fight-scenes/[fightSceneId]` — wires up list-saving and favoriting on the detail page
- **New:** `/actors/[personId]` — filmography + all tagged fight scenes, sorted by favorite count

### Decisions Documented

Added entries to `DECISIONS.md` covering:
- Actor pages as browse-only entry points (not wired into search filter)
- Per-movie fight scene pagination as client-side "Show more" (not URL-based)
- Fight scenes get Favorite only, not Watchlist (scenes are clips, not queue items)
- Separate `MemberListFightSceneEntry` model vs. nullable column on `MemberListEntry`

## Checklist

- [x] `README.md` updated (new actor pages, fight scene list-saving, favorites, search sort option)
- [x] `.env.example` — no new environment variables
- [x] `DECISIONS.md` updated (four

https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX