### PR TITLE
Turn genre and fight-scene tag badges into quick-links to filtered search

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,6 +91,17 @@ the site.
 
 ## Feature Decisions
 
+### Browse-by-tag/genre quick links reuse existing badges rather than adding a new pill strip
+**PR #TBD.** The backlog item described "pill-link strips deep-linking
+into filtered search." *Considered:* a dedicated new section (e.g. a
+homepage genre/tag rail) — passed on it in favor of making the genre
+badges already shown on a movie page, and the category-tag badges already
+shown on every fight scene card, into links themselves (`/search?genre=`
+and `/search/fight-scenes?tag=`). Same destination, no new UI surface or
+page real estate, and it puts the link exactly where someone is already
+looking at that genre/tag rather than a separate browsing section they'd
+have to notice first.
+
 ### Submission follow-through: a "View submission" link and a member-facing Pending Submissions section
 **PR #30.** Two small follow-ups after adding the "+ Add Movie" nav
 link surfaced: a successful submission only showed a toast-style message
@@ -376,8 +387,6 @@ time.
 - **Top Rated Fight Scenes rail** — homepage rail using existing fight-scene
   rating data, to put the feature in front of visitors who'd otherwise only
   find it via nav.
-- **Browse-by-tag / browse-by-genre quick links** — pill-link strips
-  deep-linking straight into filtered search.
 - **Cross-member list browsing / "recommended lists"** — lists were made
   public specifically to leave room for this without another schema change;
   no browse UI for other members' lists exists yet beyond a direct permalink.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
 - **`/search`** (movies) — filters: genre, director (autocomplete), actor (autocomplete), country, release-year range, minimum community rating, minimum editor rating. Sort by relevance, highest rated, newest, or oldest. A typo-tolerant "did you mean" fallback (via Postgres `pg_trgm`, see [Getting Set Up](#getting-set-up)) kicks in when nothing matches exactly.
 - **`/search/fight-scenes`** — filters: category tag (multi-select, matches any selected), actor (autocomplete, scoped to people actually tagged in a fight scene — not just anyone in a movie's cast), minimum member rating, minimum editor rating. Sort by newest, highest member rated, highest editor rated, or most favorited.
 - The navbar's search box submits to `/search` in "browse" mode (no filters) when submitted empty, rather than doing nothing — both pages are also reachable directly via the "Browse" and "Fight Scenes" nav links.
+- **Quick links into filtered search**: a movie's genre badges and a fight scene's category-tag badges are clickable, deep-linking straight into the matching filtered search (`/search?genre=`, `/search/fight-scenes?tag=`) instead of requiring the filter to be set by hand.
 
 ## TMDB Import
 

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -241,12 +241,13 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           {movie.genres.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {movie.genres.map((genre) => (
-                <span
+                <Link
                   key={genre.id}
-                  className="rounded-full border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300"
+                  href={`/search?genre=${encodeURIComponent(genre.name)}`}
+                  className="rounded-full border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300 hover:border-neutral-500 hover:text-white"
                 >
                   {genre.name}
-                </span>
+                </Link>
               ))}
             </div>
           )}

--- a/src/components/fight-scene-result-card.tsx
+++ b/src/components/fight-scene-result-card.tsx
@@ -83,9 +83,14 @@ export function FightSceneResultCard({
 
       <div className="mt-3 flex flex-wrap gap-1.5">
         {scene.tags.map((tag) => (
-          <span key={tag.id} className="border px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ borderColor: TICKET_INK }}>
+          <Link
+            key={tag.id}
+            href={`/search/fight-scenes?tag=${encodeURIComponent(tag.name)}`}
+            className="border px-2 py-0.5 text-[10px] tracking-wide uppercase hover:opacity-70"
+            style={{ borderColor: TICKET_INK }}
+          >
             {tag.name}
-          </span>
+          </Link>
         ))}
         {scene.isVerified && (
           <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#e8dcc4" }}>

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -621,9 +621,14 @@ export function FightSceneSection({
 
               <div className="mt-3 flex flex-wrap gap-1.5">
                 {scene.tags.map((tag) => (
-                  <span key={tag.id} className="border px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ borderColor: TICKET_INK }}>
+                  <Link
+                    key={tag.id}
+                    href={`/search/fight-scenes?tag=${encodeURIComponent(tag.name)}`}
+                    className="border px-2 py-0.5 text-[10px] tracking-wide uppercase hover:opacity-70"
+                    style={{ borderColor: TICKET_INK }}
+                  >
                     {tag.name}
-                  </span>
+                  </Link>
                 ))}
                 {scene.isVerified && (
                   <span className="px-2 py-0.5 text-[10px] tracking-wide uppercase" style={{ background: TICKET_INK, color: "#e8dcc4" }}>


### PR DESCRIPTION
## Summary

Builds the backlogged "Browse-by-tag / browse-by-genre quick links" item. A movie's genre badges and a fight scene's category-tag badges were plain, non-interactive spans. Made them links straight into the matching filtered search:

- Movie genre badges → `/search?genre=<name>`
- Fight scene category-tag badges (on movie pages, permalinks, search results, list pages, and profile pages) → `/search/fight-scenes?tag=<name>`

Considered a dedicated new "browse" section (e.g. a homepage pill strip) instead — passed on it in favor of reusing the badges already shown wherever a genre/tag appears, since it's the same destination with no new UI surface needed.

## Checklist

- [x] `README.md` updated to reflect this change
- [ ] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated (backlog item resolved, judgment call recorded)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright against a local build: clicking a movie's genre badge lands on `/search` with that genre pre-selected and results filtered; clicking a fight scene's tag badge lands on `/search/fight-scenes` with that tag pre-selected and results filtered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_