### PR TITLE
Stop leaking raw exception messages and fix CRON_SECRET timing comparison

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -217,6 +217,46 @@ seven limiters built on `@upstash/ratelimit`'s sliding-window algorithm.
   (5-per-window on login/registration, etc., with 429s and a correct
   `Retry-After` once exceeded) for all seven limiters.
 
+### Medium-risk security findings: two fixed, two deferred
+Follow-up to the original security review (see above). Of the five
+remaining findings, two were clean, self-contained fixes; the other three
+were left alone — either genuinely low-risk or a real product tradeoff
+that shouldn't be made silently as part of a security patch.
+
+- **Fixed — raw exception messages returned to clients**: six routes
+  (`movies/search`, `movies/submit`, and four `admin/tmdb/*` routes) caught
+  errors and returned `(error as Error).message` directly, which could
+  surface an upstream TMDB response body or an internal misconfiguration
+  hint (e.g. a missing-API-key message) to the client. New
+  `src/lib/api-error.ts` centralizes the fix: log the real error
+  server-side, return a fixed generic message to the client.
+- **Fixed — `CRON_SECRET` compared with `!==`**: string `!==` short-circuits
+  on the first differing byte, which is a textbook timing side-channel
+  (impractical to exploit over typical network jitter, but a one-line fix
+  with `crypto.timingSafeEqual` removes the anti-pattern entirely rather
+  than relying on that impracticality).
+- **Deferred — registration email enumeration**: registering with an
+  already-used email returns an explicit "account already exists" error,
+  letting an attacker check which emails have accounts. Closing this fully
+  means the client can no longer auto-sign-in right after registration
+  (a successful sign-in for a genuine new account vs. a failed one for an
+  attacker guessing an existing account's password re-leaks the same
+  signal at the login step) — i.e. it's a permanent UX regression (no more
+  instant browsing after signup) for every future user, not just
+  attackers, to close a signal that rate limiting (already shipped) makes
+  expensive to exploit at scale. Left as-is pending a product decision
+  rather than folded into a security patch.
+- **Deferred — poster upload MIME validation**: `admin/movies/[id]/poster`
+  trusts the browser-reported `file.type` rather than sniffing actual file
+  content, so a spoofed `Content-Type` could get stored/served with a
+  mismatched type. Left as low-risk since the route is `ADMIN`-only —
+  exploiting it needs an already-privileged account, which has much more
+  direct ways to cause damage than a poster upload.
+- **Deferred — bcrypt cost factor of 10**: still within OWASP's accepted
+  range (bumping to 12 is best-practice hardening, not a fix for an actual
+  weakness) and re-hashing existing users' passwords isn't free, so left
+  alone rather than bundled into this pass.
+
 ## Feature Decisions
 
 ### Admin Recommendations: per-admin badges, not a single shared flag

--- a/src/app/api/admin/tmdb/discover/route.ts
+++ b/src/app/api/admin/tmdb/discover/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { requireAdminSession } from "@/lib/require-admin";
 import { discoverMoviesByKeywords, getTmdbMovieDetails } from "@/lib/tmdb";
 import { prisma } from "@/lib/prisma";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 // TMDB refuses to serve page 501+ even when total_pages reports higher.
 const MAX_DISCOVER_PAGE = 500;
@@ -81,6 +82,6 @@ export async function GET(request: Request) {
       totalResults: discovered.total_results,
     });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to discover TMDB movies for keywords ${keywordsParam}:`, error);
   }
 }

--- a/src/app/api/admin/tmdb/import/route.ts
+++ b/src/app/api/admin/tmdb/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireAdminSession } from "@/lib/require-admin";
 import { importMovieFromTmdb } from "@/lib/tmdb-import";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 export async function POST(request: Request) {
   const session = await requireAdminSession();
@@ -17,6 +18,6 @@ export async function POST(request: Request) {
     const movie = await importMovieFromTmdb(tmdbId);
     return NextResponse.json({ movie });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to import TMDB movie ${tmdbId}:`, error);
   }
 }

--- a/src/app/api/admin/tmdb/keywords/route.ts
+++ b/src/app/api/admin/tmdb/keywords/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireAdminSession } from "@/lib/require-admin";
 import { searchTmdbKeywords } from "@/lib/tmdb";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 export async function GET(request: Request) {
   const session = await requireAdminSession();
@@ -17,6 +18,6 @@ export async function GET(request: Request) {
     const keywords = await searchTmdbKeywords(query);
     return NextResponse.json({ keywords });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to search TMDB keywords for "${query}":`, error);
   }
 }

--- a/src/app/api/admin/tmdb/search/route.ts
+++ b/src/app/api/admin/tmdb/search/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireAdminSession } from "@/lib/require-admin";
 import { searchTmdbMovies } from "@/lib/tmdb";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 export async function GET(request: Request) {
   const session = await requireAdminSession();
@@ -17,6 +18,6 @@ export async function GET(request: Request) {
     const results = await searchTmdbMovies(query);
     return NextResponse.json({ results });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to search TMDB for "${query}":`, error);
   }
 }

