### PR TITLE
Make the recommendation badge bigger on movie posters

### DIFF
--- a/src/components/movie-card.tsx
+++ b/src/components/movie-card.tsx
@@ -38,8 +38,8 @@ export function MovieCard({ movie }: { movie: MovieCardData }) {
           </div>
         )}
         {movie.recommendedBy && movie.recommendedBy.length > 0 && (
-          <div className="absolute top-1.5 left-1.5">
-            <RecommendedBadges recommenders={movie.recommendedBy} />
+          <div className="absolute top-2 left-2">
+            <RecommendedBadges recommenders={movie.recommendedBy} size="lg" />
           </div>
         )}
       </div>

--- a/src/components/recommended-badge.tsx
+++ b/src/components/recommended-badge.tsx
@@ -3,18 +3,23 @@ import { adminBadgeColor, adminInitial } from "@/lib/admin-badge";
 import { ADMIN_BADGE_ICONS } from "@/lib/admin-badge-icons";
 import type { MovieRecommender } from "@/lib/movie-recommendations";
 
-const SIZES = { sm: 20, md: 28 } as const;
+const SIZES = { sm: 20, md: 28, lg: 36 } as const;
+const DIMENSION_CLASSES = {
+  sm: "h-5 w-5 text-[10px]",
+  md: "h-7 w-7 text-xs",
+  lg: "h-9 w-9 text-sm",
+} as const;
 
 export function RecommendedBadges({
   recommenders,
   size = "sm",
 }: {
   recommenders: MovieRecommender[];
-  size?: "sm" | "md";
+  size?: "sm" | "md" | "lg";
 }) {
   if (recommenders.length === 0) return null;
 
-  const dimensionClass = size === "sm" ? "h-5 w-5 text-[10px]" : "h-7 w-7 text-xs";
+  const dimensionClass = DIMENSION_CLASSES[size];
   const pixels = SIZES[size];
 
   return (


### PR DESCRIPTION
## Summary

- The admin recommendation badge on movie poster cards read too small (20px) against a full poster — bumped it up.
- Added a `"lg"` size (36px) to `RecommendedBadges` alongside the existing `sm`/`md`.
- `MovieCard`'s poster overlay now uses `size="lg"` instead of the default `sm`.

## Checklist

- [x] `README.md` updated (or not applicable — pure UI sizing tweak, no user-facing behavior/env var/setup step change)
- [x] `.env.example` updated if a new environment variable was added (not applicable)
- [x] `DECISIONS.md` updated if this involved a real judgment call (or not applicable — sizing tweak, not a judgment call worth logging)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright screenshot on `/search`: the badge on a recommended movie's poster is now visibly larger (36px) and reads clearly against the card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_