### PR TITLE
Add two-factor authentication to the backlog

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -880,3 +880,11 @@ time.
 - **Top Rated Fight Scenes rail** — homepage rail using existing fight-scene
   rating data, to put the feature in front of visitors who'd otherwise only
   find it via nav.
+- **Two-factor authentication (TOTP)** — identified during the
+  login/password hardening pass as the one remaining major lever beyond
+  what's already shipped (rate limiting, CAPTCHA, breach-password
+  checking, session invalidation on password change, the login timing
+  fix). Deliberately not folded into any of those changes — it's a real
+  feature (secret generation/storage, an enrollment flow, backup/recovery
+  codes, a recovery path for a lost authenticator), not a small hardening
+  patch. Revisit as its own scoped piece of work.


### PR DESCRIPTION
## Summary

Docs-only. Logs 2FA/TOTP under `DECISIONS.md`'s "Deferred & Backlog" section — identified during the recent login/password hardening pass (rate limiting, CAPTCHA, breach-password checking, session invalidation on password change, the login timing fix) as the one remaining major lever, but deliberately not folded into that work since it's a real feature (enrollment flow, secret storage, backup codes, account recovery) rather than a small patch.

## Checklist

- [x] `README.md` updated — not applicable, no user-facing feature changed, this is a backlog note only
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — this PR's entire change
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Docs-only change; `npm run lint` and `npm run build` both pass with no changes to app behavior.

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_