### PR TITLE
Fix fight scene edit form clearing the YouTube link

### DIFF
--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -524,6 +524,7 @@ export function FightSceneSection({
                   castOptions={castOptions}
                   tagOptions={tagOptions}
                   initialTitle={scene.title}
+                  initialUrl={`https://www.youtube.com/watch?v=${scene.youtubeVideoId}`}
                   initialPersonIds={scene.cast.map((c) => c.person.id)}
                   initialTagIds={scene.tags.map((t) => t.id)}
                   submitLabel="Save"


### PR DESCRIPTION
## Summary

The edit-mode `FightSceneForm` never received `initialUrl`, so the YouTube link field rendered blank on edit even though the scene still had its video. Saving without noticing and re-pasting the link failed server-side ("youtubeUrl is required"), which reads as the link getting cleared. Now pre-fills the field with the existing video's watch URL.

## Checklist

- [ ] `README.md` updated — not applicable, this restores already-documented edit behavior rather than changing it
- [ ] `.env.example` updated — not applicable
- [ ] `DECISIONS.md` updated — not applicable, pure bug fix with no judgment call
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright against a local build: opening the edit form on an existing fight scene now shows the current YouTube URL pre-filled (previously blank).
- Verified saving without touching the URL field now succeeds (previously failed with "youtubeUrl is required").

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_