### PR TITLE
Add a Community Activity feed to the homepage

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -554,10 +554,11 @@ query recent rows across existing tables rather than introduce an
   or discussion tied to a movie still awaiting admin approval is excluded
   until the movie goes live, so the feed can't leak a pending submission
   through a side door.
-- Placed below the movie rails and above Recent Reviews by Editors —
-  grouped with the other community-generated homepage section rather than
-  above the fold, since it's a discovery/engagement feature, not a hero
-  element competing with the trending carousel for first-glance attention.
+- Placed at the very bottom of the homepage, below Recent Reviews by
+  Editors (moved there by explicit direction after initially sitting above
+  Recent Reviews) — the last section on the page rather than competing
+  with the movie rails or the trending carousel for above-the-fold
+  attention.
 
 **Reworked from one merged/sorted list to three grouped columns, in
 preview (same PR).** The first version merged all three event types by

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -544,12 +544,11 @@ query recent rows across existing tables rather than introduce an
   single "created" moment to point at (a rating can change), so they'd
   need either a separate history table (violates the no-new-schema goal)
   or showing a merely-updated rating as if it were new (misleading).
-- Each event type is queried independently (`take: 8` each) and merged by
-  `createdAt` in application code, rather than one UNION query — Prisma
-  doesn't support cross-model UNIONs without raw SQL, and three cheap
-  indexed queries (each already sorted by an indexed/default-ordered
-  `createdAt`) is simpler than hand-writing and maintaining raw SQL for
-  what's ultimately a lightweight homepage widget.
+- Each event type is queried independently — Prisma doesn't support
+  cross-model UNIONs without raw SQL, and three cheap indexed queries (each
+  already sorted by an indexed/default-ordered `createdAt`) is simpler than
+  hand-writing and maintaining raw SQL for what's ultimately a lightweight
+  homepage widget.
 - Reuses the exact pending-movie visibility rule already established
   everywhere else (search, homepage rails, weekly-trending): a fight scene
   or discussion tied to a movie still awaiting admin approval is excluded
@@ -559,6 +558,21 @@ query recent rows across existing tables rather than introduce an
   grouped with the other community-generated homepage section rather than
   above the fold, since it's a discovery/engagement feature, not a hero
   element competing with the trending carousel for first-glance attention.
+
+**Reworked from one merged/sorted list to three grouped columns, in
+preview (same PR).** The first version merged all three event types by
+`createdAt` into a single flat top-8 list, styled as plain text sentences.
+Feedback on the preview was that this was both too plain (no visual weight
+beyond a line of text) and had the wrong content mix (a burst of one event
+type — e.g. several fight scenes tagged close together — could crowd the
+other two types out of the top 8 entirely, so "Community Activity" didn't
+reliably read as covering the whole community). Reworked to three
+independently-limited columns (`take: 3` each, not merged), one per event
+type, so every type is guaranteed visibility regardless of how bursty any
+one type's activity is. Each row became a bordered card reusing Recent
+Reviews by Editors' poster-thumbnail-plus-byline layout (for the two
+movie-linked types) rather than a plain sentence, for visual parity with
+the site's other homepage feed section.
 
 ### Error monitoring added without wrapping next.config.ts in Sentry's build plugin
 **PR #TBD.** Closes a real gap: server errors were already visible via

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -530,6 +530,36 @@ other, not just with the general principle.
 
 ## Feature Decisions
 
