### PR TITLE
Add meme generator to the backlog

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1128,3 +1128,22 @@ time.
   timeline groupable/orderable. The timeline visualization itself (not
   just the data model) is also a real, non-trivial UI build, not a
   reskin of an existing list/grid view.
+- **Meme generator** — a tool letting members caption/remix an image into
+  a meme, seeded from a fight scene or movie. Image-sourcing was already
+  scoped: `youtubeThumbnailUrl()` (`src/lib/youtube.ts`) gives a free,
+  ToS-safe still today, already proven via the fight-scene permalink
+  pages' Open Graph previews, but it's the *video's* thumbnail, not a
+  frame at that scene's `youtubeStartSeconds` — for a long/compilation
+  video the thumbnail may not show the tagged fight at all. Explicitly
+  ruled out: extracting a real frame at that timestamp server-side
+  (yt-dlp/ffmpeg or similar), since downloading YouTube video content
+  violates their ToS and adds a fragile dependency YouTube could break at
+  any time. Three options on the table, undecided: (1) use the
+  video-level thumbnail as-is, simple but sometimes inaccurate; (2) let
+  the fight-scene submitter/admin attach their own still per scene,
+  mirroring the existing admin poster-override pattern (manual upload to
+  Vercel Blob) — more accurate, more UI, needs someone to actually
+  screenshot it; (3) fall back to the movie's poster/backdrop if neither
+  of the above feels reliable enough. Also undecided: the
+  caption/text-overlay editor itself, and whether generated memes get
+  stored/shared or are download-only.


### PR DESCRIPTION
## Summary

Docs-only — adds a `DECISIONS.md` backlog entry for a meme generator (caption/remix tool seeded from a fight scene or movie image).

Records the image-sourcing discussion already had on this: `youtubeThumbnailUrl()` (`src/lib/youtube.ts`) is a free, ToS-safe still already proven via the fight-scene permalink pages' Open Graph previews — but it's the *video's* thumbnail, not a frame at the scene's actual `youtubeStartSeconds`, so for a long/compilation video it may not show the tagged fight at all. Real frame extraction (yt-dlp/ffmpeg or similar) is explicitly ruled out — downloading YouTube video content violates their ToS and is a fragile dependency YouTube could break at any time. Three options left open, undecided: use the video-level thumbnail as-is, let the submitter/admin attach a manual still per scene (mirroring the existing admin poster-override pattern), or fall back to the movie's poster/backdrop. The caption/text-overlay editor and whether generated memes get stored/shared vs. download-only are also undecided.

## Checklist

- [ ] `README.md` updated — not applicable, backlog entry only, no feature shipped
- [ ] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated (this is the change)
- [x] `npm run lint` and `npm run build` — not applicable, no code changed

## Test plan

Docs-only change, nothing to test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_