### PR TITLE
Rekey admin badge icons by user id instead of username

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -512,6 +512,22 @@ docs typo.
   the local DB specifically would force every existing local setup to
   recreate it for a purely cosmetic reason.
 
+### Admin badge icons rekeyed by user id, not username
+**PR #TBD.** Found as a real, reproduced bug, not a theoretical one: an
+admin's custom recommendation-badge icon (`src/lib/admin-badge-icons.ts`)
+silently reverted to the generic colored-circle placeholder the moment
+that admin's username changed, because the lookup table was keyed by the
+username string itself. Usernames are a mutable, member-changeable field
+(currently only changeable via a direct database update, since there's no
+self-service username-change feature yet) — keying anything long-lived by
+one instead of a stable id is exactly the kind of drift this project's own
+`CLAUDE.md` conventions (derive from immutable relations, not
+hand-duplicated strings) exist to prevent, and this table was the one spot
+that didn't follow it. Rekeyed by the admin's `User.id` instead, matching
+how `adminBadgeColor()` in the same feature already keys off id rather
+than username — the fix makes the two functions consistent with each
+other, not just with the general principle.
+
 ## Feature Decisions
 
 ### Error monitoring added without wrapping next.config.ts in Sentry's build plugin

--- a/src/components/recommended-badge.tsx
+++ b/src/components/recommended-badge.tsx
@@ -25,7 +25,7 @@ export function RecommendedBadges({
   return (
     <div className="flex items-center -space-x-1.5">
       {recommenders.map((recommender) => {
-        const icon = ADMIN_BADGE_ICONS[recommender.username];
+        const icon = ADMIN_BADGE_ICONS[recommender.id];
         if (icon) {
           return (
             <Image

--- a/src/lib/admin-badge-icons.ts
+++ b/src/lib/admin-badge-icons.ts
@@ -6,6 +6,5 @@
 // admin has a real icon image (under public/badges/); admins without one
 // still fall back to the placeholder automatically.
 export const ADMIN_BADGE_ICONS: Record<string, string> = {
-  // TODO: replace with the real production user id (see chat/PR notes).
-  "REPLACE_WITH_PRODUCTION_USER_ID": "/badges/wang-seal.png",
+  cms87tzb7000fqstccf83d453: "/badges/wang-seal.png",
 };

--- a/src/lib/admin-badge-icons.ts
+++ b/src/lib/admin-badge-icons.ts
@@ -1,7 +1,11 @@
-// Real per-admin badge icons, keyed by username — takes precedence over the
-// generic colored-circle placeholder in RecommendedBadges. Add an entry here
-// once an admin has a real icon image (under public/badges/); admins without
-// one still fall back to the placeholder automatically.
+// Real per-admin badge icons, keyed by the admin's (immutable) user id, not
+// their username — a username is a mutable, member-changeable field (see
+// DECISIONS.md), so keying this table by it silently orphaned an admin's
+// badge the moment they renamed. Takes precedence over the generic
+// colored-circle placeholder in RecommendedBadges. Add an entry here once an
+// admin has a real icon image (under public/badges/); admins without one
+// still fall back to the placeholder automatically.
 export const ADMIN_BADGE_ICONS: Record<string, string> = {
-  son323: "/badges/wang-seal.png",
+  // TODO: replace with the real production user id (see chat/PR notes).
+  "REPLACE_WITH_PRODUCTION_USER_ID": "/badges/wang-seal.png",
 };


### PR DESCRIPTION
## Summary

Fixes a real, reproduced bug: `src/lib/admin-badge-icons.ts` looked up an admin's custom recommendation-badge icon by their **username** string, so the icon silently reverted to the generic colored-circle placeholder the instant that admin renamed. Usernames are a mutable, member-changeable field — keying a long-lived lookup table by one instead of a stable id was the actual root cause, not the rename itself.

- Rekeyed `ADMIN_BADGE_ICONS` by `User.id`, matching how `adminBadgeColor()` in the same feature already correctly keys off id rather than username — the fix makes both functions consistent with each other.
- Updated `src/components/recommended-badge.tsx`'s lookup to match.
- Filled in the real production user id for the existing badge entry.
- `DECISIONS.md` updated with the full reasoning.

## Test plan

- [x] `npm run lint` and `npm run build` pass
- [x] Root cause confirmed by reading the actual lookup code (not assumed) after the reporter observed their badge disappear following a username change

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7q6UaTzPPFpwCCssdZLQV)_