--- a/src/app/api/cron/weekly-featured/route.ts
+++ b/src/app/api/cron/weekly-featured/route.ts
@@ -1,11 +1,23 @@
+import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import { computeWeeklyFeatured } from "@/lib/weekly-featured";
 
-export async function GET(request: Request) {
-  const authHeader = request.headers.get("authorization");
-  const expected = `Bearer ${process.env.CRON_SECRET}`;
+function isAuthorized(request: Request): boolean {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) return false;
 
-  if (!process.env.CRON_SECRET || authHeader !== expected) {
+  const authHeader = request.headers.get("authorization") ?? "";
+  const expected = Buffer.from(`Bearer ${cronSecret}`);
+  const actual = Buffer.from(authHeader);
+
+  // Buffer lengths must match before timingSafeEqual can compare them, but
+  // returning early on a length mismatch is itself timing-safe — it leaks
+  // nothing more than a plain !== comparison already would.
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/api/movies/search/route.ts
+++ b/src/app/api/movies/search/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { isEmailVerified } from "@/lib/verification";
 import { searchTmdbMoviesForSubmission } from "@/lib/movie-submission";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 export async function GET(request: Request) {
   const session = await auth();
@@ -21,6 +22,6 @@ export async function GET(request: Request) {
     const results = await searchTmdbMoviesForSubmission(query);
     return NextResponse.json({ results });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to search TMDB for "${query}":`, error);
   }
 }

--- a/src/app/api/movies/submit/route.ts
+++ b/src/app/api/movies/submit/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { isEmailVerified } from "@/lib/verification";
 import { submitMovieForReview } from "@/lib/movie-submission";
 import { checkRateLimit, movieSubmitLimiter } from "@/lib/rate-limit";
+import { tmdbErrorResponse } from "@/lib/api-error";
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -33,6 +34,6 @@ export async function POST(request: Request) {
     }
     return NextResponse.json({ movie: result.movie });
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 502 });
+    return tmdbErrorResponse(`Failed to submit TMDB movie ${tmdbId}:`, error);
   }
 }

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+// A raw exception's `.message` can carry an upstream response body, a
+// missing-API-key hint, or other internals that don't belong in a client
+// response. Log the real error server-side and return a generic one instead.
+export function tmdbErrorResponse(context: string, error: unknown) {
+  console.error(context, error);
+  return NextResponse.json({ error: "TMDB request failed. Try again shortly." }, { status: 502 });
+}


### PR DESCRIPTION
## Summary

Two medium-risk findings from the earlier security review, fixed independently of the rate-limiting/CSP work already merged in #46:

- **Raw exception messages returned to clients**: six routes (`movies/search`, `movies/submit`, and four `admin/tmdb/*` routes) caught errors and returned `(error as Error).message` directly to the client — which could surface an upstream TMDB response body or an internal misconfiguration hint (e.g. a missing-API-key message). New `src/lib/api-error.ts` centralizes the fix: log the real error server-side, return a fixed generic message to the client.
- **`CRON_SECRET` compared with `!==`**: string `!==` short-circuits on the first differing byte, a textbook timing side-channel. Replaced with `crypto.timingSafeEqual` (with an explicit length check first, since `timingSafeEqual` throws on mismatched buffer lengths rather than comparing them).

Three other findings from the same review were intentionally left out of this PR — see the new `DECISIONS.md` entry for why: poster-upload MIME validation and the bcrypt cost factor are low-risk as-is, and registration email enumeration needs a product decision (closing it fully means dropping auto-login-after-registration for everyone) rather than a silent patch.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no user-facing feature, env var, setup step, or seed data changed) — not applicable, no user-facing behavior changed
- [x] `.env.example` updated if a new environment variable was added — not applicable, no new env vars
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — done, documents both fixes and the three deferred findings
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` and `npm run build` both pass with no errors or new warnings
- Manually traced each of the six modified routes to confirm the generic-error path still returns the correct HTTP status (502) and that the real error is still logged server-side via `console.error`
- Reviewed the `CRON_SECRET` change against Node's `crypto.timingSafeEqual` docs to confirm the length-check-before-compare pattern (it throws rather than returning false on a length mismatch, so the explicit `actual.length === expected.length` guard is required)

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_