### PR TITLE
Rename site from Kung Fu Movie Database to Kung Fu Sauce

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Working on this repo
 
-This is a Next.js + Prisma + Auth.js app (Kung Fu Movie Database). Multiple
+This is a Next.js + Prisma + Auth.js app (Kung Fu Sauce). Multiple
 conversations work on this repo in parallel, each usually on its own feature
 branch and PR, so a few conventions keep things from drifting apart.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -478,6 +478,37 @@ both self-contained enough not to need their own entry.
   works against the length/breach-check requirements added earlier in
   this same pass.
 
+### Site renamed from "Kung Fu Movie Database" to "Kung Fu Sauce"
+**PR #TBD.** Admin decision, not a technical judgment call — recorded here
+so the rename shows up in the same place every other foundational milestone
+does, and so a future conversation searching for why the brand name doesn't
+match an old screenshot/PR title finds the answer instead of assuming a
+docs typo.
+
+- Every user-visible and code-visible occurrence of the old name updated in
+  one pass rather than piecemeal: `README.md`, `CLAUDE.md`, `package.json`'s
+  `name` field, the root layout's `<title>` default/template, the About
+  page's metadata, verification/password-reset email subject and from-name,
+  and the OG description fallback text on movie and actor pages. Found via
+  a repo-wide grep for every old-name variant (`Kung Fu Movie Database`,
+  `Kung Fu Movie DB`, `Kung Fu DB`, `kung-fu-movie-database`) rather than
+  updating only the files that came to mind, since a partial rename (new
+  name on the homepage, old name still in a password-reset email subject
+  line) would be a worse, more confusing state than the rename not
+  happening yet.
+- **Left open**: `src/components/logo.tsx`'s 師父 (Sifu — "master/teacher")
+  prefix on the navbar wordmark was kept as-is rather than removed. It read
+  naturally next to "Kung Fu DB" but its fit alongside "Sauce" is a real
+  brand-tone question (respectful master-title vs. a more playful name)
+  that wasn't part of what was asked — flagged for a deliberate call
+  rather than silently dropped or silently kept.
+- **Not touched, deliberately out of scope for a code-level rename**: the
+  actual Vercel project name/dashboard, the live domain, and the local dev
+  database name (`kungfu_dev` in `.env.example`'s example connection
+  string) — none of those are user-visible brand surfaces, and renaming
+  the local DB specifically would force every existing local setup to
+  recreate it for a purely cosmetic reason.
+
 ## Feature Decisions
 
 ### Error monitoring added without wrapping next.config.ts in Sentry's build plugin

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -496,12 +496,15 @@ docs typo.
   name on the homepage, old name still in a password-reset email subject
   line) would be a worse, more confusing state than the rename not
   happening yet.
