### PR TITLE
Tighten mobile nav gap so Join fits on the same line

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -21,7 +21,7 @@ export async function Navbar() {
         <div className="order-3 w-full sm:order-2 sm:w-auto sm:flex-1">
           <SearchBar />
         </div>
-        <nav className="order-2 flex w-full flex-wrap items-center justify-start gap-x-4 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap">
+        <nav className="order-2 flex w-full flex-wrap items-center justify-start gap-x-3 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap sm:gap-x-4">
           <Link href="/search" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
             Movies
           </Link>


### PR DESCRIPTION
## Summary

Follow-up to #61 (mobile nav left-alignment fix). After that fix, the nav links started flush left as intended, but "Join" still wrapped to its own row at typical phone widths (~390px, e.g. iPhone 12/13/14-class) because `gap-x-4` (16px between each item) left just enough total width that "Join" didn't fit on the first line alongside "Movies Fights Lists + Add Movie Sign in".

Fix: `gap-x-4` → `gap-x-3` on mobile only (`sm:gap-x-4` restores the original spacing at the desktop breakpoint, where the nav is a single non-wrapping row anyway). That's enough to fit everything on one line at 390px and wider.

**Caveat:** at the narrowest common mobile width (320px, iPhone SE 1st-gen class — largely obsolete hardware at this point), "Join" still wraps to a second line — the content is wider than the viewport regardless of gap size, and squeezing the gap further hurts tap-target spacing without actually fixing it at that width. This isn't a regression — it wrapped at 320px before this change too.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — pure styling tweak, no user-facing feature/env var/setup step/data model change)
- [ ] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call (or not applicable — one-line spacing tweak, not a judgment call)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npm run lint` and `npm run build` locally — both pass.
- Took Playwright screenshots at 390px (matches the reported screenshot's device class) confirming all nav items including Join now sit on one line; confirmed 320px still wraps regardless of gap size (tested down to `gap-x-2`, which didn't help either, so kept the more readable `gap-x-3`); confirmed desktop (1280px) is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hqmL2SBUewmgcbCjdcCpV)_