### PR TITLE
Reorganize member's own profile view into tabs

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1468,6 +1468,45 @@ but can't invent new tags — same shape as the existing `Genre`–`Movie`
 relation, keeps the taxonomy from fragmenting into near-duplicate tags over
 time.
 
+### Member profile split into tabs, own-profile view only
+First step on the "Expand member profile" backlog item — the site owner
+flagged that the page's organization "doesn't scale well." It didn't:
+Favorites, Watchlist, Pending Submissions, and Favorite Fight Scenes each
+rendered their *entire* collection into an unpaginated flex-wrap grid,
+stacked one after another, then every one of a member's custom lists
+rendered *its* entire contents too, stacked below that — a member with a
+modest amount of activity turned this into one very long scroll with no
+way to jump to a specific section.
+
+- **Tabs (`ProfileTabs`, a small client component holding just the active
+  tab's key), not pagination or a redesigned dashboard** — the underlying
+  data was already fetched together server-side in one page load; tabs
+  just change how it's *presented*, which is the actual problem being
+  solved right now. Pagination/infinite-scroll within a tab and a curated
+  "Overview" summary tab are both reasonable follow-ups, deliberately left
+  out of this pass to keep it scoped to the reorganization itself.
+- **Only the owner's own view gets tabs.** Viewing someone else's profile
+  only ever showed their public custom lists — a single section — so a
+  tab bar around one tab would be pure UI noise. That view is untouched.
+- **Each tab label carries a live count** (e.g. "Favorites (2)") pulled
+  from the same data already being fetched — gives an at-a-glance sense of
+  how much is in each section without opening it, which the old stacked
+  layout couldn't offer since everything was already visible at once.
+- **`MovieRow`/`FightSceneRow`'s `title` prop made optional** rather than
+  adding a second variant of each — the tab label already names the
+  section, so the row's own heading is only rendered when a title is
+  passed (i.e., never from the tabbed owner view, still shown in the
+  untouched non-owner list rendering).
+- **Verified in a real browser, not just lint/build**: seeded a member
+  account with favorites, a watchlist entry, and an existing list,
+  confirmed each tab switches correctly with accurate counts, and
+  confirmed the non-owner view still renders the plain (non-tabbed) public
+  lists section unchanged.
+
+Stats, a bio field, and contributor badges — the other pieces discussed
+for this backlog item — are intentionally not part of this change; see the
+"Expand member profile" backlog entry below for what's still open.
+
 ## Deferred & Backlog
 
 - **About page copy: mission, About the Creators, Contact/feedback, and
@@ -1532,12 +1571,13 @@ time.
   data gap the timeline page needs; if it means real-world trivia
   (production history, behind-the-scenes facts), it's a simpler,
   unrelated content field. Scope that distinction first.
-- **Expand member profile** — open-ended, not yet scoped. `/members/[username]`
-  currently shows a member's public lists, favorited movies/fight scenes,
-  and not much else. Needs a concrete list of what to add (bio? favorite
-  genres? stats like submission/verification counts? the member
-  contributor badges idea from the engagement discussion?) before this is
-  buildable — revisit with specifics.
+- **Expand member profile** — tabbed reorganization of the owner's own view
+  shipped (see Feature Decisions above), which was the actual scaling
+  problem. Still open: a stats strip (submission/verification counts, all
+  derivable from existing tables, no schema change), a `bio` field (needs
+  one new `User` column), contributor badges (computed from the same stats,
+  no new schema needed to start), and favorite genres (lower priority, more
+  design questions — derived from rating history or a manual preference?).
 - **Lists expansion to drive community engagement** — explicitly flagged
   as needing more ideas, not a scoped feature yet. Starter thoughts from
   an earlier engagement discussion, none decided: collaborative lists

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
 
 ## Member Lists & Profiles
 
-Every member has a profile page at `/members/[username]`. Viewing your own shows Favorites, Watchlist, Favorite Fight Scenes, and your custom lists with full management controls (create/rename/delete); viewing someone else's shows only their public custom lists, read-only. `/my-lists` still works as a link — it just redirects to your own profile.
+Every member has a profile page at `/members/[username]`. Viewing your own shows a tabbed layout — Favorites, Watchlist, Pending Submissions, Favorite Fight Scenes, and your custom lists (with full management controls: create/rename/delete), each tab labeled with a live count; viewing someone else's shows only their public custom lists, read-only, with no tabs. `/my-lists` still works as a link — it just redirects to your own profile.
 
 Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile. Lists hold fight scenes as well as movies — every fight scene card, wherever it appears (a movie page, its own permalink, fight scene search results, or another member's list), has its own bookmark-icon "save to list" control alongside the share icon.
 

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -8,6 +8,7 @@ import { MovieCard } from "@/components/movie-card";
 import { FightSceneResultCard, type FightSceneResult } from "@/components/fight-scene-result-card";
 import type { AddToListItem } from "@/components/add-to-list-control";
 import { MemberListManager } from "@/components/member-list-manager";
+import { ProfileTabs } from "@/components/profile-tabs";
 import type { Movie } from "@/generated/prisma/client";
 
 const fightSceneCardInclude = {
@@ -21,13 +22,15 @@ async function MovieRow({
   movies,
   ratingSummaries,
 }: {
-  title: string;
+  // Omitted when rendered as a tab panel — the tab label already names the
+  // section, so repeating it as a heading inside the panel is redundant.
+  title?: string;
   movies: Pick<Movie, "id" | "title" | "releaseDate" | "posterPath" | "posterOverrideUrl" | "tmdbRating">[];
   ratingSummaries: Awaited<ReturnType<typeof getRatingSummaries>>;
 }) {
   return (
     <section className="mb-8">
-      <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>
+      {title && <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>}
       {movies.length === 0 ? (
         <p className="text-sm text-neutral-400">Nothing here yet.</p>
       ) : (
@@ -56,13 +59,14 @@ function FightSceneRow({
   scenes,
   signedIn,
 }: {
-  title: string;
+  // Omitted when rendered as a tab panel — see MovieRow's title comment.
+  title?: string;
   scenes: (FightSceneResult & { initialLists: AddToListItem[]; initialFavorite: boolean })[];
   signedIn: boolean;
 }) {
   return (
     <section className="mb-8">
-      <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>
+      {title && <h2 className="mb-4 text-lg font-semibold text-white">{title}</h2>}
       {scenes.length === 0 ? (
         <p className="text-sm text-neutral-400">Nothing here yet.</p>
       ) : (
@@ -233,53 +237,81 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   const favoriteFightSceneData = favoriteFightScenes.map(withSceneListState);
 
+  const listsPanel =
+    memberListData.length === 0 && !isOwner ? (
+      <p className="text-sm text-neutral-500">No public lists yet.</p>
+    ) : isOwner ? (
+      <MemberListManager initialLists={memberListData} viewerSignedIn={!!session?.user} />
+    ) : (
+      memberListData.map((list) => (
+        <section key={list.id} className="mb-8">
+          <div className="mb-3 flex items-center gap-3">
+            <h3 className="text-lg font-semibold text-white">{list.name}</h3>
+            <Link href={`/lists/${list.id}`} className="text-xs text-neutral-400 underline hover:text-white">
+              Permalink
+            </Link>
+          </div>
+          {list.movies.length === 0 && list.fightScenes.length === 0 ? (
+            <p className="text-sm text-neutral-400">Nothing in this list yet.</p>
+          ) : (
+            <div className="flex flex-wrap gap-4">
+              {list.movies.map((movie) => (
+                <MovieCard key={movie.id} movie={movie} />
+              ))}
+              {list.fightScenes.map((scene) => (
+                <FightSceneResultCard
+                  key={scene.id}
+                  scene={scene}
+                  initialLists={scene.initialLists}
+                  signedIn={!!session?.user}
+                  initialFavorite={scene.initialFavorite}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      ))
+    );
+
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
       <h1 className="mb-6 text-2xl font-bold text-white">{profileUser.username}</h1>
 
-      {isOwner && (
-        <>
-          <MovieRow title="Favorites" movies={favorites} ratingSummaries={ratingSummaries} />
-          <MovieRow title="Watchlist" movies={watchlist} ratingSummaries={ratingSummaries} />
-          <MovieRow title="Pending Submissions" movies={pendingSubmissions} ratingSummaries={ratingSummaries} />
-          <FightSceneRow title="Favorite Fight Scenes" scenes={favoriteFightSceneData} signedIn={!!session?.user} />
-        </>
-      )}
-
-      <h2 className="mb-4 text-xl font-bold text-white">{isOwner ? "Your Lists" : "Lists"}</h2>
       {isOwner ? (
-        <MemberListManager initialLists={memberListData} viewerSignedIn={!!session?.user} />
-      ) : memberListData.length === 0 ? (
-        <p className="text-sm text-neutral-500">No public lists yet.</p>
+        <ProfileTabs
+          tabs={[
+            {
+              key: "favorites",
+              label: `Favorites (${favorites.length})`,
+              content: <MovieRow movies={favorites} ratingSummaries={ratingSummaries} />,
+            },
+            {
+              key: "watchlist",
+              label: `Watchlist (${watchlist.length})`,
+              content: <MovieRow movies={watchlist} ratingSummaries={ratingSummaries} />,
+            },
+            {
+              key: "pending",
+              label: `Pending (${pendingSubmissions.length})`,
+              content: <MovieRow movies={pendingSubmissions} ratingSummaries={ratingSummaries} />,
+            },
+            {
+              key: "fight-scenes",
+              label: `Fight Scenes (${favoriteFightSceneData.length})`,
+              content: <FightSceneRow scenes={favoriteFightSceneData} signedIn={!!session?.user} />,
+            },
+            {
+              key: "lists",
+              label: `Lists (${memberListData.length})`,
+              content: listsPanel,
+            },
+          ]}
+        />
       ) : (
-        memberListData.map((list) => (
-          <section key={list.id} className="mb-8">
-            <div className="mb-3 flex items-center gap-3">
-              <h3 className="text-lg font-semibold text-white">{list.name}</h3>
-              <Link href={`/lists/${list.id}`} className="text-xs text-neutral-400 underline hover:text-white">
-                Permalink
-              </Link>
-            </div>
-            {list.movies.length === 0 && list.fightScenes.length === 0 ? (
-              <p className="text-sm text-neutral-400">Nothing in this list yet.</p>
-            ) : (
-              <div className="flex flex-wrap gap-4">
-                {list.movies.map((movie) => (
-                  <MovieCard key={movie.id} movie={movie} />
-                ))}
-                {list.fightScenes.map((scene) => (
-                  <FightSceneResultCard
-                    key={scene.id}
-                    scene={scene}
-                    initialLists={scene.initialLists}
-                    signedIn={!!session?.user}
-                    initialFavorite={scene.initialFavorite}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
-        ))
+        <>
+          <h2 className="mb-4 text-xl font-bold text-white">Lists</h2>
+          {listsPanel}
+        </>
       )}
     </div>
   );

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+export function ProfileTabs({ tabs }: { tabs: { key: string; label: string; content: ReactNode }[] }) {
+  const [active, setActive] = useState(tabs[0]?.key);
+  const activeTab = tabs.find((tab) => tab.key === active) ?? tabs[0];
+
+  return (
+    <div>
+      <div className="mb-6 flex gap-1 overflow-x-auto border-b border-neutral-800">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActive(tab.key)}
+            className={`shrink-0 border-b-2 px-4 py-2 text-sm font-medium whitespace-nowrap ${
+              tab.key === activeTab?.key
+                ? "border-red-600 text-white"
+                : "border-transparent text-neutral-400 hover:text-neutral-200"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab?.content}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

First step on the "Expand member profile" backlog item. `/members/[username]`'s owner view didn't scale: Favorites, Watchlist, Pending Submissions, and Favorite Fight Scenes each rendered their entire unpaginated collection into a flex-wrap grid, stacked one after another, then every one of a member's custom lists rendered its entire contents too, stacked below that — a member with a modest amount of activity turned this into one very long scroll with no way to jump to a section.

- New `ProfileTabs` component (`src/components/profile-tabs.tsx`) — a small client component holding just the active tab key, switching between server-rendered panels passed in as children.
- Owner's own view: tabs for Favorites, Watchlist, Pending, Fight Scenes, and Lists, each label showing a live count (e.g. "Favorites (2)").
- Non-owner view is unchanged — it only ever showed one section (public custom lists), so a tab bar around a single tab would be pure noise.
- `MovieRow`/`FightSceneRow`'s `title` prop made optional rather than adding a second variant — the tab label already names the section, so the row's own heading is only rendered when a title is passed (never from the tabbed owner view).
- Deliberately scoped to just the reorganization: no pagination within a tab, no new "Overview" dashboard, no stats/bio/badges — those remain open on the backlog entry as follow-ups.

## Checklist

- [x] `README.md` updated — Member Lists & Profiles section now describes the tabbed layout and per-tab counts
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — documents the tabs-vs-pagination/dashboard tradeoff and why only the owner view got tabs; backlog entry updated to reflect what shipped vs. what's still open
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` both clean
- Verified in a real browser against a local Postgres dev server: seeded a member account with 2 favorites, 1 watchlist entry, and an existing 2-movie list, confirmed all 5 tabs switch correctly with accurate live counts, confirmed the non-owner view still renders the plain (non-tabbed) public-lists-only section unchanged

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_