### PR TITLE
Document master branch ruleset in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,20 @@ than discovering it as a merge conflict later. A quick scan of open PRs
 (titles/descriptions are usually enough) is worth doing at the start of a new
 task, alongside the `master` check above.
 
+## `master` branch protection
+
+`master` is protected by a GitHub ruleset: pushes must go through a pull
+request, force-pushes and branch deletion are blocked, and the
+`build-and-lint` CI check must pass before a PR is mergeable. This is
+enforced by GitHub itself now, not just convention — a direct push to
+`master` will be rejected outright.
+
+There is deliberately **no required-approval review** — a passing
+`build-and-lint` is enough to merge. This is unchanged from how every PR in
+this repo has already been merged: open a PR, wait for `build-and-lint` to
+go green, merge it via the GitHub API once it does. No human needs to click
+approve first.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -707,6 +707,25 @@ round trips instead of one browser-orchestrated request.
   `signIn("google", ...)`, a redirect-based flow) was untouched — this
   only reworked the credentials path.
 
+### `master` protected by a GitHub ruleset, no required review
+GitHub itself flagged `master` as unprotected (force-push/deletion
+possible, no required status checks). Site owner set up a branch ruleset
+via the repo's Settings → Rulesets UI: PRs required to reach `master`,
+force-pushes and deletion blocked, `build-and-lint` required to pass
+before merge.
+
+Deliberately **no required-approval review** — every PR in this repo is
+already opened, CI-checked, and merged by Claude sessions working
+autonomously in parallel, with no human approval step today. Requiring
+reviews would block that entirely (including this session's own merges),
+and the site owner explicitly confirmed no human-review gate is wanted.
+"Require branches to be up to date before merging" was also left off —
+with several PRs merging into `master` independently, that setting would
+force a rebase/CI re-run on every PR each time another one lands first,
+fighting the very workflow this repo runs on. Documented in `CLAUDE.md` so
+future sessions know a direct push to `master` will now be rejected
+outright, not just discouraged by convention.
+
 ## Feature Decisions
 
 ### Community Activity feed merges three existing tables, no new schema


### PR DESCRIPTION
## Summary

GitHub flagged `master` as unprotected (force-push/deletion possible, no required status checks). The site owner set up a branch ruleset via Settings → Rulesets: PRs required to reach `master`, force-pushes and deletion blocked, `build-and-lint` required to pass before merge, and deliberately no required-approval review (every PR here is already opened, CI-checked, and merged autonomously by Claude sessions with no human approval step).

This PR just documents that in `CLAUDE.md` so future sessions know a direct push to `master` will now be rejected outright, not just discouraged by convention, and records the reasoning (including why "require branches up to date" was left off) in `DECISIONS.md`.

No code changes.

## Checklist

- [x] `README.md` updated — not applicable, this is a repo-governance setting, not an app-facing feature, env var, or local setup step
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — documents the ruleset setup and the reasoning behind each toggle choice, since it's a real process-convention decision
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Docs-only change. `npm run lint` and `npm run build` both pass clean (no code touched).

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_