### PR TITLE
Render the real recommendation icon as a square, not a circle

### DIFF
--- a/src/components/recommended-badge.tsx
+++ b/src/components/recommended-badge.tsx
@@ -35,7 +35,7 @@ export function RecommendedBadges({
               title={`Recommended by ${recommender.username}`}
               width={pixels}
               height={pixels}
-              className={`${dimensionClass} shrink-0 rounded-full border-2 border-neutral-950 object-contain bg-white`}
+              className={`${dimensionClass} shrink-0 rounded-md border-2 border-neutral-950 object-contain bg-white`}
             />
           );
         }


### PR DESCRIPTION
## Summary

- The real admin icon (son323's 王 seal) was being clipped into a circle via `rounded-full`, losing its square shape.
- Switched the `<Image>` badge in `RecommendedBadges` from `rounded-full` to `rounded-md`, so a real icon keeps a shape close to its original artwork.
- The placeholder colored-initial badge (used for any admin without a real icon) is unaffected — still circular.

## Checklist

- [x] `README.md` updated (or not applicable — pure styling tweak, no user-facing behavior/env var/setup step change)
- [x] `.env.example` updated if a new environment variable was added (not applicable)
- [x] `DECISIONS.md` updated if this involved a real judgment call (or not applicable — styling tweak, not a judgment call worth logging)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified via Playwright screenshot on `/search` and a movie detail page: son323's badge now renders as a square (slightly rounded corners) instead of a circle, on both surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvJjRH7ukqVfEjrfKrQDFX)_