### PR TITLE
Fix post-auth UI lag on login and register

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -663,6 +663,50 @@ platform with public handles.
   confirmed `generateUniqueUsername("nashpopob")` correctly detects the
   collision and suffixes to `nashpopob1`.
 
+### Login switched from fetch-based signIn() to a Server Action with a native form
+Two real, reported bugs shared one root cause: `/login` called
+`next-auth/react`'s `signIn()` from a `fetch()`-driven `onSubmit` handler
+(`preventDefault()`, POST via `fetch`, then a separate JS-triggered
+navigation). Browsers only reliably offer to save credentials for a
+genuine `<form>` POST that completes with a navigation — a
+`fetch()`-intercepted submit doesn't look like a real form submission to
+the password manager, so Chrome/Firefox never prompted to save. The same
+split also caused a visible ~1s lag before the header reflected being
+signed in, since the fetch and the follow-up navigation were two separate
+round trips instead of one browser-orchestrated request.
+
+- **Rebuilt `/login` as a Server Component (`page.tsx`) + Client Component
+  (`login-form.tsx`) + Server Action (`actions.ts`)**, following the
+  pattern Next.js's own App Router auth guide recommends
+  (`<form action={serverAction}>` + `useActionState`) rather than
+  hand-rolling CSRF token plumbing for a raw POST to Auth.js's
+  `/api/auth/callback/credentials` endpoint — Server Actions get Next's
+  built-in same-origin protection for free, and Auth.js v5's server-side
+  `signIn()` (imported from `@/lib/auth`, not `next-auth/react`) is
+  designed to be called directly from one.
+- **Error handling**: `signIn()` throws `NEXT_REDIRECT` internally on
+  success (Next's own mechanism for a Server Action to trigger a
+  navigation) and throws `AuthError`/`CredentialsSignin` on failure. The
+  action catches only `AuthError` and returns a message for
+  `useActionState` to render inline; anything else is rethrown so the
+  success redirect isn't accidentally swallowed.
+- **`/register`'s post-signup navigation got a smaller, related fix**:
+  it stayed fetch-based (registration also needs the JSON `/api/register`
+  call and captcha token, not just a sign-in), but its post-success
+  `router.push("/")` immediately followed by an unawaited `router.refresh()`
+  had the same race as the login lag — if `/` was already prefetched while
+  signed out, `push()` could paint that stale cached page before
+  `refresh()`'s background re-fetch caught up. Swapped both for a single
+  hard `window.location.href = "/"`, matching what login effectively does
+  via its Server Action redirect.
+- **Verified against a real dev server, not just lint/build**: Playwright
+  against a local Postgres — wrong password stays on `/login` and shows
+  the existing generic error; correct password redirects to `/` in ~500ms
+  with the header immediately reflecting signed-in state; registration
+  redirects to `/` the same way. Google OAuth sign-in (`next-auth/react`'s
+  `signIn("google", ...)`, a redirect-based flow) was untouched — this
+  only reworked the credentials path.
+
 ## Feature Decisions
 
 ### Community Activity feed merges three existing tables, no new schema

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { AuthError } from "next-auth";
+import { signIn } from "@/lib/auth";
+
+export async function authenticate(_prevState: string | undefined, formData: FormData) {
+  try {
+    await signIn("credentials", {
+      email: formData.get("email"),
+      password: formData.get("password"),
+      redirectTo: (formData.get("callbackUrl") as string) || "/",
+    });
+  } catch (error) {
+    // signIn() redirects internally on success by throwing Next's special
+    // NEXT_REDIRECT error — that must propagate, not be swallowed here, or
+    // the browser never navigates. Only an actual auth failure (AuthError)
+    // should turn into a returned message instead.
+    if (error instanceof AuthError) {
+      return "Invalid email or password.";
+    }
+    throw error;
+  }
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useActionState } from "react";
+import { signIn } from "next-auth/react";
+import Link from "next/link";
+import { authenticate } from "./actions";
+
+export function LoginForm({ callbackUrl }: { callbackUrl: string }) {
+  const [error, formAction, pending] = useActionState(authenticate, undefined);
+
+  return (
+    <div className="mx-auto flex w-full max-w-sm flex-1 flex-col justify-center px-4 py-16">
+      <h1 className="mb-6 text-2xl font-bold text-white">Sign in</h1>
+
+      <button
+        onClick={() => signIn("google", { callbackUrl })}
+        className="mb-4 flex items-center justify-center rounded-md border border-neutral-700 bg-neutral-900 py-2 text-sm font-medium text-neutral-100 hover:bg-neutral-800"
+      >
+        Continue with Google
+      </button>
+
+      <div className="my-4 flex items-center gap-3 text-xs text-neutral-500">
+        <div className="h-px flex-1 bg-neutral-800" />
+        or
+        <div className="h-px flex-1 bg-neutral-800" />
+      </div>
+
+      {/* A real <form action={serverAction}> submission, not a fetch()
+          intercepted with preventDefault — browsers only reliably offer to
+          save credentials for a genuine form POST that completes with a
+          navigation, and this also collapses sign-in into a single
+          browser-orchestrated request instead of a fetch followed by a
+          separate client-triggered navigation. */}
+      <form action={formAction} className="flex flex-col gap-3">
+        <input type="hidden" name="callbackUrl" value={callbackUrl} />
+        <input
+          type="email"
+          name="email"
+          required
+          autoComplete="email"
+          placeholder="Email"
+          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <input
+          type="password"
+          name="password"
+          required
+          autoComplete="current-password"
+          placeholder="Password"
+          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <Link href="/forgot-password" className="-mt-1 self-end text-xs text-neutral-400 hover:text-red-500 hover:underline">
+          Forgot password?
+        </Link>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-red-700 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+        >
+          {pending ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-neutral-400">
+        No account?{" "}
+        <Link href="/register" className="text-red-500 hover:underline">
+          Register
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,99 +1,10 @@
-"use client";
+import { LoginForm } from "./login-form";
 
-import { signIn } from "next-auth/react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
-
-export default function LoginPage() {
-  return (
-    <Suspense>
-      <LoginForm />
-    </Suspense>
-  );
-}
-
-function LoginForm() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setLoading(true);
-    setError(null);
-    const result = await signIn("credentials", {
-      email,
-      password,
-      redirect: false,
-      callbackUrl,
-    });
-    setLoading(false);
-    if (result?.error) {
-      setError("Invalid email or password.");
-      return;
-    }
-    window.location.href = result?.url ?? callbackUrl;
-  }
-
-  return (
-    <div className="mx-auto flex w-full max-w-sm flex-1 flex-col justify-center px-4 py-16">
-      <h1 className="mb-6 text-2xl font-bold text-white">Sign in</h1>
-
-      <button
-        onClick={() => signIn("google", { callbackUrl })}
-        className="mb-4 flex items-center justify-center rounded-md border border-neutral-700 bg-neutral-900 py-2 text-sm font-medium text-neutral-100 hover:bg-neutral-800"
-      >
-        Continue with Google
-      </button>
-
-      <div className="my-4 flex items-center gap-3 text-xs text-neutral-500">
-        <div className="h-px flex-1 bg-neutral-800" />
-        or
-        <div className="h-px flex-1 bg-neutral-800" />
-      </div>
-
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-        <input
-          type="email"
-          required
-          autoComplete="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
-        />
-        <input
-          type="password"
-          required
-          autoComplete="current-password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
-        />
-        <Link href="/forgot-password" className="-mt-1 self-end text-xs text-neutral-400 hover:text-red-500 hover:underline">
-          Forgot password?
-        </Link>
-        {error && <p className="text-sm text-red-500">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="rounded-md bg-red-700 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
-        >
-          {loading ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
-
-      <p className="mt-6 text-center text-sm text-neutral-400">
-        No account?{" "}
-        <Link href="/register" className="text-red-500 hover:underline">
-          Register
-        </Link>
-      </p>
-    </div>
-  );
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}) {
+  const { callbackUrl } = await searchParams;
+  return <LoginForm callbackUrl={callbackUrl ?? "/"} />;
 }

--- a/src/app/register/register-form.tsx
+++ b/src/app/register/register-form.tsx
@@ -2,12 +2,10 @@
 
 import { signIn } from "next-auth/react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Turnstile } from "@/components/turnstile";
 
 export function RegisterForm({ nonce }: { nonce: string | null }) {
-  const router = useRouter();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -52,8 +50,14 @@ export function RegisterForm({ nonce }: { nonce: string | null }) {
       setError("Account created, but sign-in failed. Try signing in.");
       return;
     }
-    router.push("/");
-    router.refresh();
+    // A hard navigation, not router.push()+router.refresh(): those two are
+    // unawaited and can race — if "/" was already prefetched while signed
+    // out, push() can paint that stale cached page before refresh()'s
+    // background RSC re-fetch catches up, flashing the signed-out header
+    // for a moment. A full navigation re-renders "/" from scratch against
+    // the now-set session cookie, so there's nothing stale to flash.
+    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
+    window.location.href = "/";
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixes two related reports: a visible ~1s lag before the UI reflects being signed in after login/registration, and login never offering to save credentials in a password manager. Both trace back to the same root cause on `/login`: `next-auth/react`'s `signIn()` was called from a `fetch()`-driven `onSubmit` handler (`preventDefault()` + `fetch()` + a separate JS-triggered navigation) instead of a real form POST — browsers only reliably offer to save credentials for a genuine `<form>` submission that completes with a navigation, and the fetch-then-navigate split is what caused the visible lag.

- **`/login` rebuilt as Server Component (`page.tsx`) + Client Component (`login-form.tsx`) + Server Action (`actions.ts`)**, following the `<form action={serverAction}>` + `useActionState` pattern from Next.js's own App Router auth guide, rather than hand-rolling CSRF token plumbing for a raw POST to Auth.js's `/api/auth/callback/credentials`. Auth.js v5's server-side `signIn()` (from `@/lib/auth`) is designed to be called directly from a Server Action.
- Error handling: `signIn()` throws `NEXT_REDIRECT` internally on success (Next's own redirect mechanism) and `AuthError`/`CredentialsSignin` on failure. The action catches only `AuthError` and returns a message for `useActionState`; anything else rethrows so the success redirect isn't swallowed.
- **`/register`'s post-signup navigation got a smaller, related fix**: it stays fetch-based (still needs the JSON `/api/register` call and captcha token), but its `router.push("/")` immediately followed by an unawaited `router.refresh()` had the same race — if `/` was already prefetched while signed out, `push()` could paint that stale cached page before `refresh()`'s background re-fetch caught up. Swapped both for a single hard `window.location.href = "/"`.
- Google OAuth sign-in (`next-auth/react`'s `signIn("google", ...)`, a redirect-based flow) was untouched — this only reworked the credentials path.

## Checklist

- [x] `README.md` updated — not applicable, no user-facing feature, env var, setup step, or seed data changed
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — documents the Server Action vs. hand-rolled CSRF tradeoff, since this is a real architectural judgment call (first Server Action in the codebase)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` both clean
- Verified against a real local dev server (Postgres + `npm run dev`), not just lint/build, with Playwright:
  - Wrong password stays on `/login` and shows the existing generic error
  - Correct password redirects to `/` in ~500ms with the header immediately reflecting signed-in state (no stale flash)
  - Registration redirects to `/` the same way, header reflects signed-in state
- Google OAuth button unchanged, not touched by this diff

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_