### PR TITLE
Fix mobile nav links being right-packed with a gap on the left

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -21,7 +21,7 @@ export async function Navbar() {
         <div className="order-3 w-full sm:order-2 sm:w-auto sm:flex-1">
           <SearchBar />
         </div>
-        <nav className="order-2 flex w-full flex-wrap items-center justify-end gap-x-4 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap">
+        <nav className="order-2 flex w-full flex-wrap items-center justify-start gap-x-4 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap">
           <Link href="/search" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
             Movies
           </Link>


### PR DESCRIPTION
## Summary

Pure bug fix — no user-facing feature/behavior change beyond the visual alignment fix.

On mobile, the navbar's link row (`Movies`, `Fights`, `Lists`, `+ Add Movie`, `Sign in`/user menu, `Join`) is a `flex-wrap` container that's `w-full` below the `sm:` breakpoint. It also had `justify-end`, which packed the wrapped links against the right edge of that full-width row instead of starting them flush under the logo — leaving a visible empty gap on the left, as reported with a screenshot from an actual iPhone.

Fix: `justify-end` → `justify-start` in `src/components/navbar.tsx`. This class was already a no-op on desktop (`sm:w-auto` sizes the nav to its content, so there's no leftover space for `justify-content` to act on there — positioning at that breakpoint comes entirely from `sm:ml-auto`), so the change only affects the mobile layout.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — pure bug fix, no user-facing feature/env var/setup step/data model change)
- [ ] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call (or not applicable — one-line alignment fix, not a judgment call)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npm run lint` and `npm run build` locally — both pass.
- Took Playwright screenshots at 390px (iPhone width, matching the reported screenshot), 320px (narrowest common mobile width), and 1280px (desktop) — confirmed the mobile nav now starts flush left under the logo with no gap, and the desktop layout is unchanged (nav still right-aligned via `sm:ml-auto`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_