### PR TITLE
Add SEO metadata to movie/actor pages, plus TMDB bio on actor pages

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -480,6 +480,42 @@ both self-contained enough not to need their own entry.
 
 ## Feature Decisions
 
+### Movie/actor SEO metadata and actor-page TMDB bios
+**PR #TBD.** `/movies/[id]` and `/actors/[personId]` previously had no
+per-page `<title>`/description/Open Graph tags — every page fell back to
+the site-wide default, and shared links didn't unfurl with a poster or
+synopsis. Actor pages also showed filmography and fight-scene appearances
+from our own catalog but no biography/birthday/place-of-birth, even though
+that data is one TMDB `/person/{id}` call away via the existing
+`person.tmdbId`.
+
+- Both pages' `generateMetadata` share the same Prisma lookup as the page
+  body via React's `cache()`, rather than querying twice per request (the
+  simpler pattern already used by
+  `movies/[id]/fight-scenes/[fightSceneId]/page.tsx`, which re-fetches) —
+  worth the extra `cache()` wrapper here since these are heavier
+  multi-relation queries than a single fight-scene lookup.
+- `generateMetadata` on the movie page re-runs the exact same
+  pending-movie visibility check (`status === "APPROVED"` or
+  submitter/admin/reviewer) as the page body, not just a `notFound()` in
+  the body — metadata output is as much a side door onto a pending movie's
+  title/synopsis as any other public surface, and PR #15/#16 was explicit
+  that a partial gate defeats the point.
+- `layout.tsx` already had a `metadataBase` (derived from `NEXTAUTH_URL`);
+  reused it directly rather than introducing a second derivation off
+  `VERCEL_PROJECT_PRODUCTION_URL` from an earlier, since-abandoned attempt
+  at this same feature — one metadataBase source, not two disagreeing ones.
+- Actor bios are live-fetched from TMDB on every page view and never cached
+  in our own database, same tradeoff already made for movie posters/details
+  elsewhere — gracefully omitted (not an error page) if TMDB is unreachable
+  or has nothing on record for that person.
+- `noindex` added to thin/duplicate-content and account-only pages that
+  don't benefit from ranking: both search pages (`follow: true`, so
+  crawlers still reach movie/actor pages linked from results), and
+  login/register/forgot-password/reset-password/verify-email/my-lists
+  (`follow: false`). The whole `/admin` subtree got one `noindex` on its
+  shared layout rather than one per admin page.
+
 ### Admin Recommendations: per-admin badges, not a single shared flag
 **PR #TBD.** Two admins each need their own "I recommend this" mark on a
 movie, distinct from the existing single shared Editorial Review.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -481,7 +481,7 @@ both self-contained enough not to need their own entry.
 ## Feature Decisions
 
 ### Movie/actor SEO metadata and actor-page TMDB bios
-**PR #TBD.** `/movies/[id]` and `/actors/[personId]` previously had no
+**PR #53.** `/movies/[id]` and `/actors/[personId]` previously had no
 per-page `<title>`/description/Open Graph tags — every page fell back to
 the site-wide default, and shared links didn't unfurl with a poster or
 synopsis. Actor pages also showed filmography and fight-scene appearances

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Below the cast list on every movie page, members can catalog individual fight sc
 
 Every credited person has a page at `/actors/[personId]` showing their Filmography (movies in the catalog, excluding any still-pending submission) and every Fight Scene they're tagged in across the whole catalog, sorted by most favorited, reusing the same movie/fight-scene cards used everywhere else. Linked from a movie's Cast section and from the "Featuring" line on a fight scene card — there's no dedicated actor search yet, so browsing there is the only way in for now.
 
+Biography, birthday, and place of birth (when TMDB has them) are shown under the actor's name, live-fetched via their `person.tmdbId` on each page view rather than stored in our own database — if TMDB is unreachable or has nothing on record, that section is simply omitted.
+
 ## Editorial Reviews
 
 Admins can write a long-form review (up to 10,000 characters) for any movie, shown alongside the cast list. There's one review per movie — any admin can write or update it, and the page just tracks who last touched it.

