### PR TITLE
Add a standalone "+ Add Movie" nav link

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,8 +91,20 @@ the site.
 
 ## Feature Decisions
 
+### Standalone "Add Movie" nav link, always visible rather than gated on sign-in
+**PR #TBD.** `/movies/submit` was previously only reachable via the "Can't
+find it? Add a movie" link on a zero-result search — no direct nav link.
+Added a "+ Add Movie" link to the site nav, next to Movies/Fights/Lists.
+*Considered:* showing it only to signed-in members, matching the Admin
+link's conditional pattern — rejected in favor of matching Movies/Fights/
+Lists' always-visible pattern instead, since `/movies/submit` already
+handles a signed-out visitor correctly on its own (redirects to `/login`
+with the right `callbackUrl`, same as every other gated action in the
+app) — no need to duplicate that gate in the nav itself. The zero-result
+search link stays as a second, more contextual entry point.
+
 ### Actor pages browse-only for now, not wired into the search actor filter
-**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** New `/actors/[personId]`
+**PR #28.** New `/actors/[personId]`
 pages (filmography + every tagged fight scene, reusing existing card
 components) needed entry points. Linked from a movie's Cast section and a
 fight scene's "Featuring" line, both of which already show one specific
@@ -107,7 +119,7 @@ its own exists yet either — browsing via Cast/Featuring links is the only
 way in for now.
 
 ### Per-movie fight scene pagination is a client-side "Show more," not URL-based paging
-**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** `/search/fight-scenes`
+**PR #28.** `/search/fight-scenes`
 already paginates via `?page=` and a server round-trip per page — the
 per-movie list on a movie's own page didn't. *Considered:* the same
 URL-based pattern — rejected because `FightSceneSection` is a client
@@ -122,7 +134,7 @@ list, revealed 6 at a time via a "Show more" button — no route change, no
 loss of in-progress edits when a page is revealed.
 
 ### Fight scenes get a one-tap Favorite, deliberately no Watchlist
-**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** After building
+**PR #28.** After building
 custom-list saving for fight scenes (see the `MemberListFightSceneEntry`
 entry below), a follow-up question was whether to also extend movies'
 one-tap Favorite/Watchlist toggle (`ListEntry`, `listType:
@@ -150,7 +162,7 @@ carried back to the movie-level Favorite button's own icon/text for
 consistency in the other direction.
 
 ### Saved fight scenes get their own MemberListFightSceneEntry model, not a nullable column on MemberListEntry
-**PR #TBD (branch `claude/save-fight-scenes-to-lists`).** Extending member
+**PR #28.** Extending member
 lists to hold fight scenes needed a schema decision: add nullable
 `movieId`/`fightSceneId` columns to the existing `MemberListEntry` with an
 app-level "exactly one is set" rule, or a separate mirrored entry model.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Beyond the built-in Favorites and Watchlist, members can create any number of th
 
 ## Member Movie Submissions
 
-If a member searches and can't find a movie, `/movies/submit` (linked from a "no results" search) lets them search TMDB and submit a match directly — the same underlying TMDB import used by `/admin/import`, but scoped to one title at a time and requiring a verified email.
+`/movies/submit` lets a member search TMDB and submit a match directly — the same underlying TMDB import used by `/admin/import`, but scoped to one title at a time and requiring a verified email. Reachable two ways: a "+ Add Movie" link in the site nav (visible to everyone; signing in is only required to actually submit), or the "Can't find it? Add a movie" link shown on a zero-result search.
 
 - **Submissions start `PENDING`**, not live: hidden from the homepage, search (including the navbar's), autocomplete director/actor filters, and the weekly-trending computation, and its own movie page 404s for everyone except the submitter and admins. This mirrors fight-scene verification's "member-created content, admin-gated visibility" pattern rather than admin imports' "goes live immediately" one, since anyone can trigger this path, not just a trusted admin.
 - Submitting a `tmdbId` that's already in the catalog (approved or still pending) is rejected with a specific error rather than silently re-importing it — re-running the shared import logic on an existing row would otherwise reset an already-approved movie back to pending.

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -31,6 +31,9 @@ export async function Navbar() {
           <Link href="/leaderboard" className="text-sm text-neutral-300 hover:text-white">
             Lists
           </Link>
+          <Link href="/movies/submit" className="text-sm text-neutral-300 hover:text-white">
+            + Add Movie
+          </Link>
           {session?.user ? (
             <>
               {session.user.role === "ADMIN" && (


### PR DESCRIPTION
## Summary

`/movies/submit` was previously only reachable via the "Can't find it? Add a movie" link shown on a zero-result search — no direct nav link. Adds a flat "+ Add Movie" link to the site nav, next to Movies/Fights/Lists, always visible. The page already handles a signed-out visitor correctly on its own (redirects to `/login` with the right `callbackUrl`), so no extra sign-in gating was needed in the nav itself. The zero-result search link stays as a second, more contextual entry point.

Also backfills `PR #TBD` references in `DECISIONS.md` to `PR #28` now that the previous branch's PR number is known.

## Checklist

- [x] `README.md` updated to reflect this change
- [ ] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated (new judgment call: nav link always-visible vs. sign-in-gated)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright against a local build: the "+ Add Movie" link renders in the nav on every page and points to `/movies/submit`.
- Confirmed `/movies/submit` already redirects a signed-out visitor to `/login?callbackUrl=/movies/submit`, so no additional gating was needed for the nav link itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_