### PR TITLE
Add a "View submission" link and a Pending Submissions profile section

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,6 +91,18 @@ the site.
 
 ## Feature Decisions
 
+### Submission follow-through: a "View submission" link and a member-facing Pending Submissions section
+**PR #TBD.** Two small follow-ups after adding the "+ Add Movie" nav
+link surfaced: a successful submission only showed a toast-style message
+with no way to see what was just created, and nothing anywhere reminded a
+member they had a submission awaiting review. Added a "View submission →"
+link straight to the new (still-pending) movie page right after submitting,
+and a **Pending Submissions** row on the member's own profile — same
+`MovieRow` component and same owner-only visibility rule already used for
+Favorites/Watchlist, not a new pattern. Reuses the existing pending-movie
+visibility rule (only the submitter or an admin can load that page) rather
+than adding a new one.
+
 ### Actor pages browse-only for now, not wired into the search actor filter
 **PR #TBD (branch `claude/save-fight-scenes-to-lists`).** New `/actors/[personId]`
 pages (filmography + every tagged fight scene, reusing existing card

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If a member searches and can't find a movie, `/movies/submit` (linked from a "no
 - **Submissions start `PENDING`**, not live: hidden from the homepage, search (including the navbar's), autocomplete director/actor filters, and the weekly-trending computation, and its own movie page 404s for everyone except the submitter and admins. This mirrors fight-scene verification's "member-created content, admin-gated visibility" pattern rather than admin imports' "goes live immediately" one, since anyone can trigger this path, not just a trusted admin.
 - Submitting a `tmdbId` that's already in the catalog (approved or still pending) is rejected with a specific error rather than silently re-importing it — re-running the shared import logic on an existing row would otherwise reset an already-approved movie back to pending.
 - Admins review submissions in a **Pending Submissions** section at the top of `/admin/movies` — Approve moves it to the catalog immediately; Reject permanently deletes it, same as deleting any other catalog entry.
+- A successful submission shows a "View submission →" link straight to the new (still-pending) movie page, and the submitter's own profile lists everything they've got awaiting review in its own **Pending Submissions** section (visible only to them, same as Favorites/Watchlist), so there's somewhere to check status without waiting on an email.
 
 ## Fight Scenes
 

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -92,11 +92,19 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   // everyone except the list owner, same as every other public listing.
   const isOwner = session?.user?.id === profileUser.id;
 
-  const [entries, fightSceneFavoriteEntries, memberLists] = await Promise.all([
+  const [entries, pendingSubmissions, fightSceneFavoriteEntries, memberLists] = await Promise.all([
     isOwner
       ? prisma.listEntry.findMany({
           where: { userId: profileUser.id },
           include: { movie: true },
+          orderBy: { createdAt: "desc" },
+        })
+      : [],
+    // Only the submitter (or an admin) can even load a pending movie's own
+    // page — same visibility rule as everywhere else a pending movie shows.
+    isOwner
+      ? prisma.movie.findMany({
+          where: { submittedById: profileUser.id, status: "PENDING" },
           orderBy: { createdAt: "desc" },
         })
       : [],
@@ -140,6 +148,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   const allListedMovieIds = [
     ...favorites,
     ...watchlist,
+    ...pendingSubmissions,
     ...visibleMemberLists.flatMap((list) => list.entries.map((entry) => entry.movie)),
   ].map((m) => m.id);
   const ratingSummaries = await getRatingSummaries(allListedMovieIds);
@@ -224,6 +233,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
         <>
           <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
           <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
+          <MovieRow title="Pending Submissions" movies={pendingSubmissions} ratingSummaries={ratingSummaries} />
           <FightSceneRow title="Favorite Fight Scenes" scenes={favoriteFightSceneData} signedIn={!!session?.user} />
         </>
       )}

--- a/src/components/movie-submission-search.tsx
+++ b/src/components/movie-submission-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import type { TmdbMovieSearchResult } from "@/lib/tmdb";
 
 type SubmissionResult = TmdbMovieSearchResult & { catalogStatus: string | null };
@@ -10,6 +11,7 @@ export function MovieSubmissionSearch() {
   const [results, setResults] = useState<SubmissionResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [lastSubmittedMovie, setLastSubmittedMovie] = useState<{ id: string; title: string } | null>(null);
   const [submittedIds, setSubmittedIds] = useState<Set<number>>(new Set());
   const [submittingId, setSubmittingId] = useState<number | null>(null);
 
@@ -17,6 +19,7 @@ export function MovieSubmissionSearch() {
     e.preventDefault();
     setLoading(true);
     setMessage(null);
+    setLastSubmittedMovie(null);
     const res = await fetch(`/api/movies/search?q=${encodeURIComponent(query)}`);
     const body = await res.json();
     setLoading(false);
@@ -30,6 +33,7 @@ export function MovieSubmissionSearch() {
   async function handleSubmit(tmdbId: number) {
     setSubmittingId(tmdbId);
     setMessage(null);
+    setLastSubmittedMovie(null);
     const res = await fetch("/api/movies/submit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -42,6 +46,7 @@ export function MovieSubmissionSearch() {
       return;
     }
     setSubmittedIds((prev) => new Set(prev).add(tmdbId));
+    setLastSubmittedMovie({ id: body.movie.id, title: body.movie.title });
     setMessage(`"${body.movie.title}" submitted for review.`);
   }
 
@@ -64,7 +69,19 @@ export function MovieSubmissionSearch() {
         </button>
       </form>
 
-      {message && <p className="mb-4 text-sm text-neutral-300">{message}</p>}
+      {message && (
+        <p className="mb-4 text-sm text-neutral-300">
+          {message}
+          {lastSubmittedMovie && (
+            <>
+              {" "}
+              <Link href={`/movies/${lastSubmittedMovie.id}`} className="text-red-500 hover:underline">
+                View submission →
+              </Link>
+            </>
+          )}
+        </p>
+      )}
 
       <ul className="flex flex-col gap-3">
         {results.map((movie) => {


### PR DESCRIPTION
## Summary

Two small follow-ups after adding the "+ Add Movie" nav link (#29): a successful submission only showed a toast-style message with no way to see what was just created, and nothing anywhere reminded a member they had a submission awaiting review.

- Adds a "View submission →" link next to the success message, pointing straight to the new (still-pending) movie page.
- Adds a **Pending Submissions** row to the member's own profile — same `MovieRow` component and owner-only visibility rule already used for Favorites/Watchlist, not a new pattern.

## Checklist

- [x] `README.md` updated to reflect this change
- [ ] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated (new judgment call recorded)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- TMDB search itself couldn't be exercised live in this environment (no API key/network egress), so the "View submission" link's target was verified directly: inserted a test `PENDING` movie owned by the seeded test member, confirmed it renders in the new Pending Submissions section, and confirmed the submitter can actually load that movie's own page (200, title present) while it stays 404 for everyone else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_