--- a/src/app/actors/[personId]/page.tsx
+++ b/src/app/actors/[personId]/page.tsx
@@ -1,18 +1,17 @@
+import { cache } from "react";
 import Image from "next/image";
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { tmdbImageUrl } from "@/lib/tmdb";
+import { tmdbImageUrl, getTmdbPersonDetails } from "@/lib/tmdb";
 import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries, getFightSceneFavoriteCounts } from "@/lib/fight-scenes";
 import { MovieCard } from "@/components/movie-card";
 import { FightSceneResultCard } from "@/components/fight-scene-result-card";
 import { getRatingSummaries } from "@/lib/ratings";
 
-export default async function ActorPage({ params }: { params: Promise<{ personId: string }> }) {
-  const { personId } = await params;
-  const session = await auth();
-
-  const person = await prisma.person.findUnique({
+const getPerson = cache((personId: string) =>
+  prisma.person.findUnique({
     where: { id: personId },
     include: {
       castCredits: { include: { movie: true }, orderBy: { movie: { releaseDate: "desc" } } },
@@ -29,10 +28,55 @@ export default async function ActorPage({ params }: { params: Promise<{ personId
         orderBy: { fightScene: { createdAt: "desc" } },
       },
     },
-  });
+  }),
+);
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ personId: string }>;
+}): Promise<Metadata> {
+  const { personId } = await params;
+  const person = await getPerson(personId);
+  if (!person) return {};
+
+  const knownFor = person.castCredits
+    .filter((c) => c.movie.status === "APPROVED")
+    .slice(0, 3)
+    .map((c) => c.movie.title);
+  const description =
+    knownFor.length > 0
+      ? `${person.name}, known for ${knownFor.join(", ")}, on Kung Fu Movie DB.`
+      : `${person.name} on Kung Fu Movie DB.`;
+  const image = tmdbImageUrl(person.profilePath, "w500");
+
+  return {
+    title: person.name,
+    description,
+    openGraph: {
+      title: person.name,
+      description,
+      images: image ? [image] : undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: person.name,
+      description,
+      images: image ? [image] : undefined,
+    },
+  };
+}
+
+export default async function ActorPage({ params }: { params: Promise<{ personId: string }> }) {
+  const { personId } = await params;
+  const session = await auth();
+
+  const person = await getPerson(personId);
   if (!person) {
     notFound();
   }
+
+  const bio = await getTmdbPersonDetails(person.tmdbId).catch(() => null);
 
   // A pending (not yet admin-approved) movie is excluded the same way it's
   // excluded from every other public listing.
@@ -72,13 +116,29 @@ export default async function ActorPage({ params }: { params: Promise<{ personId
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
-      <div className="mb-8 flex items-center gap-4">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start">
         <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-full bg-neutral-800">
           {person.profilePath && (
             <Image src={tmdbImageUrl(person.profilePath, "w200") ?? ""} alt={person.name} fill sizes="96px" className="object-cover" />
           )}
         </div>
-        <h1 className="text-2xl font-bold text-white">{person.name}</h1>
+        <div>
+          <h1 className="text-2xl font-bold text-white">{person.name}</h1>
+          {bio && (
+            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm text-neutral-400">
+              {bio.birthday && (
+                <span>
+                  Born {new Date(bio.birthday).toLocaleDateString(undefined, { dateStyle: "long" })}
+                  {bio.deathday && ` — Died ${new Date(bio.deathday).toLocaleDateString(undefined, { dateStyle: "long" })}`}
+                </span>
+              )}
+              {bio.place_of_birth && <span>{bio.place_of_birth}</span>}
+            </div>
+          )}
+          {bio?.biography && (
+            <p className="mt-2 max-w-2xl whitespace-pre-line text-sm text-neutral-300">{bio.biography}</p>
+          )}
+        </div>
       </div>
 
       <h2 className="mb-4 text-xl font-bold text-white">Filmography</h2>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 import { requireReviewerSession } from "@/lib/require-admin";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 // REVIEWER only gets Movies (pending-submission review, not the full
 // catalog — see AdminMoviesPage) and Fight Scene Tags, plus the same

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,5 +1,11 @@
 import { headers } from "next/headers";
+import type { Metadata } from "next";
 import { ForgotPasswordForm } from "./forgot-password-form";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+  robots: { index: false, follow: false },
+};
 
 export default async function ForgotPasswordPage() {
   const nonce = (await headers()).get("x-nonce");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,10 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000"),
-  title: "Kung Fu Movie DB",
+  title: {
+    default: "Kung Fu Movie DB",
+    template: "%s | Kung Fu Movie DB",
+  },
   description: "An IMDB-style database for kung fu and martial arts films.",
 };
 

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  robots: { index: false, follow: false },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -1,9 +1,13 @@
+import { cache } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import type { Session } from "next-auth";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { tmdbImageUrl, resolvePosterUrl } from "@/lib/tmdb";
+import { truncate } from "@/lib/text";
 import { getCommunityRatingSummary, getEditorsRatingSummary } from "@/lib/ratings";
 import { getMovieRecommenders } from "@/lib/movie-recommendations";
 import { getDiscussionPage } from "@/lib/discussion";
@@ -24,11 +28,8 @@ import { EditorialReview } from "@/components/editorial-review";
 import { PosterOverrideControl } from "@/components/poster-override-control";
 import { RecommendationControl } from "@/components/recommendation-control";
 
-export default async function MovieDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const session = await auth();
-
-  const movie = await prisma.movie.findUnique({
+const getMovie = cache((id: string) =>
+  prisma.movie.findUnique({
     where: { id },
     include: {
       genres: true,
@@ -37,23 +38,71 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         include: { person: true },
       },
     },
-  });
+  }),
+);
+
+// Pending (member-submitted, not yet admin-approved) movies are invisible to
+// everyone except the person who submitted them and admins/reviewers (who
+// need to see it to review it) — everyone else gets the same 404 as a
+// nonexistent movie, matching how it's already hidden from every public
+// listing/search. generateMetadata is a side door onto the same data (page
+// title, OG tags), so it needs the identical check, not just the page body.
+function isMovieVisible(
+  movie: { status: string; submittedById: string | null },
+  session: Session | null,
+) {
+  return (
+    movie.status === "APPROVED" ||
+    session?.user?.role === "ADMIN" ||
+    session?.user?.role === "REVIEWER" ||
+    session?.user?.id === movie.submittedById
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const [movie, session] = await Promise.all([getMovie(id), auth()]);
+  if (!movie || !isMovieVisible(movie, session)) return {};
+
+  const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
+  const title = year ? `${movie.title} (${year})` : movie.title;
+  const description = movie.overview
+    ? truncate(movie.overview, 200)
+    : `${movie.title} on Kung Fu Movie DB.`;
+  const image = resolvePosterUrl(movie, "w500");
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: image ? [image] : undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: image ? [image] : undefined,
+    },
+  };
+}
+
+export default async function MovieDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const session = await auth();
+
+  const movie = await getMovie(id);
 
   if (!movie) {
     notFound();
   }
 
-  // Pending (member-submitted, not yet admin-approved) movies are invisible
-  // to everyone except the person who submitted them and admins/reviewers
-  // (who need to see it to review it) — everyone else gets the same 404 as
-  // a nonexistent movie, matching how it's already hidden from every public
-  // listing/search.
-  const isVisible =
-    movie.status === "APPROVED" ||
-    session?.user?.role === "ADMIN" ||
-    session?.user?.role === "REVIEWER" ||
-    session?.user?.id === movie.submittedById;
-  if (!isVisible) {
+  if (!isMovieVisible(movie, session)) {
     notFound();
   }
 

--- a/src/app/my-lists/page.tsx
+++ b/src/app/my-lists/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 import { auth } from "@/lib/auth";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 // /my-lists now lives at /members/[username] (your own profile), so
 // existing links/bookmarks to this URL still work.

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,5 +1,11 @@
 import { headers } from "next/headers";
+import type { Metadata } from "next";
 import { RegisterForm } from "./register-form";
+
+export const metadata: Metadata = {
+  title: "Create Account",
+  robots: { index: false, follow: false },
+};
 
 export default async function RegisterPage() {
   const nonce = (await headers()).get("x-nonce");

--- a/src/app/reset-password/layout.tsx
+++ b/src/app/reset-password/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+  robots: { index: false, follow: false },
+};
+
+export default function ResetPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/search/fight-scenes/page.tsx
+++ b/src/app/search/fight-scenes/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries, getFightSceneFavoriteCounts } from "@/lib/fight-scenes";
@@ -6,6 +7,10 @@ import { FightSceneResultCard } from "@/components/fight-scene-result-card";
 import { RatingStarInput } from "@/components/rating-star-input";
 import { AutocompleteFilterInput } from "@/components/autocomplete-filter-input";
 import type { Prisma } from "@/generated/prisma/client";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
 
 interface FightSceneSearchParams {
   q?: string;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import { prisma } from "@/lib/prisma";
 import { getRatingSummaries, getEditorsRatingSummaries } from "@/lib/ratings";
 import { getMovieRecommendationsByMovieIds } from "@/lib/movie-recommendations";
@@ -8,6 +9,10 @@ import { MovieCard } from "@/components/movie-card";
 import { AutocompleteFilterInput } from "@/components/autocomplete-filter-input";
 import { RatingStarInput } from "@/components/rating-star-input";
 import type { Movie, Prisma } from "@/generated/prisma/client";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
 
 interface SearchPageParams {
   q?: string;

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import { prisma } from "@/lib/prisma";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default async function VerifyEmailPage({
   searchParams,

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,4 @@
+export function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -120,3 +120,17 @@ export async function discoverMoviesByKeywords(keywordIds: number[], page: numbe
     ...(originCountry ? { with_origin_country: originCountry } : {}),
   });
 }
+
+export interface TmdbPersonDetails {
+  id: number;
+  name: string;
+  biography: string;
+  birthday: string | null;
+  deathday: string | null;
+  place_of_birth: string | null;
+  profile_path: string | null;
+}
+
+export async function getTmdbPersonDetails(tmdbId: number) {
+  return tmdbFetch<TmdbPersonDetails>(`/person/${tmdbId}`);
+}


### PR DESCRIPTION
## Summary

- `generateMetadata` on `/movies/[id]` and `/actors/[personId]`: real title/description/OG/Twitter tags derived from each page's own data, deduped against the page body via React `cache()` instead of querying twice. The movie page's `generateMetadata` re-applies the same pending-movie visibility check as the page body (`status === "APPROVED"` or submitter/admin/reviewer), so a member-submitted movie awaiting approval can't leak its title/synopsis through metadata as a side door.
- Actor pages (`/actors/[personId]`, shipped in PR #28) now show biography/birthday/place-of-birth, live-fetched from TMDB via the existing `person.tmdbId` — never cached in our own DB, gracefully omitted if TMDB is unreachable or has nothing on record for that person.
- `noindex` added to thin/duplicate-content and account-only pages: both search pages (`follow: true`, so crawlers still reach movie/actor pages linked from results) and login/register/forgot-password/reset-password/verify-email/my-lists (`follow: false`). The whole `/admin` subtree gets one `noindex` on its shared layout rather than one per admin page.
- Root `layout.tsx` gets a title template (`%s | Kung Fu Movie DB`), reusing the `metadataBase` it already had rather than introducing a second one.

This was originally scoped and half-built in an earlier session, before `/actors/[personId]` (PR #28) and much of the current movie-page shape existed. Rebuilt from scratch against current `master` rather than rebasing the stale branch — see `DECISIONS.md` for the judgment calls made along the way.

No schema changes.

## Checklist

- [x] `README.md` updated (Actor Pages section now documents the bio addition)
- [ ] `.env.example` updated — not applicable, no new env var
- [x] `DECISIONS.md` updated (new Feature Decisions entry)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run build` succeeds across all 46 routes.
- Ran against seeded local data:
  - Movie and actor pages render correct `<title>`/OG/Twitter meta tags.
  - Manually flipped a movie to `PENDING` and confirmed an anonymous request 404s with the generic site title — no leak of the pending movie's name via metadata.
  - Confirmed `noindex` renders on every thin/account page (`/search`, `/search/fight-scenes`, `/login`, `/register`, `/my-lists`, `/verify-email`, `/forgot-password`, `/reset-password`, `/admin`).
  - Confirmed actor-page bio section is gracefully omitted when TMDB has nothing on record, and an unknown actor id still 404s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_