### PR TITLE
Add historical-timeline page to the backlog

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1118,3 +1118,13 @@ time.
   feature (secret generation/storage, an enrollment flow, backup/recovery
   codes, a recovery path for a lost authenticator), not a small hardening
   patch. Revisit as its own scoped piece of work.
+- **Historical timeline page** — a page visually plotting movies along a
+  timeline of Chinese historical periods/dynasties each movie is *set in*
+  (not its real-world release date, which `Movie.releaseDate` already
+  covers). The real gap: no source has this data. TMDB doesn't track a
+  film's in-story historical setting, so it'd need a new admin-curated
+  attribute — likely a fixed period/dynasty taxonomy (mirroring the
+  `Genre`/`FightSceneTag` pattern) rather than free text, to keep the
+  timeline groupable/orderable. The timeline visualization itself (not
+  just the data model) is also a real, non-trivial UI build, not a
+  reskin of an existing list/grid view.


### PR DESCRIPTION
## Summary

Docs-only — adds a `DECISIONS.md` backlog entry for a page visually plotting movies along a timeline of the Chinese historical period each is *set in* (not release date, which `Movie.releaseDate` already covers).

Flags the real blocker: no data source (TMDB included) tracks a film's in-story historical setting, so this needs a new admin-curated attribute — likely a fixed period/dynasty taxonomy (mirroring the `Genre`/`FightSceneTag` pattern) rather than free text — before any timeline visualization work can start. The visualization itself is also a real UI build, not a reskin of an existing list/grid.

## Checklist

- [ ] `README.md` updated — not applicable, backlog entry only, no feature shipped
- [ ] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated (this is the change)
- [x] `npm run lint` and `npm run build` — not applicable, no code changed

## Test plan

Docs-only change, nothing to test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_