### PR TITLE
Fix hero carousel clip playing twice

### DIFF
--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -22,11 +22,9 @@ function clipEmbedUrl(videoId: string, startSeconds: number | null) {
   const params = new URLSearchParams({
     autoplay: "1",
     mute: "1",
-    loop: "1",
     controls: "0",
     playsinline: "1",
     rel: "0",
-    playlist: videoId,
     start: String(start),
     end: String(start + CLIP_SECONDS),
   });


### PR DESCRIPTION
## Summary

- Bug report: a hero carousel slide's fight scene clip plays twice — first from the admin-set start time, then a second time from the very beginning of the video.
- Root cause: `clipEmbedUrl` in `hero-carousel.tsx` set `loop=1` + `playlist=<same videoId>` (the standard trick for looping a single YouTube video). This is a documented YouTube IFrame API quirk — when `start`/`end` are also set, hitting `end` doesn't loop back to `start`, it restarts the whole video from time 0.
- `ROTATE_MS` (15000ms) is already kept equal to `CLIP_SECONDS` (15) specifically so the carousel advances to the next slide right as the clip finishes — the loop was defensive padding that wasn't needed, and it's the direct cause of the double-play.
- Fix: removed `loop`/`playlist` from the embed params. Without `loop`, the player just stops in place once it reaches `end` instead of restarting from 0.

## Checklist

- [x] `README.md` updated (or not applicable — pure bug fix, no user-facing feature/env var/setup step/data model change)
- [ ] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call (or not applicable — pure bug fix, not a judgment call worth logging)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npm run lint` and `npm run build` locally — both pass.
- Could not verify the actual playback behavior in a browser locally — this sandbox has no network route to YouTube at all (confirmed directly: a Playwright browser navigation to a `youtube-nocookie.com` embed URL fails with `ERR_TUNNEL_CONNECTION_FAILED`). Recommend verifying on the Vercel preview deployment for this PR, since it has normal internet access.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_