### PR TITLE
Lower Fight Count's bounds check from 0-100 to 0-20

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -514,7 +514,7 @@ aggregation:
 - Editing requires a verified email (same bar as fight scene/movie
   submission); ADMIN/REVIEWER are exempt from that specific check, same as
   every other admin-gated action in this app trusts the account itself.
-- Value is bounds-checked (0–100) server-side.
+- Value is bounds-checked (0–20) server-side.
 - Edits are rate-limited via the same Upstash limiter used for other
   content-mutation endpoints (`fightCountEditLimiter`).
 - Every edit is logged to a new `FightCountEdit` table (movie, editor,

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ A **Fight Count** — a member-maintained "true" number of fights in the movie �
 This is deliberately a single shared value, not an aggregate of individual member submissions like ratings are: any verified member can overwrite it directly, last edit wins, no consensus step. That simplicity trades away any built-in resistance to a bad-faith edit, so it's paired with guardrails rather than left unprotected:
 
 - **Verified email required** — same bar as fight scene submission and movie submission. Admins/reviewers are exempt from this specific check (trusted like every other admin action), not from the feature generally.
-- **Bounds-checked** (0–100) server-side, to block obviously-wrong values outright rather than relying on someone noticing later.
+- **Bounds-checked** (0–20) server-side, to block obviously-wrong values outright rather than relying on someone noticing later.
 - **Rate-limited** per user through the same Upstash limiter used for other content-mutation endpoints.
 - **Full edit history**, visible to everyone on the movie page (not just admins) — who changed it, from what value to what, and when. The value itself has no approval step, so this history is the only accountability trail; anyone can use it to spot and revert a bad edit, not just moderators.
 

--- a/src/app/api/movies/[id]/fight-count/route.ts
+++ b/src/app/api/movies/[id]/fight-count/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { isEmailVerified } from "@/lib/verification";
 import { checkRateLimit, fightCountEditLimiter } from "@/lib/rate-limit";
 
-const MAX_FIGHT_COUNT = 100;
+const MAX_FIGHT_COUNT = 20;
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await auth();

--- a/src/components/fight-count-control.tsx
+++ b/src/components/fight-count-control.tsx
@@ -11,7 +11,7 @@ export interface FightCountEditEntry {
   editedBy: { username: string };
 }
 
-const MAX_FIGHT_COUNT = 100;
+const MAX_FIGHT_COUNT = 20;
 
 export function FightCountControl({
   movieId,


### PR DESCRIPTION
## Summary

Follow-up to #56 — `MAX_FIGHT_COUNT` was set to 100 without actually checking on the right upper bound at the time. Tightened to 20 (0–20 range), which also further reduces how far a bad-faith edit can skew the value before it's caught, on top of the existing guardrails (verified-email requirement, rate limiting, full edit history).

No schema change — this is an app-level validation constant in two places (API route + client component), both updated together so client and server agree, plus the README/DECISIONS mentions of the old range.

## Checklist

- [x] `README.md` updated (bound mention corrected to 0–20)
- [ ] `.env.example` updated — not applicable, no new env var
- [x] `DECISIONS.md` updated (existing Fight Count entry's bound mention corrected)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Signed in as the seeded member account and hit `PATCH /api/movies/[id]/fight-count` directly: a value of 25 correctly 400s with the updated error message ("...between 0 and 20"), a value of 20 correctly succeeds.
- `npm run lint` and `npm run build` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_