### PR TITLE
Add a REVIEWER role: verify movies, manage fight-scene tags, verify scenes

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -89,6 +89,52 @@ always applies whatever status it's given — without the guard, "submitting"
 an already-live movie again would demote it back to pending and pull it off
 the site.
 
+### REVIEWER introduced as a role narrower than ADMIN
+A three-role model (`USER`/`REVIEWER`/`ADMIN`) replaces the previous binary
+one, driven by a concrete need: someone who should be able to verify
+member-submitted movies, manage the fight-scene-tag vocabulary, and verify
+fight scenes, without the rest of `ADMIN`'s reach (TMDB import, News &
+Updates, catalog deletion, Editors' Score, editorial reviews, discussion
+moderation).
+
+- No schema migration — `role` was already a plain `String` with no DB-level
+  check constraint, just an app-level convention (documented in a schema
+  comment). Adding a third accepted value only required updating that
+  comment and the permission checks themselves.
+- `requireReviewerSession()` (ADMIN or REVIEWER) added alongside the existing
+  `requireAdminSession()` (ADMIN-only, unchanged) in `src/lib/require-admin.ts`,
+  rather than replacing the single admin check everywhere — most admin-gated
+  routes (TMDB import, News, catalog deletion, Editors' Score/rating,
+  editorial reviews, discussion moderation, poster overrides,
+  recommendations, fight-scene start-time/admin-rating) stay on
+  `requireAdminSession()` untouched. Only the three routes REVIEWER actually
+  needed — movie approval, fight-scene-tag CRUD, fight-scene verify — moved
+  to the broader check.
+- Movie rejection needed its own endpoint (`POST /api/admin/movies/[id]/reject`,
+  REVIEWER-accessible but scoped to `status: "PENDING"` rows only) rather
+  than granting REVIEWER access to the existing general `DELETE
+  /api/admin/movies/[id]` (ADMIN-only, deletes *any* catalog movie). Branching
+  that shared route on role and target status would have made "can this
+  account delete this movie" depend on two different things read together;
+  a separate, narrowly-scoped route keeps REVIEWER's blast radius provably
+  limited to their own review queue.
+- `FightSceneSection`'s existing `isAdmin` prop already bundled several
+  admin-only powers together (delete any scene, start-time adjustment,
+  editors' rating/note) behind one boolean and one "Admin tools" toggle.
+  Rather than broaden `isAdmin` itself (which would have handed REVIEWER all
+  of those, not just verify), a second prop `canVerify` was added,
+  defaulting to `isAdmin`'s value so no other call site's behavior changed
+  by omission. Only the Verify/Unverify button reads `canVerify`; everything
+  else under the "Admin tools" toggle still reads `isAdmin`.
+- REVIEWER also gets self-service `/admin/account` access (own email/password),
+  not just the three review capabilities — same rationale as why that page
+  exists for ADMIN at all (self-service beats needing someone to run raw
+  SQL), and managing your own credentials isn't a content-moderation power
+  that needs withholding.
+- No user-management UI added for granting the role itself — promoting an
+  account to REVIEWER (or ADMIN) is still a direct database `UPDATE`,
+  consistent with how ADMIN promotion has always worked in this project.
+
 ## Feature Decisions
 
 ### Admin Recommendations: per-admin badges, not a single shared flag

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Actor pages (`/actors/[personId]`) showing an actor's filmography and every fight scene they're tagged in, linked from a movie's cast list and a scene's "Featuring" line (see [Actor Pages](#actor-pages) below)
 - Member accounts via email/password (with email verification) or Google sign-in, identified publicly by a chosen username rather than their email or real name (see [Usernames](#usernames) below)
 - Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist for movies (fight scenes get a Favorite only — see below), create their own public named lists on a profile page at `/members/[username]` and save both movies and fight scenes to them (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
-- A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, News & Updates, Account settings) plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area](#admin-area) below
+- A unified `/admin` dashboard (Movies management incl. pending-submission review and permanent deletion, TMDB import incl. title search, keyword search, and bulk CSV upload, Fight Scene Tags, News & Updates, Account settings), shared by two roles &mdash; `ADMIN` (everything) and a narrower `REVIEWER` (movie-submission review, fight-scene-tag management, fight-scene verification) &mdash; plus admin actions that stay inline on regular pages (Editors' Score, editorial reviews, poster overrides, fight scene verification) &mdash; see [Admin Area & Roles](#admin-area--roles) below
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 - A public `/lists` page for browsing every member's public custom lists (sorted by newest-updated or most-liked, paginated), plus a `/leaderboard` page ranking the Most-Liked Lists (members can like each other's public custom lists) and Top Curators (members with the most movies across their own lists) — see [Member Lists & Profiles](#member-lists--profiles) below
 - Admin-published News & Updates posts: the latest one shown as a teaser banner on the homepage, with a full paginated archive at `/news` — see [News & Updates](#news--updates) below
@@ -82,6 +82,7 @@ One of the migrations runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` (used for th
 The seed script creates a few placeholder movies (clearly not real TMDB imports) so the site is browsable immediately, plus two pre-verified test accounts:
 
 - `admin@example.com` / `admin1234` (username `admin`, role: ADMIN)
+- `reviewer@example.com` / `reviewer1234` (username `reviewer`, role: REVIEWER)
 - `member@example.com` / `member1234` (username `member`, role: USER)
 
 ### 7. Run the app
@@ -134,7 +135,7 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
   - TMDB's `/discover/movie` endpoint (used for keyword search) caps at page 500 (10,000 results) regardless of how many total matches it reports; a search with more matches than that needs narrowing (e.g. an additional keyword or a country filter) to reach everything.
   - Country and cast require an extra per-movie detail lookup beyond what the base keyword search returns, so each page of 20 keyword results costs more TMDB requests than a title search does — still well within TMDB's rate limits for realistic result counts, just not instant.
   - `with_origin_country` isn't in TMDB's official (outdated) API docs, though it's confirmed working and referenced by TMDB's own support — worth knowing if it ever needs debugging.
-- **Bulk CSV upload** — for when you already have a list of titles in hand rather than needing to discover them; see [Admin Area](#admin-area) below for the format.
+- **Bulk CSV upload** — for when you already have a list of titles in hand rather than needing to discover them; see [Admin Area & Roles](#admin-area--roles) below for the format.
 
 ## Member Lists & Profiles
 
@@ -198,19 +199,19 @@ The site's base look (backgrounds, text, accents) is defined once in `src/app/gl
 
 Fight Scene cards ("Fight Ticket" styling) are the one exception: they use hardcoded hex colors rather than the shared Tailwind scale, so they deliberately keep their ink-on-cream, ticket-stub look regardless of whatever the site-wide theme is set to.
 
-## Admin Area
+## Admin Area & Roles
 
-Signed-in admins get an "Admin" link in the navbar to `/admin` &mdash; a dashboard linking every admin section that lives on its own page, all guarded by the same `requireAdminSession()` check in `src/app/admin/layout.tsx`:
+Three roles exist: `USER` (the default member role), `REVIEWER`, and `ADMIN`. Signed-in `ADMIN`/`REVIEWER` accounts get an "Admin" link in the navbar to `/admin` &mdash; a dashboard linking every admin section that lives on its own page, gated by `requireReviewerSession()` (`ADMIN` or `REVIEWER`) in `src/app/admin/layout.tsx`; individual sections and API routes narrow further to `ADMIN`-only where noted below via `requireAdminSession()`.
 
-- **Movies** (`/admin/movies`) &mdash; a **Pending Submissions** section (see [Member Movie Submissions](#member-movie-submissions) above) to approve or reject member-submitted movies, plus the catalog itself: browse and permanently delete a movie entry (type the title to confirm). Deleting cascades through everything attached to it: cast credits, ratings, discussion posts, fight scenes (and their own casts/ratings), the editorial review, and weekly-featured entries.
-- **Import from TMDB** (`/admin/import`) &mdash; search-and-import by title or by keyword (see [TMDB Import](#tmdb-import) above), plus a bulk-upload section: a CSV with a `title` column (optionally `year` to disambiguate identically-titled results, or `tmdb_id` to skip the search entirely) imports up to 25 movies in one request. Each row is resolved and imported independently, so one bad row (no TMDB match, a transient TMDB error) doesn't fail the rest of the batch &mdash; the response reports created/updated/error per row. CSV parsing uses `papaparse` rather than the `xlsx` npm package, whose published version has known unpatched advisories (SheetJS fixed them only on their own CDN, not on the npm registry).
-- **Fight Scene Tags** (`/admin/fight-scene-tags`) &mdash; manage the category vocabulary members tag fight scenes with (see [Fight Scenes](#fight-scenes) above).
-- **News & Updates** (`/admin/news`) &mdash; publish, edit, or delete posts shown on the homepage and the `/news` archive (see [News & Updates](#news--updates) above).
-- **Account** (`/admin/account`) &mdash; change your own admin sign-in email or password (previously only possible via direct SQL). Changing your email re-triggers the normal email-verification flow on the new address; changing your password requires your current one (unless you signed up via Google and have never set one, in which case you can set an initial password). Either change signs you out immediately, since the session is JWT-based and won't otherwise pick up the new credentials until you sign back in.
+- **Movies** (`/admin/movies`) &mdash; a **Pending Submissions** section (see [Member Movie Submissions](#member-movie-submissions) above) to approve or reject member-submitted movies, open to `REVIEWER` too. The **Catalog** section below it (browse and permanently delete any movie, cascading through everything attached to it) is `ADMIN`-only — a reviewer's reject action only ever deletes a still-`PENDING` row via a separate endpoint, never an already-approved catalog entry.
+- **Import from TMDB** (`/admin/import`, `ADMIN`-only) &mdash; search-and-import by title or by keyword (see [TMDB Import](#tmdb-import) above), plus a bulk-upload section: a CSV with a `title` column (optionally `year` to disambiguate identically-titled results, or `tmdb_id` to skip the search entirely) imports up to 25 movies in one request. Each row is resolved and imported independently, so one bad row (no TMDB match, a transient TMDB error) doesn't fail the rest of the batch &mdash; the response reports created/updated/error per row. CSV parsing uses `papaparse` rather than the `xlsx` npm package, whose published version has known unpatched advisories (SheetJS fixed them only on their own CDN, not on the npm registry).
+- **Fight Scene Tags** (`/admin/fight-scene-tags`) &mdash; manage the category vocabulary members tag fight scenes with (see [Fight Scenes](#fight-scenes) above). Open to `REVIEWER`.
+- **News & Updates** (`/admin/news`, `ADMIN`-only) &mdash; publish, edit, or delete posts shown on the homepage and the `/news` archive (see [News & Updates](#news--updates) above).
+- **Account** (`/admin/account`) &mdash; change your own sign-in email or password (previously only possible via direct SQL). Changing your email re-triggers the normal email-verification flow on the new address; changing your password requires your current one (unless you signed up via Google and have never set one, in which case you can set an initial password). Either change signs you out immediately, since the session is JWT-based and won't otherwise pick up the new credentials until you sign back in. Open to `REVIEWER` too — self-managing your own credentials isn't a content-moderation power, so it follows the same "reach `/admin` at all" gate as the dashboard itself.
 
-Account management is deliberately self-service (an admin managing their own credentials) rather than a full user-management CRUD (promoting other users to admin, resetting someone else's password, etc.) &mdash; a reasonable next step if the admin area grows further.
+Outside this dashboard, fight scene verification (the Verify/Unverify link on a fight scene card) is also open to `REVIEWER`, gated by its own `canVerify` prop on `FightSceneSection` — deliberately not the same prop as the component's `isAdmin`, which still gates a scene's Editors' rating/note, start-time adjustment, and delete-any-scene, none of which `REVIEWER` has. Editors' Score, editorial reviews, poster overrides, and discussion moderation are `ADMIN`-only actions that stay inline on the regular movie page.
 
-Not every admin capability lives in this dashboard — Editors' Score, editorial reviews, poster overrides, and fight scene verification are admin-only actions that stay inline on the regular movie/fight-scene pages they act on, rather than being relocated here.
+There's no user-management UI for granting `REVIEWER`/`ADMIN` — promoting an account is a direct `UPDATE "User" SET role = 'REVIEWER' WHERE email = '...'` against the database, same as `ADMIN` always has been. A reasonable next step if the admin area grows further.
 
 ## Weekly Trending Carousel
 
@@ -279,7 +280,7 @@ It needs to be turned on per-project after deploying: **Vercel dashboard → thi
 
 ## Project Structure
 
-- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area](#admin-area)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), public list permalinks (`/lists/[listId]`), and actor pages (`/actors/[personId]`)
+- `src/app` — pages and API routes (App Router), including the `/admin` dashboard and its sub-pages (see [Admin Area & Roles](#admin-area--roles)), the fight scene permalink route (`/movies/[id]/fight-scenes/[fightSceneId]`), member movie submission (`/movies/submit`), member profiles (`/members/[username]`), public list permalinks (`/lists/[listId]`), and actor pages (`/actors/[personId]`)
 - `src/components` — UI components (`fight-scene-section.tsx`, `editorial-review.tsx`, `poster-override-control.tsx`, `share-button.tsx`, `member-list-manager.tsx`, `add-to-list-control.tsx`, etc.)
 - `src/lib` — Prisma client, Auth.js config, TMDB client, YouTube URL parsing, rating/weekly-featured/verification/fight-scene/username/member-list helpers, email sender
 - `prisma/schema.prisma` — data model

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   emailVerified DateTime?
   image         String?
   passwordHash  String?
-  role          String    @default("USER") // "USER" | "ADMIN"
+  role          String    @default("USER") // "USER" | "ADMIN" | "REVIEWER"
   createdAt     DateTime  @default(now())
 
   accounts      Account[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -143,6 +143,18 @@ async function main() {
     },
   });
 
+  await prisma.user.upsert({
+    where: { email: "reviewer@example.com" },
+    update: { emailVerified: new Date() },
+    create: {
+      username: "reviewer",
+      email: "reviewer@example.com",
+      role: "REVIEWER",
+      passwordHash: await bcrypt.hash("reviewer1234", 10),
+      emailVerified: new Date(),
+    },
+  });
+
   const enterTheDragon = await prisma.movie.findUniqueOrThrow({ where: { tmdbId: 900001 } });
   await prisma.rating.upsert({
     where: { userId_movieId: { userId: member.id, movieId: enterTheDragon.id } },

--- a/src/app/admin/account/page.tsx
+++ b/src/app/admin/account/page.tsx
@@ -18,8 +18,8 @@ export default async function AdminAccountPage() {
     <div className="max-w-md">
       <h1 className="mb-2 text-2xl font-bold text-white">Account</h1>
       <p className="mb-6 text-sm text-neutral-400">
-        Manage your own admin sign-in credentials. Changing either one signs you out so you can
-        sign back in with the new details.
+        Manage your own sign-in credentials. Changing either one signs you out so you can sign back
+        in with the new details.
       </p>
       <AdminAccountSettings currentEmail={user?.email ?? ""} hasPassword={!!user?.passwordHash} />
     </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,26 +1,34 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 
+// REVIEWER only gets Movies (pending-submission review, not the full
+// catalog — see AdminMoviesPage) and Fight Scene Tags, plus the same
+// self-service Account page ADMIN gets. TMDB import and News & Updates stay
+// full-admin-only, so they're marked adminOnly rather than left off this
+// list entirely — omitting them here would mean re-declaring the same nav
+// shape twice instead of filtering one list.
 const NAV_LINKS = [
-  { href: "/admin", label: "Dashboard" },
-  { href: "/admin/movies", label: "Movies" },
-  { href: "/admin/import", label: "Import from TMDB" },
-  { href: "/admin/fight-scene-tags", label: "Fight Scene Tags" },
-  { href: "/admin/news", label: "News & Updates" },
-  { href: "/admin/account", label: "Account" },
+  { href: "/admin", label: "Dashboard", adminOnly: false },
+  { href: "/admin/movies", label: "Movies", adminOnly: false },
+  { href: "/admin/import", label: "Import from TMDB", adminOnly: true },
+  { href: "/admin/fight-scene-tags", label: "Fight Scene Tags", adminOnly: false },
+  { href: "/admin/news", label: "News & Updates", adminOnly: true },
+  { href: "/admin/account", label: "Account", adminOnly: false },
 ];
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     redirect("/");
   }
+  const isAdmin = session.user.role === "ADMIN";
+  const links = NAV_LINKS.filter((link) => isAdmin || !link.adminOnly);
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-10 sm:flex-row">
       <nav className="rail-scrollbar flex shrink-0 gap-1 overflow-x-auto sm:w-48 sm:flex-col sm:overflow-visible">
-        {NAV_LINKS.map((link) => (
+        {links.map((link) => (
           <Link
             key={link.href}
             href={link.href}

--- a/src/app/admin/movies/page.tsx
+++ b/src/app/admin/movies/page.tsx
@@ -1,19 +1,29 @@
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { AdminMovieList } from "@/components/admin-movie-list";
 import { AdminPendingMovies } from "@/components/admin-pending-movies";
 
 export default async function AdminMoviesPage() {
+  const session = await auth();
+  const isAdmin = session?.user?.role === "ADMIN";
+
+  // REVIEWER only gets the Pending Submissions queue below — deleting from
+  // the full catalog is a bigger, ADMIN-only power (see the reject route's
+  // comment for why that split is a separate endpoint, not a role check
+  // inside the shared delete route).
   const [movies, pending] = await Promise.all([
-    prisma.movie.findMany({
-      where: { status: "APPROVED" },
-      orderBy: { title: "asc" },
-      select: {
-        id: true,
-        title: true,
-        releaseDate: true,
-        _count: { select: { ratings: true, discussionPosts: true, fightScenes: true } },
-      },
-    }),
+    isAdmin
+      ? prisma.movie.findMany({
+          where: { status: "APPROVED" },
+          orderBy: { title: "asc" },
+          select: {
+            id: true,
+            title: true,
+            releaseDate: true,
+            _count: { select: { ratings: true, discussionPosts: true, fightScenes: true } },
+          },
+        })
+      : [],
     prisma.movie.findMany({
       where: { status: "PENDING" },
       orderBy: { createdAt: "asc" },
@@ -50,12 +60,16 @@ export default async function AdminMoviesPage() {
         </section>
       )}
 
-      <h2 className="mb-2 text-lg font-semibold text-white">Catalog</h2>
-      <p className="mb-6 text-sm text-neutral-400">
-        Deleting a movie permanently removes it and everything attached to it &mdash; ratings,
-        discussion posts, and fight scenes included. This can&rsquo;t be undone.
-      </p>
-      <AdminMovieList initialMovies={serializedMovies} />
+      {isAdmin && (
+        <>
+          <h2 className="mb-2 text-lg font-semibold text-white">Catalog</h2>
+          <p className="mb-6 text-sm text-neutral-400">
+            Deleting a movie permanently removes it and everything attached to it &mdash; ratings,
+            discussion posts, and fight scenes included. This can&rsquo;t be undone.
+          </p>
+          <AdminMovieList initialMovies={serializedMovies} />
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,39 +1,49 @@
 import Link from "next/link";
+import { auth } from "@/lib/auth";
 
 const SECTIONS = [
   {
     href: "/admin/movies",
     title: "Movies",
     description: "Browse the catalog and permanently delete a movie entry.",
+    adminOnly: false,
   },
   {
     href: "/admin/import",
     title: "Import from TMDB",
     description: "Search TMDB and pull new films into the catalog.",
+    adminOnly: true,
   },
   {
     href: "/admin/fight-scene-tags",
     title: "Fight Scene Tags",
     description: "Manage the category vocabulary members tag fight scenes with.",
+    adminOnly: false,
   },
   {
     href: "/admin/news",
     title: "News & Updates",
     description: "Publish posts shown on /news and as a homepage teaser.",
+    adminOnly: true,
   },
   {
     href: "/admin/account",
     title: "Account",
-    description: "Change your own admin sign-in email or password.",
+    description: "Change your own sign-in email or password.",
+    adminOnly: false,
   },
 ];
 
-export default function AdminDashboardPage() {
+export default async function AdminDashboardPage() {
+  const session = await auth();
+  const isAdmin = session?.user?.role === "ADMIN";
+  const sections = SECTIONS.filter((section) => isAdmin || !section.adminOnly);
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-white">Admin</h1>
       <div className="grid gap-4 sm:grid-cols-2">
-        {SECTIONS.map((section) => (
+        {sections.map((section) => (
           <Link
             key={section.href}
             href={section.href}

--- a/src/app/api/admin/account/email/route.ts
+++ b/src/app/api/admin/account/email/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 import { createVerificationToken, buildVerificationUrl } from "@/lib/verification";
 import { sendVerificationEmail } from "@/lib/email";
 
 export async function PATCH(request: Request) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/admin/account/password/route.ts
+++ b/src/app/api/admin/account/password/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 
 const MIN_PASSWORD_LENGTH = 8;
 
 export async function PATCH(request: Request) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/admin/fight-scene-tags/[tagId]/route.ts
+++ b/src/app/api/admin/fight-scene-tags/[tagId]/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 
 const MAX_TAG_NAME_LENGTH = 40;
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ tagId: string }> }) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
@@ -38,7 +38,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ ta
 }
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ tagId: string }> }) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/admin/fight-scene-tags/route.ts
+++ b/src/app/api/admin/fight-scene-tags/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 
 const MAX_TAG_NAME_LENGTH = 40;
 
 export async function GET() {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
@@ -18,7 +18,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/admin/movies/[id]/approve/route.ts
+++ b/src/app/api/admin/movies/[id]/approve/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/admin/movies/[id]/reject/route.ts
+++ b/src/app/api/admin/movies/[id]/reject/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { requireReviewerSession } from "@/lib/require-admin";
+import { prisma } from "@/lib/prisma";
+
+// Deliberately separate from the general DELETE /api/admin/movies/[id] (ADMIN
+// only, deletes any catalog movie). REVIEWER can reject a submission, but
+// that permission must not extend to deleting an already-approved movie —
+// scoping this endpoint to PENDING rows only is what keeps those two powers
+// apart, rather than branching on status inside the shared delete route.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireReviewerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: movieId } = await params;
+  const existing = await prisma.movie.findUnique({ where: { id: movieId } });
+  if (!existing) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+  if (existing.status !== "PENDING") {
+    return NextResponse.json({ error: "Only pending submissions can be rejected." }, { status: 400 });
+  }
+
+  await prisma.movie.delete({ where: { id: movieId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/verify/route.ts
+++ b/src/app/api/movies/[id]/fight-scenes/[fightSceneId]/verify/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { requireAdminSession } from "@/lib/require-admin";
+import { requireReviewerSession } from "@/lib/require-admin";
 import { prisma } from "@/lib/prisma";
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string; fightSceneId: string }> },
 ) {
-  const session = await requireAdminSession();
+  const session = await requireReviewerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -121,6 +121,7 @@ export default async function FightScenePage({ params }: { params: Promise<Param
         signedIn={!!session?.user}
         currentUserId={session?.user?.id ?? null}
         isAdmin={session?.user?.role === "ADMIN"}
+        canVerify={session?.user?.role === "ADMIN" || session?.user?.role === "REVIEWER"}
         myRatings={myRating ? { [scene.id]: myRating.score } : {}}
         myAdminRatings={myAdminRating ? { [scene.id]: myAdminRating.score } : {}}
         myMemberLists={myMemberListItems}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -44,12 +44,14 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   }
 
   // Pending (member-submitted, not yet admin-approved) movies are invisible
-  // to everyone except the person who submitted them and admins — everyone
-  // else gets the same 404 as a nonexistent movie, matching how it's already
-  // hidden from every public listing/search.
+  // to everyone except the person who submitted them and admins/reviewers
+  // (who need to see it to review it) — everyone else gets the same 404 as
+  // a nonexistent movie, matching how it's already hidden from every public
+  // listing/search.
   const isVisible =
     movie.status === "APPROVED" ||
     session?.user?.role === "ADMIN" ||
+    session?.user?.role === "REVIEWER" ||
     session?.user?.id === movie.submittedById;
   if (!isVisible) {
     notFound();
@@ -362,6 +364,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           signedIn={!!session?.user}
           currentUserId={session?.user?.id ?? null}
           isAdmin={session?.user?.role === "ADMIN"}
+          canVerify={session?.user?.role === "ADMIN" || session?.user?.role === "REVIEWER"}
           myRatings={myFightSceneRatingMap}
           myAdminRatings={myFightSceneAdminRatingMap}
           myMemberLists={myMemberLists.map((list) => ({ id: list.id, name: list.name }))}

--- a/src/components/admin-pending-movies.tsx
+++ b/src/components/admin-pending-movies.tsx
@@ -30,7 +30,7 @@ export function AdminPendingMovies({ initialMovies }: { initialMovies: PendingMo
     if (!window.confirm(`Reject and permanently remove "${title}"?`)) return;
     setBusyId(id);
     setError(null);
-    const res = await fetch(`/api/admin/movies/${id}`, { method: "DELETE" });
+    const res = await fetch(`/api/admin/movies/${id}/reject`, { method: "POST" });
     setBusyId(null);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -276,6 +276,7 @@ export function FightSceneSection({
   signedIn,
   currentUserId,
   isAdmin,
+  canVerify = isAdmin,
   myRatings,
   myAdminRatings,
   myMemberLists = [],
@@ -290,7 +291,14 @@ export function FightSceneSection({
   tagOptions: TagOption[];
   signedIn: boolean;
   currentUserId: string | null;
+  // Full admin powers: delete any scene, adjust start-time, set the
+  // editors' rating/note. Deliberately not the same gate as canVerify below.
   isAdmin: boolean;
+  // Verify/unverify only — granted to REVIEWER as well as ADMIN. Defaults to
+  // isAdmin's value so existing call sites that don't pass it yet keep
+  // exactly today's behavior (admin-only) instead of silently losing the
+  // verify button.
+  canVerify?: boolean;
   myRatings: Record<string, number>;
   myAdminRatings: Record<string, number>;
   // The signed-in member's public lists, and which of those already contain
@@ -690,7 +698,7 @@ export function FightSceneSection({
                       Delete
                     </button>
                   )}
-                  {isAdmin && (
+                  {canVerify && (
                     <button onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)} className="ml-2 underline hover:opacity-70">
                       {scene.isVerified ? "Unverify" : "Verify"}
                     </button>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -36,7 +36,7 @@ export async function Navbar() {
           </Link>
           {session?.user ? (
             <>
-              {session.user.role === "ADMIN" && (
+              {(session.user.role === "ADMIN" || session.user.role === "REVIEWER") && (
                 <Link href="/admin" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
                   Admin
                 </Link>

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -7,3 +7,18 @@ export async function requireAdminSession() {
   }
   return session;
 }
+
+// REVIEWER is a narrower role than ADMIN: movie-submission approval/rejection,
+// fight-scene-tag management, and fight-scene verification only — everything
+// else admin-gated (TMDB import, News & Updates, catalog deletion, Editorial
+// Reviews, discussion moderation, etc.) stays ADMIN-only via
+// requireAdminSession above. Account self-service (own email/password) is
+// also open to REVIEWER, same rationale as why it exists for ADMIN at all:
+// self-managing your own credentials beats needing someone to run raw SQL.
+export async function requireReviewerSession() {
+  const session = await auth();
+  if (!session?.user || (session.user.role !== "ADMIN" && session.user.role !== "REVIEWER")) {
+    return null;
+  }
+  return session;
+}


### PR DESCRIPTION
## Summary

Introduces a third role, `REVIEWER`, alongside the existing `USER`/`ADMIN`, scoped to exactly three capabilities:

- Approve or reject member-submitted movies (`/admin/movies`'s Pending Submissions queue).
- Create, rename, and delete fight-scene tags (`/admin/fight-scene-tags`).
- Verify/unverify fight scenes (the Verify link on a fight scene card).

Plus self-service account management (own email/password) — same rationale as why that page exists for `ADMIN` at all: self-service beats needing someone to run raw SQL for your own credentials.

Everything else stays `ADMIN`-only and untouched: TMDB import, News & Updates, full catalog deletion, Editors' Score, editorial reviews, poster overrides, recommendations, discussion moderation, fight-scene start-time adjustment, fight-scene admin-rating.

**No schema migration** — `role` was already a plain, unconstrained `String`; only the schema comment and the permission checks themselves changed.

**Two scoping decisions worth flagging** (full reasoning in `DECISIONS.md`):
- Movie rejection got its own `PENDING`-only endpoint (`POST /api/admin/movies/[id]/reject`) rather than granting `REVIEWER` access to the general `DELETE /api/admin/movies/[id]` (which deletes *any* catalog movie, `ADMIN`-only). Keeps a reviewer's blast radius provably limited to their own review queue instead of depending on a role+status branch inside a shared route.
- `FightSceneSection`'s `isAdmin` prop already bundled several `ADMIN`-only powers (delete any scene, start-time, editors' rating/note) behind one boolean and an "Admin tools" toggle. Rather than broaden `isAdmin` (which would've handed `REVIEWER` all of those), added a second prop `canVerify` that only the Verify/Unverify button reads — "Admin tools" and everything under it stays `isAdmin`-gated.

Also confirmed and documented: `REVIEWER` (like `ADMIN`) keeps full ordinary member capabilities — rating, favoriting, lists, discussion posts, fight-scene/movie submission — since none of those routes check for `role === "USER"` specifically, only "signed in" + "email verified." Role has always been additive here, not a mutually-exclusive tier.

## Checklist

- [x] `README.md` updated — new "Admin Area & Roles" section (renamed from "Admin Area"), updated anchors, Features bullet, seed account list
- [x] `DECISIONS.md` updated — new Foundational Changes entry with the full "why" behind each scoping call
- [x] `.env.example` — not applicable, no new env vars
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Ran a real local Postgres + dev server with three distinct role accounts (`reviewer@example.com` / `admin@example.com` / `member@example.com`, all seeded):

- Confirmed `/admin` nav link and dashboard rendering per role: a plain member is redirected away from `/admin` entirely (not just hidden nav — verified via Playwright that navigation actually lands back on `/`); reviewer sees Dashboard/Movies/Fight Scene Tags/Account only; admin sees all five sections including Import from TMDB and News & Updates.
- Confirmed reviewer can: approve a pending movie (200), create a fight-scene tag (200), verify a fight scene (200).
- Confirmed reviewer is blocked (403) from: TMDB search/import, fight-scene start-time, fight-scene admin-rating, movie admin-rating (Editors' Score), News creation, and the general catalog `DELETE` on an already-approved movie.
- Confirmed rejecting an already-`APPROVED` movie via the new `/reject` endpoint is rejected with 400 ("Only pending submissions can be rejected"), so a reviewer's reject action can never escalate into deleting a live catalog entry.
- Visually confirmed (screenshots) the movie page for a reviewer: Verify/Unverify link present on fight scene cards, no "Admin tools" toggle, no Editors' Score widget, no poster-override control, no recommendation control — matching the intended scope exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG


---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_