+### Community Activity feed merges three existing tables, no new schema
+**PR #65.** Backlog ask was for a homepage strip surfacing recent member
+activity to make the site "feel alive" — deliberately scoped to be cheap:
+query recent rows across existing tables rather than introduce an
+`ActivityLog`/event-sourcing table.
+
+- Three event types, chosen because each already has a natural "who did
+  what, when" shape with no extra state needed: a `FightScene` created, a
+  `MemberList` created, and a top-level `DiscussionPost` created (replies
+  excluded — a reply isn't "starting" a discussion). Ratings and likes
+  were considered and dropped: they're per-user upserts with no reliable
+  single "created" moment to point at (a rating can change), so they'd
+  need either a separate history table (violates the no-new-schema goal)
+  or showing a merely-updated rating as if it were new (misleading).
+- Each event type is queried independently (`take: 8` each) and merged by
+  `createdAt` in application code, rather than one UNION query — Prisma
+  doesn't support cross-model UNIONs without raw SQL, and three cheap
+  indexed queries (each already sorted by an indexed/default-ordered
+  `createdAt`) is simpler than hand-writing and maintaining raw SQL for
+  what's ultimately a lightweight homepage widget.
+- Reuses the exact pending-movie visibility rule already established
+  everywhere else (search, homepage rails, weekly-trending): a fight scene
+  or discussion tied to a movie still awaiting admin approval is excluded
+  until the movie goes live, so the feed can't leak a pending submission
+  through a side door.
+- Placed below the movie rails and above Recent Reviews by Editors —
+  grouped with the other community-generated homepage section rather than
+  above the fold, since it's a discovery/engagement feature, not a hero
+  element competing with the trending carousel for first-glance attention.
+
 ### Error monitoring added without wrapping next.config.ts in Sentry's build plugin
 **PR #TBD.** Closes a real gap: server errors were already visible via
 `console.error` (captured in Vercel's function logs), but a client-side

--- a/README.md
+++ b/README.md
@@ -326,14 +326,18 @@ shared-not-per-author model.
 ## Community Activity
 
 A "Community Activity" section on the homepage, below the movie rails and
-above Recent Reviews by Editors, surfaces the 8 most recent
-member-generated events across the site, merged from three existing
-tables with no new schema: a fight scene tagged, a custom list created, or
-a discussion thread started (top-level posts only — a reply doesn't count
-as starting a new one). Each row links through to the relevant movie,
-list, or discussion, plus the member's profile. Same visibility rule as
-every other public listing: an event tied to a still-pending (not yet
-admin-approved) movie stays out of the feed until the movie is approved.
+above Recent Reviews by Editors, surfaces recent member-generated events
+from three existing tables with no new schema — a fight scene tagged, a
+custom list created, or a discussion thread started (top-level posts
+only — a reply doesn't count as starting a new one). Shown as three
+columns, one per event type (the 3 most recent of each), rather than one
+merged list, so a burst of activity in one type can't crowd the other two
+out of view. Movie-linked rows (fight scenes, discussions) show a poster
+thumbnail, matching Recent Reviews by Editors' card layout. Each row links
+through to the relevant movie, list, or discussion, plus the member's
+profile. Same visibility rule as every other public listing: an event tied
+to a still-pending (not yet admin-approved) movie stays out of the feed
+until the movie is approved.
 
 ## Web Analytics
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Social sharing (native share sheet on mobile, copy-link/X/Facebook/Reddit fallback on desktop) on movie and fight scene pages
 - A public `/lists` page for browsing every member's public custom lists (sorted by newest-updated or most-liked, paginated), plus a `/leaderboard` page ranking the Most-Liked Lists (members can like each other's public custom lists) and Top Curators (members with the most movies across their own lists) — see [Member Lists & Profiles](#member-lists--profiles) below
 - Admin-published News & Updates posts: the latest one shown as a teaser banner on the homepage, with a full paginated archive at `/news` — see [News & Updates](#news--updates) below
+- A "Community Activity" feed on the homepage surfacing the site's most recent fight scenes tagged, lists created, and discussions started, across all members — see [Community Activity](#community-activity) below
 - Security headers (CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) on every response, plus rate limiting and CAPTCHA on login, registration, forgot-password, and content-creation endpoints — see [Security](#security) below
 
 ## Tech Stack
@@ -321,6 +322,18 @@ Recent Reviews by Editors feed already established.
 
 Any admin can edit or delete any post, mirroring Editorial Reviews'
 shared-not-per-author model.
+
+## Community Activity
+
+A "Community Activity" section on the homepage, below the movie rails and
+above Recent Reviews by Editors, surfaces the 8 most recent
+member-generated events across the site, merged from three existing
+tables with no new schema: a fight scene tagged, a custom list created, or
+a discussion thread started (top-level posts only — a reply doesn't count
+as starting a new one). Each row links through to the relevant movie,
+list, or discussion, plus the member's profile. Same visibility rule as
+every other public listing: an event tied to a still-pending (not yet
+admin-approved) movie stays out of the feed until the movie is approved.
 
 ## Web Analytics
 

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ shared-not-per-author model.
 
 ## Community Activity
 
-A "Community Activity" section on the homepage, below the movie rails and
-above Recent Reviews by Editors, surfaces recent member-generated events
+A "Community Activity" section at the very bottom of the homepage, below
+Recent Reviews by Editors, surfaces recent member-generated events
 from three existing tables with no new schema — a fight scene tagged, a
 custom list created, or a discussion thread started (top-level posts
 only — a reply doesn't count as starting a new one). Shown as three

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -504,14 +504,16 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           myFavoriteSceneIds={myFavoriteFightSceneIds}
         />
 
-        <DiscussionThread
-          movieId={movie.id}
-          initialPosts={serializedPosts}
-          initialNextCursor={discussionPage.nextCursor}
-          signedIn={!!session?.user}
-          currentUserId={session?.user?.id ?? null}
-          isAdmin={session?.user?.role === "ADMIN"}
-        />
+        <div id="discussion">
+          <DiscussionThread
+            movieId={movie.id}
+            initialPosts={serializedPosts}
+            initialNextCursor={discussionPage.nextCursor}
+            signedIn={!!session?.user}
+            currentUserId={session?.user?.id ?? null}
+            isAdmin={session?.user?.role === "ADMIN"}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,20 +4,23 @@ import { getRatingSummaries, getTopRatedMovies } from "@/lib/ratings";
 import { getMovieRecommendationsByMovieIds } from "@/lib/movie-recommendations";
 import { getRecentEditorialReviews } from "@/lib/editorial-reviews";
 import { getLatestNewsPost } from "@/lib/news";
+import { getRecentActivity } from "@/lib/activity";
 import { HeroCarousel } from "@/components/hero-carousel";
 import { MovieRail } from "@/components/movie-rail";
 import { RecentReviewsFeed, type RecentReviewItem } from "@/components/recent-reviews-feed";
 import { NewsTeaser } from "@/components/news-teaser";
+import { ActivityFeed } from "@/components/activity-feed";
 
 export const revalidate = 3600;
 
 export default async function HomePage() {
-  const [featured, recent, topRated, recentReviews, latestNewsPost] = await Promise.all([
+  const [featured, recent, topRated, recentReviews, latestNewsPost, recentActivity] = await Promise.all([
     getFeaturedMovies(),
     prisma.movie.findMany({ where: { status: "APPROVED" }, orderBy: { createdAt: "desc" }, take: 12 }),
     getTopRatedMovies(),
     getRecentEditorialReviews(),
     getLatestNewsPost(),
+    getRecentActivity(),
   ]);
 
   const recentReviewItems: RecentReviewItem[] = recentReviews.map((review) => ({
@@ -76,6 +79,8 @@ export default async function HomePage() {
         movies={topRatedWithRecommendations}
         emptyMessage="No community ratings yet — be the first to rate a movie."
       />
+
+      <ActivityFeed items={recentActivity} />
 
       <RecentReviewsFeed reviews={recentReviewItems} />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,7 @@ export default async function HomePage() {
         emptyMessage="No community ratings yet — be the first to rate a movie."
       />
 
-      <ActivityFeed items={recentActivity} />
+      <ActivityFeed activity={recentActivity} />
 
       <RecentReviewsFeed reviews={recentReviewItems} />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,9 +80,9 @@ export default async function HomePage() {
         emptyMessage="No community ratings yet — be the first to rate a movie."
       />
 
-      <ActivityFeed activity={recentActivity} />
-
       <RecentReviewsFeed reviews={recentReviewItems} />
+
+      <ActivityFeed activity={recentActivity} />
     </div>
   );
 }

--- a/src/components/activity-feed.tsx
+++ b/src/components/activity-feed.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import type { ActivityItem } from "@/lib/activity";
+
+function timeAgo(date: Date) {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+const linkClass = "text-neutral-300 underline decoration-neutral-700 underline-offset-2 hover:text-red-400";
+
+function ActivityDescription({ item }: { item: ActivityItem }) {
+  switch (item.type) {
+    case "FIGHT_SCENE":
+      return (
+        <>
+          tagged a new fight scene in{" "}
+          <Link href={`/movies/${item.movieId}`} className={linkClass}>
+            {item.movieTitle}
+          </Link>
+        </>
+      );
+    case "LIST":
+      return (
+        <>
+          created a new list{" "}
+          <Link href={`/lists/${item.listId}`} className={linkClass}>
+            &ldquo;{item.listName}&rdquo;
+          </Link>
+        </>
+      );
+    case "DISCUSSION":
+      return (
+        <>
+          started a discussion on{" "}
+          <Link href={`/movies/${item.movieId}#discussion`} className={linkClass}>
+            {item.movieTitle}
+          </Link>
+        </>
+      );
+  }
+}
+
+export function ActivityFeed({ items }: { items: ActivityItem[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-8">
+      <h2 className="mb-4 font-serif text-xl font-bold text-white">Community Activity</h2>
+      <div className="divide-y divide-neutral-800 border-y border-neutral-800">
+        {items.map((item) => (
+          <div key={`${item.type}-${item.id}`} className="flex items-center justify-between gap-3 py-2.5 text-sm">
+            <p className="min-w-0 truncate text-neutral-300">
+              <Link href={`/members/${item.username}`} className="font-medium text-white hover:text-red-400">
+                {item.username}
+              </Link>{" "}
+              <ActivityDescription item={item} />
+            </p>
+            <span className="shrink-0 text-xs text-neutral-500">{timeAgo(item.createdAt)}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/activity-feed.tsx
+++ b/src/components/activity-feed.tsx
@@ -1,5 +1,12 @@
+import Image from "next/image";
 import Link from "next/link";
-import type { ActivityItem } from "@/lib/activity";
+import { resolvePosterUrl } from "@/lib/tmdb";
+import type {
+  DiscussionActivityItem,
+  FightSceneActivityItem,
+  ListActivityItem,
+  RecentActivity,
+} from "@/lib/activity";
 
 function timeAgo(date: Date) {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
@@ -12,58 +19,107 @@ function timeAgo(date: Date) {
   return `${days}d ago`;
 }
 
-const linkClass = "text-neutral-300 underline decoration-neutral-700 underline-offset-2 hover:text-red-400";
-
-function ActivityDescription({ item }: { item: ActivityItem }) {
-  switch (item.type) {
-    case "FIGHT_SCENE":
-      return (
-        <>
-          tagged a new fight scene in{" "}
-          <Link href={`/movies/${item.movieId}`} className={linkClass}>
-            {item.movieTitle}
-          </Link>
-        </>
-      );
-    case "LIST":
-      return (
-        <>
-          created a new list{" "}
-          <Link href={`/lists/${item.listId}`} className={linkClass}>
-            &ldquo;{item.listName}&rdquo;
-          </Link>
-        </>
-      );
-    case "DISCUSSION":
-      return (
-        <>
-          started a discussion on{" "}
-          <Link href={`/movies/${item.movieId}#discussion`} className={linkClass}>
-            {item.movieTitle}
-          </Link>
-        </>
-      );
-  }
+function ByLine({ username, createdAt }: { username: string; createdAt: Date }) {
+  return (
+    <p className="text-xs text-neutral-500">
+      <Link href={`/members/${username}`} className="hover:text-red-400">
+        {username}
+      </Link>{" "}
+      · {timeAgo(createdAt)}
+    </p>
+  );
 }
 
-export function ActivityFeed({ items }: { items: ActivityItem[] }) {
-  if (items.length === 0) return null;
+function PosterThumb({ movie }: { movie: { id: string; title: string; posterPath: string | null; posterOverrideUrl: string | null } }) {
+  const posterUrl = resolvePosterUrl(movie, "w200");
+  return (
+    <Link href={`/movies/${movie.id}`} className="shrink-0">
+      <div className="relative aspect-2/3 w-10 overflow-hidden rounded bg-neutral-800">
+        {posterUrl ? <Image src={posterUrl} alt={movie.title} fill sizes="40px" className="object-cover" /> : null}
+      </div>
+    </Link>
+  );
+}
+
+function FightSceneCard({ item }: { item: FightSceneActivityItem }) {
+  return (
+    <article className="flex gap-2.5 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+      <PosterThumb movie={item.movie} />
+      <div className="min-w-0">
+        <Link href={`/movies/${item.movie.id}`} className="block truncate text-sm font-bold text-white hover:text-red-400">
+          {item.sceneTitle}
+        </Link>
+        <p className="truncate text-xs text-neutral-400">{item.movie.title}</p>
+        <ByLine username={item.username} createdAt={item.createdAt} />
+      </div>
+    </article>
+  );
+}
+
+function ListCard({ item }: { item: ListActivityItem }) {
+  return (
+    <article className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+      <Link href={`/lists/${item.listId}`} className="block truncate text-sm font-bold text-white hover:text-red-400">
+        {item.listName}
+      </Link>
+      <ByLine username={item.username} createdAt={item.createdAt} />
+    </article>
+  );
+}
+
+function DiscussionCard({ item }: { item: DiscussionActivityItem }) {
+  return (
+    <article className="flex gap-2.5 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+      <PosterThumb movie={item.movie} />
+      <div className="min-w-0">
+        <Link href={`/movies/${item.movie.id}#discussion`} className="block truncate text-sm font-bold text-white hover:text-red-400">
+          {item.movie.title}
+        </Link>
+        <p className="truncate text-xs text-neutral-400">{item.excerpt}</p>
+        <ByLine username={item.username} createdAt={item.createdAt} />
+      </div>
+    </article>
+  );
+}
+
+function ActivityColumn({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-red-500">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+export function ActivityFeed({ activity }: { activity: RecentActivity }) {
+  const { fightScenes, lists, discussions } = activity;
+  if (fightScenes.length === 0 && lists.length === 0 && discussions.length === 0) return null;
 
   return (
     <section className="mx-auto w-full max-w-6xl px-4 py-8">
       <h2 className="mb-4 font-serif text-xl font-bold text-white">Community Activity</h2>
-      <div className="divide-y divide-neutral-800 border-y border-neutral-800">
-        {items.map((item) => (
-          <div key={`${item.type}-${item.id}`} className="flex items-center justify-between gap-3 py-2.5 text-sm">
-            <p className="min-w-0 truncate text-neutral-300">
-              <Link href={`/members/${item.username}`} className="font-medium text-white hover:text-red-400">
-                {item.username}
-              </Link>{" "}
-              <ActivityDescription item={item} />
-            </p>
-            <span className="shrink-0 text-xs text-neutral-500">{timeAgo(item.createdAt)}</span>
-          </div>
-        ))}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {fightScenes.length > 0 && (
+          <ActivityColumn label="Fight Scenes">
+            {fightScenes.map((item) => (
+              <FightSceneCard key={item.id} item={item} />
+            ))}
+          </ActivityColumn>
+        )}
+        {lists.length > 0 && (
+          <ActivityColumn label="New Lists">
+            {lists.map((item) => (
+              <ListCard key={item.id} item={item} />
+            ))}
+          </ActivityColumn>
+        )}
+        {discussions.length > 0 && (
+          <ActivityColumn label="Discussions">
+            {discussions.map((item) => (
+              <DiscussionCard key={item.id} item={item} />
+            ))}
+          </ActivityColumn>
+        )}
       </div>
     </section>
   );

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,56 +1,76 @@
 import { prisma } from "@/lib/prisma";
 
-const ACTIVITY_FEED_LIMIT = 8;
-// Overfetch per event type before merging and sorting, so a burst of one
-// type (e.g. several fight scenes tagged in a row) can't crowd out
-// still-recent events of another type once everything's combined.
-const PER_TYPE_FETCH_LIMIT = 8;
+// Grouped by type rather than one merged/sorted list — a burst of one type
+// (e.g. several fight scenes tagged in a row) shouldn't be able to push the
+// other two types out of view entirely, the way a flat top-N list allowed.
+const PER_TYPE_LIMIT = 3;
 
-export type ActivityItem =
-  | {
-      type: "FIGHT_SCENE";
-      id: string;
-      createdAt: Date;
-      username: string;
-      movieId: string;
-      movieTitle: string;
-    }
-  | {
-      type: "LIST";
-      id: string;
-      createdAt: Date;
-      username: string;
-      listId: string;
-      listName: string;
-    }
-  | {
-      type: "DISCUSSION";
-      id: string;
-      createdAt: Date;
-      username: string;
-      movieId: string;
-      movieTitle: string;
-    };
+interface MoviePoster {
+  id: string;
+  title: string;
+  posterPath: string | null;
+  posterOverrideUrl: string | null;
+}
 
-export async function getRecentActivity(limit = ACTIVITY_FEED_LIMIT): Promise<ActivityItem[]> {
+export interface FightSceneActivityItem {
+  id: string;
+  createdAt: Date;
+  username: string;
+  sceneTitle: string;
+  movie: MoviePoster;
+}
+
+export interface ListActivityItem {
+  id: string;
+  createdAt: Date;
+  username: string;
+  listId: string;
+  listName: string;
+}
+
+export interface DiscussionActivityItem {
+  id: string;
+  createdAt: Date;
+  username: string;
+  excerpt: string;
+  movie: MoviePoster;
+}
+
+export interface RecentActivity {
+  fightScenes: FightSceneActivityItem[];
+  lists: ListActivityItem[];
+  discussions: DiscussionActivityItem[];
+}
+
+const DISCUSSION_EXCERPT_LENGTH = 100;
+
+function excerpt(content: string) {
+  if (content.length <= DISCUSSION_EXCERPT_LENGTH) return content;
+  return `${content.slice(0, DISCUSSION_EXCERPT_LENGTH).trimEnd()}…`;
+}
+
+export async function getRecentActivity(limit = PER_TYPE_LIMIT): Promise<RecentActivity> {
+  const moviePosterSelect = { select: { id: true, title: true, posterPath: true, posterOverrideUrl: true } } as const;
+
   const [fightScenes, lists, discussions] = await Promise.all([
     // Same visibility rule as every other public listing: a fight scene on a
     // still-pending movie stays invisible until the movie is approved.
     prisma.fightScene.findMany({
       where: { isDeleted: false, movie: { status: "APPROVED" } },
       orderBy: { createdAt: "desc" },
-      take: PER_TYPE_FETCH_LIMIT,
+      take: limit,
       select: {
         id: true,
+        title: true,
         createdAt: true,
         submittedBy: { select: { username: true } },
-        movie: { select: { id: true, title: true } },
+        movie: moviePosterSelect,
       },
     }),
     // Lists are public by design from creation, so no extra filtering needed.
     prisma.memberList.findMany({
       orderBy: { createdAt: "desc" },
-      take: PER_TYPE_FETCH_LIMIT,
+      take: limit,
       select: {
         id: true,
         name: true,
@@ -63,42 +83,38 @@ export async function getRecentActivity(limit = ACTIVITY_FEED_LIMIT): Promise<Ac
     prisma.discussionPost.findMany({
       where: { isDeleted: false, parentId: null, movie: { status: "APPROVED" } },
       orderBy: { createdAt: "desc" },
-      take: PER_TYPE_FETCH_LIMIT,
+      take: limit,
       select: {
         id: true,
+        content: true,
         createdAt: true,
         user: { select: { username: true } },
-        movie: { select: { id: true, title: true } },
+        movie: moviePosterSelect,
       },
     }),
   ]);
 
-  const items: ActivityItem[] = [
-    ...fightScenes.map((s) => ({
-      type: "FIGHT_SCENE" as const,
+  return {
+    fightScenes: fightScenes.map((s) => ({
       id: s.id,
       createdAt: s.createdAt,
       username: s.submittedBy.username,
-      movieId: s.movie.id,
-      movieTitle: s.movie.title,
+      sceneTitle: s.title,
+      movie: s.movie,
     })),
-    ...lists.map((l) => ({
-      type: "LIST" as const,
+    lists: lists.map((l) => ({
       id: l.id,
       createdAt: l.createdAt,
       username: l.user.username,
       listId: l.id,
       listName: l.name,
     })),
-    ...discussions.map((d) => ({
-      type: "DISCUSSION" as const,
+    discussions: discussions.map((d) => ({
       id: d.id,
       createdAt: d.createdAt,
       username: d.user.username,
-      movieId: d.movie.id,
-      movieTitle: d.movie.title,
+      excerpt: excerpt(d.content),
+      movie: d.movie,
     })),
-  ];
-
-  return items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()).slice(0, limit);
+  };
 }

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+
+const ACTIVITY_FEED_LIMIT = 8;
+// Overfetch per event type before merging and sorting, so a burst of one
+// type (e.g. several fight scenes tagged in a row) can't crowd out
+// still-recent events of another type once everything's combined.
+const PER_TYPE_FETCH_LIMIT = 8;
+
+export type ActivityItem =
+  | {
+      type: "FIGHT_SCENE";
+      id: string;
+      createdAt: Date;
+      username: string;
+      movieId: string;
+      movieTitle: string;
+    }
+  | {
+      type: "LIST";
+      id: string;
+      createdAt: Date;
+      username: string;
+      listId: string;
+      listName: string;
+    }
+  | {
+      type: "DISCUSSION";
+      id: string;
+      createdAt: Date;
+      username: string;
+      movieId: string;
+      movieTitle: string;
+    };
+
+export async function getRecentActivity(limit = ACTIVITY_FEED_LIMIT): Promise<ActivityItem[]> {
+  const [fightScenes, lists, discussions] = await Promise.all([
+    // Same visibility rule as every other public listing: a fight scene on a
+    // still-pending movie stays invisible until the movie is approved.
+    prisma.fightScene.findMany({
+      where: { isDeleted: false, movie: { status: "APPROVED" } },
+      orderBy: { createdAt: "desc" },
+      take: PER_TYPE_FETCH_LIMIT,
+      select: {
+        id: true,
+        createdAt: true,
+        submittedBy: { select: { username: true } },
+        movie: { select: { id: true, title: true } },
+      },
+    }),
+    // Lists are public by design from creation, so no extra filtering needed.
+    prisma.memberList.findMany({
+      orderBy: { createdAt: "desc" },
+      take: PER_TYPE_FETCH_LIMIT,
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        user: { select: { username: true } },
+      },
+    }),
+    // Top-level posts only ("started a discussion") — a reply isn't a new
+    // discussion. Same pending-movie visibility rule as fight scenes above.
+    prisma.discussionPost.findMany({
+      where: { isDeleted: false, parentId: null, movie: { status: "APPROVED" } },
+      orderBy: { createdAt: "desc" },
+      take: PER_TYPE_FETCH_LIMIT,
+      select: {
+        id: true,
+        createdAt: true,
+        user: { select: { username: true } },
+        movie: { select: { id: true, title: true } },
+      },
+    }),
+  ]);
+
+  const items: ActivityItem[] = [
+    ...fightScenes.map((s) => ({
+      type: "FIGHT_SCENE" as const,
+      id: s.id,
+      createdAt: s.createdAt,
+      username: s.submittedBy.username,
+      movieId: s.movie.id,
+      movieTitle: s.movie.title,
+    })),
+    ...lists.map((l) => ({
+      type: "LIST" as const,
+      id: l.id,
+      createdAt: l.createdAt,
+      username: l.user.username,
+      listId: l.id,
+      listName: l.name,
+    })),
+    ...discussions.map((d) => ({
+      type: "DISCUSSION" as const,
+      id: d.id,
+      createdAt: d.createdAt,
+      username: d.user.username,
+      movieId: d.movie.id,
+      movieTitle: d.movie.title,
+    })),
+  ];
+
+  return items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()).slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Adds a "Community Activity" section to the homepage — addressing the backlog ask for something that makes the homepage "feel alive on every visit" beyond just movie content. Went through one redesign in preview (see below).

- New `src/lib/activity.ts`: `getRecentActivity()` queries three existing tables independently (`FightScene`, `MemberList`, top-level `DiscussionPost`), each capped at 3 most recent. **No schema change.**
- New `src/components/activity-feed.tsx`: three columns, one per event type ("Fight Scenes", "New Lists", "Discussions"), each row a bordered card. Movie-linked types (fight scenes, discussions) show a poster thumbnail, reusing the same layout pattern as Recent Reviews by Editors.
- Wired into `src/app/page.tsx`, placed below the movie rails and above Recent Reviews by Editors.
- `src/app/movies/[id]/page.tsx`: wrapped `DiscussionThread` in `<div id="discussion">` so a discussion card can deep-link straight to the thread.

**Design iteration:** the first version merged all three types by `createdAt` into one flat top-8 list of plain-text sentences. Preview feedback was that this was too plain (no visual weight) and had the wrong content mix — a burst of one event type could crowd the other two out of the top 8 entirely. Reworked to three independently-limited columns so every type is always represented, with card styling instead of plain text. Full reasoning in the updated `DECISIONS.md` entry.

**Visibility:** fight scenes and discussion posts on a still-pending (not yet admin-approved) movie are excluded, matching the same rule applied everywhere else in the app. Lists are public from creation already. Soft-deleted fight scenes/posts are excluded.

## Checklist

- [x] `README.md` updated — "Community Activity" section (describes the final grouped-columns design) plus a Features bullet.
- [ ] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated — entry covers both the initial design and the in-preview rework.
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npm run lint` and `npm run build` locally after each iteration — both pass.
- Seeded multiple test rows across all three event types locally (including a movie with two fight scenes, to confirm per-type limiting works), took Playwright screenshots confirming the three-column layout, poster thumbnails, and sort order within each column.
- Extracted and verified every link's `href` in the first iteration (movie page, list permalink, `#discussion`-anchored movie page, member profile) — link generation logic is unchanged in the rework.
- Removed all test data before each commit.
