### PR TITLE
Fix inconsistent edit-form placement on fight scene cards

### DIFF
--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -463,6 +463,7 @@ export function FightSceneSection({
   const sortedScenes = [...scenes].sort((a, b) => a.roundNumber - b.roundNumber);
   const visibleScenes = sortedScenes.slice(0, visibleCount);
   const remainingSceneCount = sortedScenes.length - visibleScenes.length;
+  const editingScene = visibleScenes.find((s) => s.id === editingId) ?? null;
 
   return (
     <section className="mt-10">
@@ -511,30 +512,41 @@ export function FightSceneSection({
         </div>
       )}
 
+      {/* Rendered outside the grid below, same as the "add" form above —
+          a full-width item spliced into a multi-column CSS grid only lands
+          in its original card's spot when that card happened to start a
+          row; otherwise auto-placement bumps it to wherever it next fits,
+          which is why editing used to open in a different-looking spot
+          depending on which scene was clicked. */}
+      {editingScene && (
+        <div className="mb-6 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+          <FightSceneForm
+            castOptions={castOptions}
+            tagOptions={tagOptions}
+            initialTitle={editingScene.title}
+            initialUrl={`https://www.youtube.com/watch?v=${editingScene.youtubeVideoId}`}
+            initialPersonIds={editingScene.cast.map((c) => c.person.id)}
+            initialTagIds={editingScene.tags.map((t) => t.id)}
+            submitLabel="Save"
+            submitting={submitting}
+            onCancel={() => setEditingId(null)}
+            onSubmit={(title, url, personIds, tagIds) => handleEdit(editingScene.id, title, url, personIds, tagIds)}
+            isEditing
+          />
+        </div>
+      )}
+
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {visibleScenes.map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;
           const permalinkPath = `/movies/${movieId}/fight-scenes/${scene.id}`;
 
+          // Shown as its own full-width form above the grid instead
+          // (see editingScene above) rather than inline here, so it
+          // doesn't duplicate the card also being edited.
           if (editingId === scene.id) {
-            return (
-              <li key={scene.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-3 sm:col-span-2 lg:col-span-3">
-                <FightSceneForm
-                  castOptions={castOptions}
-                  tagOptions={tagOptions}
-                  initialTitle={scene.title}
-                  initialUrl={`https://www.youtube.com/watch?v=${scene.youtubeVideoId}`}
-                  initialPersonIds={scene.cast.map((c) => c.person.id)}
-                  initialTagIds={scene.tags.map((t) => t.id)}
-                  submitLabel="Save"
-                  submitting={submitting}
-                  onCancel={() => setEditingId(null)}
-                  onSubmit={(title, url, personIds, tagIds) => handleEdit(scene.id, title, url, personIds, tagIds)}
-                  isEditing
-                />
-              </li>
-            );
+            return null;
           }
 
           const avgLabel = scene.ratingAverage ? scene.ratingAverage.toFixed(1) : "—";


### PR DESCRIPTION
## Summary

The edit form was spliced inline into the fight scenes CSS grid as a full-width (`col-span-3`) item at the position of the card being edited. A multi-column-span item can only land in its original spot if that card happened to start a row — otherwise grid auto-placement bumps it to wherever it next fits, so editing looked like it opened in a different spot depending on which scene was clicked.

Now rendered as a fixed block above the grid, the same pattern the "+ Add fight scene" form already used — always the same spot regardless of which scene is being edited or which row it's in.

## Checklist

- [ ] `README.md` updated — not applicable, this fixes a layout bug rather than changing documented behavior
- [ ] `.env.example` updated — not applicable
- [ ] `DECISIONS.md` updated — not applicable, pure bug fix with no judgment call
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright against a local build: measured the pixel gap between the "Fight Scenes" heading and the edit form's top for a row-1 scene (Round 1) and a row-2 scene (Round 4) — identical 57px gap both times, confirming the form always renders in the same fixed spot regardless of which row the edited card was in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_