-- **Left open**: `src/components/logo.tsx`'s 師父 (Sifu — "master/teacher")
-  prefix on the navbar wordmark was kept as-is rather than removed. It read
-  naturally next to "Kung Fu DB" but its fit alongside "Sauce" is a real
-  brand-tone question (respectful master-title vs. a more playful name)
-  that wasn't part of what was asked — flagged for a deliberate call
-  rather than silently dropped or silently kept.
+- **Resolved**: `src/components/logo.tsx`'s 師父 (Sifu — "master/teacher")
+  prefix on the navbar wordmark was flagged rather than silently kept or
+  dropped, since it read naturally next to "Kung Fu DB" but its fit
+  alongside "Sauce" was a real brand-tone question, not a mechanical part
+  of the rename. Admin call: drop it. The wordmark is now plain "Kung Fu
+  Sauce," inheriting the `<Link>`'s existing `text-red-600` directly rather
+  than leaving a now-pointless white-text `<span>` wrapper behind — without
+  a colored prefix to contrast against, the old two-tone split had nothing
+  left to split.
 - **Not touched, deliberately out of scope for a code-level rename**: the
   actual Vercel project name/dashboard, the live domain, and the local dev
   database name (`kungfu_dev` in `.env.example`'s example connection

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kung Fu Movie Database
+# Kung Fu Sauce
 
 An IMDB-style website for kung fu and martial arts films, built for martial arts movie enthusiasts. Movie data is sourced from [TMDB](https://www.themoviedb.org/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kung-fu-movie-database",
+  "name": "kung-fu-sauce",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kung-fu-movie-database",
+      "name": "kung-fu-sauce",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kung-fu-movie-database",
+  "name": "kung-fu-sauce",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "About — Kung Fu Movie DB",
-  description: "What Kung Fu Movie DB is, how the catalog is curated, and how to reach an admin.",
+  title: "About — Kung Fu Sauce",
+  description: "What Kung Fu Sauce is, how the catalog is curated, and how to reach an admin.",
 };
 
 export default function AboutPage() {

--- a/src/app/actors/[personId]/page.tsx
+++ b/src/app/actors/[personId]/page.tsx
@@ -46,8 +46,8 @@ export async function generateMetadata({
     .map((c) => c.movie.title);
   const description =
     knownFor.length > 0
-      ? `${person.name}, known for ${knownFor.join(", ")}, on Kung Fu Movie DB.`
-      : `${person.name} on Kung Fu Movie DB.`;
+      ? `${person.name}, known for ${knownFor.join(", ")}, on Kung Fu Sauce.`
+      : `${person.name} on Kung Fu Sauce.`;
   const image = tmdbImageUrl(person.profilePath, "w500");
 
   return {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,8 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000"),
   title: {
-    default: "Kung Fu Movie DB",
-    template: "%s | Kung Fu Movie DB",
+    default: "Kung Fu Sauce",
+    template: "%s | Kung Fu Sauce",
   },
   description: "An IMDB-style database for kung fu and martial arts films.",
 };

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -79,7 +79,7 @@ export async function generateMetadata({
   const title = year ? `${movie.title} (${year})` : movie.title;
   const description = movie.overview
     ? truncate(movie.overview, 200)
-    : `${movie.title} on Kung Fu Movie DB.`;
+    : `${movie.title} on Kung Fu Sauce.`;
   const image = resolvePosterUrl(movie, "w500");
 
   return {

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -8,7 +8,7 @@ export function Logo() {
       href="/"
       className="flex shrink-0 items-center whitespace-nowrap font-serif text-lg font-bold tracking-tight text-red-600"
     >
-      師父<span className="text-white">Kung Fu DB</span>
+      師父<span className="text-white">Kung Fu Sauce</span>
     </Link>
   );
 }

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -8,7 +8,7 @@ export function Logo() {
       href="/"
       className="flex shrink-0 items-center whitespace-nowrap font-serif text-lg font-bold tracking-tight text-red-600"
     >
-      師父<span className="text-white">Kung Fu Sauce</span>
+      Kung Fu Sauce
     </Link>
   );
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -19,9 +19,9 @@ export async function sendVerificationEmail(email: string, verifyUrl: string) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      from: process.env.EMAIL_FROM ?? "Kung Fu Movie DB <onboarding@resend.dev>",
+      from: process.env.EMAIL_FROM ?? "Kung Fu Sauce <onboarding@resend.dev>",
       to: email,
-      subject: "Verify your email — Kung Fu Movie DB",
+      subject: "Verify your email — Kung Fu Sauce",
       html: `<p>Click <a href="${verifyUrl}">this link</a> to verify your email address. It expires in 24 hours.</p>`,
     }),
   });
@@ -46,9 +46,9 @@ export async function sendPasswordResetEmail(email: string, resetUrl: string) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      from: process.env.EMAIL_FROM ?? "Kung Fu Movie DB <onboarding@resend.dev>",
+      from: process.env.EMAIL_FROM ?? "Kung Fu Sauce <onboarding@resend.dev>",
       to: email,
-      subject: "Reset your password — Kung Fu Movie DB",
+      subject: "Reset your password — Kung Fu Sauce",
       html: `<p>Click <a href="${resetUrl}">this link</a> to set a new password. It expires in 1 hour. If you didn't request this, ignore this email — your password won't change.</p>`,
     }),
   });


### PR DESCRIPTION
## Summary

Admin decision to rebrand the site as "Kung Fu Sauce." Every occurrence of the old name updated in one pass, found via a repo-wide grep rather than piecemeal:

- `README.md`, `CLAUDE.md`, `package.json`'s `name` field
- Root layout's `<title>` default/template
- About page's metadata
- Verification and password-reset email subject lines + from-name
- Navbar logo wordmark
- Open Graph description fallback text on movie and actor pages

Full reasoning (including what was deliberately left open and what was deliberately left untouched) is in `DECISIONS.md`.

**Left open, not decided in this PR**: whether the navbar logo's 師父 (Sifu — "master/teacher") prefix still fits paired with "Sauce" — it read naturally next to the old name, but that's a brand-tone call for the admins, not something to resolve unilaterally here. Currently reads "師父Kung Fu Sauce."

**Deliberately not touched**: the actual Vercel project name/dashboard, the live domain (a `.film` domain has been chosen separately but isn't wired up yet), and the local dev database name (`kungfu_dev`) — none of those are user-visible brand surfaces, and renaming the DB specifically would force every existing local setup to recreate it for a cosmetic reason only.

## Test plan

- [x] `npm run lint` and `npm run build` pass
- [x] Repo-wide grep for every old-name variant (`Kung Fu Movie Database`, `Kung Fu Movie DB`, `Kung Fu DB`, `kung-fu-movie-database`) returns no remaining occurrences outside `package-lock.json` (auto-synced)
- [x] Manually verified live in `next dev`: homepage `<title>`, navbar logo, and `/about` page title all correctly show "Kung Fu Sauce"

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7q6UaTzPPFpwCCssdZLQV)_