### PR TITLE
News & Updates: eyebrow label + 2-column grid on homepage strip

### DIFF
--- a/src/components/news-strip.tsx
+++ b/src/components/news-strip.tsx
@@ -20,9 +20,10 @@ function formatDate(iso: string) {
 
 export function NewsStrip({ posts }: { posts: NewsPostItem[] }) {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       {posts.map((post) => (
         <article key={post.id} className="rounded-md border border-neutral-800 bg-neutral-900 p-4">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-red-500">Site Update</p>
           <h3 className="font-serif text-lg font-bold text-white">{post.title}</h3>
           <p className="mb-2 text-xs text-neutral-500">
             {post.author.username} · {formatDate(post.createdAt)}


### PR DESCRIPTION
## Summary

Visual polish for the homepage News & Updates section, per user-directed design review of PR #35:

- Added a red "SITE UPDATE" eyebrow label to each card, reusing the existing pattern from the hero carousel ("Trending this week"): `text-xs font-semibold uppercase tracking-wide text-red-500`.
- Changed the card layout from a single stacked column (`flex flex-col gap-4`) to a 2-column grid (`grid grid-cols-1 gap-4 sm:grid-cols-2`), matching Recent Reviews by Editors' exact grid classes.

Only `src/components/news-strip.tsx` (the homepage preview component) was touched — the `/news` archive page (`news-list.tsx`) is unchanged.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no user-facing feature, env var, setup step, or seed data changed) — styling-only tweak, no README update needed per repo convention.
- [ ] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral (or not applicable — no such decision here) — not applicable, this just applies two already-decided design directions from user review, no new judgment call.
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npm run lint` and `npm run build` locally — both pass.
- Seeded 3 realistic test `NewsPost` rows locally and took a Playwright screenshot against the running dev server to visually confirm the eyebrow label and 2-column grid render correctly, then removed the test data before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_