### PR TITLE
Improve error handling for poster uploads

### DIFF
--- a/src/app/api/admin/movies/[id]/poster/route.ts
+++ b/src/app/api/admin/movies/[id]/poster/route.ts
@@ -12,18 +12,6 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // put() throws if this isn't set, which — left uncaught — surfaces to the
-  // admin as a bare 500 with no JSON body (the client's generic "Something
-  // went wrong" fallback). Checking up front, before doing any of the
-  // request work below, gives a message that actually says what's wrong.
-  if (!process.env.BLOB_READ_WRITE_TOKEN) {
-    console.error("Poster upload failed: BLOB_READ_WRITE_TOKEN is not configured.");
-    return NextResponse.json(
-      { error: "Poster uploads aren't configured on this deployment (missing BLOB_READ_WRITE_TOKEN)." },
-      { status: 500 },
-    );
-  }
-
   const { id: movieId } = await params;
   const movie = await prisma.movie.findUnique({ where: { id: movieId } });
   if (!movie) {

--- a/src/app/api/admin/movies/[id]/poster/route.ts
+++ b/src/app/api/admin/movies/[id]/poster/route.ts
@@ -12,6 +12,18 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  // put() throws if this isn't set, which — left uncaught — surfaces to the
+  // admin as a bare 500 with no JSON body (the client's generic "Something
+  // went wrong" fallback). Checking up front, before doing any of the
+  // request work below, gives a message that actually says what's wrong.
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    console.error("Poster upload failed: BLOB_READ_WRITE_TOKEN is not configured.");
+    return NextResponse.json(
+      { error: "Poster uploads aren't configured on this deployment (missing BLOB_READ_WRITE_TOKEN)." },
+      { status: 500 },
+    );
+  }
+
   const { id: movieId } = await params;
   const movie = await prisma.movie.findUnique({ where: { id: movieId } });
   if (!movie) {
@@ -37,10 +49,16 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Poster must be a JPEG, PNG, or WebP image." }, { status: 400 });
   }
 
-  const blob = await put(`movie-posters/${movieId}-${Date.now()}`, bytes, {
-    access: "public",
-    contentType: sniffedType,
-  });
+  let blob;
+  try {
+    blob = await put(`movie-posters/${movieId}-${Date.now()}`, bytes, {
+      access: "public",
+      contentType: sniffedType,
+    });
+  } catch (error) {
+    console.error("Poster upload to Vercel Blob failed:", error);
+    return NextResponse.json({ error: "Failed to upload poster. Please try again." }, { status: 500 });
+  }
 
   // Best-effort cleanup of the previous override so replacing a poster
   // doesn't silently accumulate orphaned blobs — not worth failing the


### PR DESCRIPTION
## Summary

Adds proactive validation and error handling to the movie poster upload endpoint to surface configuration and runtime errors with clear, actionable messages instead of generic 500 responses.

**Changes:**
1. **Upfront environment validation**: Check that `BLOB_READ_WRITE_TOKEN` is configured before attempting the upload, returning a descriptive 500 error if missing. This prevents the Vercel Blob `put()` call from throwing an uncaught error that surfaces as a bare 500 with no JSON body.
2. **Blob upload error handling**: Wrap the `put()` call in a try-catch to gracefully handle upload failures (network issues, service errors, etc.) with a user-friendly error message instead of an unhandled exception.

Both changes include console logging for debugging.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no user-facing feature, env var, setup step, or seed data changed)
- [x] `.env.example` updated if a new environment variable was added (not applicable — no new env vars)
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral (not applicable — bug fix/error handling improvement)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Verified by:
- Confirming the endpoint returns a descriptive error when `BLOB_READ_WRITE_TOKEN` is unset
- Confirming the endpoint gracefully handles Blob upload failures with a user-friendly message
- Existing tests continue to pass

https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu