### PR TITLE
Add a member-editable bio field to profile pages

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1507,6 +1507,38 @@ Stats, a bio field, and contributor badges — the other pieces discussed
 for this backlog item — are intentionally not part of this change; see the
 "Expand member profile" backlog entry below for what's still open.
 
+### Member profile bio field
+**Schema-touching.** Second step on "Expand member profile" — adds
+`User.bio` (nullable `String`, no DB-level length constraint) plus an
+inline editor on the owner's own profile page.
+
+- **280-character cap, enforced app-side only** (`BIO_MAX_LENGTH` in
+  `src/lib/profile.ts`), the same pattern already used for list names
+  (`MEMBER_LIST_NAME_MAX_LENGTH`) and usernames — no CHECK constraint in
+  the migration. Chose 280 specifically (the familiar Twitter-bio length)
+  over a longer free-text field: a profile bio is meant to be a short
+  self-description, not another content field, and a hard cap keeps the
+  profile page's layout predictable.
+- **Public, same visibility as username** — shown to any visitor on the
+  owner's profile, not just the owner. Consistent with the rest of the
+  profile page: usernames, public lists, and now bios are all visible to
+  everyone; only Favorites/Watchlist/Pending Submissions stay
+  owner-only.
+- **Empty string clears back to `null`, not stored as `""`** — the
+  profile page's placeholder logic ("No bio yet." / "Add a bio") checks
+  for a falsy value, so an explicitly-cleared bio and a never-set one look
+  identical rather than rendering an empty paragraph.
+- **New `PATCH /api/profile/bio` endpoint, not folded into an existing
+  route** — mirrors `PATCH /api/lists/[listId]`'s shape (auth check,
+  trim, length validation, single `prisma.user.update`) but needs no
+  ownership lookup first, since it always targets `session.user.id`
+  rather than a resource ID from the URL.
+- **Verified in a real browser, not just lint/build**: applied the new
+  migration against a local Postgres dev DB, added a bio as the `member`
+  seed account, confirmed it persists across a page reload, and confirmed
+  it's visible on a signed-out/other-member view of that profile while a
+  bio-less profile (`admin`) shows nothing rather than an empty section.
+
 ## Deferred & Backlog
 
 - **About page copy: mission, About the Creators, Contact/feedback, and
@@ -1572,11 +1604,12 @@ for this backlog item — are intentionally not part of this change; see the
   (production history, behind-the-scenes facts), it's a simpler,
   unrelated content field. Scope that distinction first.
 - **Expand member profile** — tabbed reorganization of the owner's own view
-  shipped (see Feature Decisions above), which was the actual scaling
-  problem. Still open: a stats strip (submission/verification counts, all
-  derivable from existing tables, no schema change), a `bio` field (needs
-  one new `User` column), contributor badges (computed from the same stats,
-  no new schema needed to start), and favorite genres (lower priority, more
+  and a member-editable `bio` field have both shipped (see Feature
+  Decisions above), leaving the actual scaling problem solved and one
+  piece of the original wishlist done. Still open: a stats strip
+  (submission/verification counts, all derivable from existing tables, no
+  schema change), contributor badges (computed from the same stats, no new
+  schema needed to start), and favorite genres (lower priority, more
   design questions — derived from rating history or a manual preference?).
 - **Lists expansion to drive community engagement** — explicitly flagged
   as needing more ideas, not a scoped feature yet. Starter thoughts from

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
 
 Every member has a profile page at `/members/[username]`. Viewing your own shows a tabbed layout — Favorites, Watchlist, Pending Submissions, Favorite Fight Scenes, and your custom lists (with full management controls: create/rename/delete), each tab labeled with a live count; viewing someone else's shows only their public custom lists, read-only, with no tabs. `/my-lists` still works as a link — it just redirects to your own profile.
 
+Every profile also has an optional bio (up to 280 characters), editable only by its owner directly on their own profile page and shown publicly to anyone who visits it — same visibility as the username itself. An unset bio shows nothing on someone else's profile, and an "Add a bio" prompt on your own.
+
 Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile. Lists hold fight scenes as well as movies — every fight scene card, wherever it appears (a movie page, its own permalink, fight scene search results, or another member's list), has its own bookmark-icon "save to list" control alongside the share icon.
 
 - **Fight scenes get a one-tap Favorite, same red heart icon movies use, but no Watchlist** — a scene is a short clip you can watch right where it's linked, not something to queue up for later the way a full movie is. Every fight scene card has its own heart icon, independent of the movie it belongs to and independent of custom lists — you can favorite a scene without favoriting its movie, or vice versa.

--- a/prisma/migrations/20260816165338_add_user_bio/migration.sql
+++ b/prisma/migrations/20260816165338_add_user_bio/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "bio" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,13 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  // Free text, member-editable from their own profile page, shown publicly
+  // on it (same visibility as username). Null/empty means no bio set — the
+  // profile page shows a placeholder for the owner and nothing for anyone
+  // else, rather than an empty section. Length capped app-side only
+  // (BIO_MAX_LENGTH in src/lib/profile.ts), matching how username length is
+  // enforced — no DB-level constraint.
+  bio           String?
   passwordHash  String?
   // Set whenever passwordHash is (re)written — registration, admin password
   // change, or a forgot-password reset — so a JWT session issued before the

--- a/src/app/api/profile/bio/route.ts
+++ b/src/app/api/profile/bio/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { BIO_MAX_LENGTH } from "@/lib/profile";
+
+export async function PATCH(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { bio } = await request.json();
+  if (typeof bio !== "string") {
+    return NextResponse.json({ error: "A bio is required." }, { status: 400 });
+  }
+
+  const trimmedBio = bio.trim();
+  if (trimmedBio.length > BIO_MAX_LENGTH) {
+    return NextResponse.json({ error: `Bio must be ${BIO_MAX_LENGTH} characters or fewer.` }, { status: 400 });
+  }
+
+  // Empty clears the bio back to unset, rather than storing an empty string
+  // — matches the profile page's "no bio set" placeholder logic.
+  const user = await prisma.user.update({
+    where: { id: session.user.id },
+    data: { bio: trimmedBio || null },
+  });
+  return NextResponse.json({ bio: user.bio });
+}

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -8,6 +8,7 @@ import { MovieCard } from "@/components/movie-card";
 import { FightSceneResultCard, type FightSceneResult } from "@/components/fight-scene-result-card";
 import type { AddToListItem } from "@/components/add-to-list-control";
 import { MemberListManager } from "@/components/member-list-manager";
+import { MemberBioEditor } from "@/components/member-bio-editor";
 import { ProfileTabs } from "@/components/profile-tabs";
 import type { Movie } from "@/generated/prisma/client";
 
@@ -275,7 +276,13 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
-      <h1 className="mb-6 text-2xl font-bold text-white">{profileUser.username}</h1>
+      <h1 className="mb-2 text-2xl font-bold text-white">{profileUser.username}</h1>
+
+      {isOwner ? (
+        <MemberBioEditor initialBio={profileUser.bio} />
+      ) : (
+        profileUser.bio && <p className="mb-6 max-w-xl text-sm whitespace-pre-wrap text-neutral-300">{profileUser.bio}</p>
+      )}
 
       {isOwner ? (
         <ProfileTabs

--- a/src/components/member-bio-editor.tsx
+++ b/src/components/member-bio-editor.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { BIO_MAX_LENGTH } from "@/lib/profile";
+
+export function MemberBioEditor({ initialBio }: { initialBio: string | null }) {
+  const [bio, setBio] = useState(initialBio);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initialBio ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    if (draft.trim().length > BIO_MAX_LENGTH) return;
+    setSaving(true);
+    setError(null);
+    const res = await fetch("/api/profile/bio", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bio: draft }),
+    });
+    const body = await res.json();
+    setSaving(false);
+    if (!res.ok) {
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setBio(body.bio);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div className="mb-6">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={3}
+          placeholder="Tell other members a bit about yourself…"
+          className="w-full max-w-xl resize-none rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        />
+        <div className="mt-1 flex items-center gap-3">
+          <span className={`text-xs ${draft.trim().length > BIO_MAX_LENGTH ? "text-red-500" : "text-neutral-500"}`}>
+            {draft.trim().length}/{BIO_MAX_LENGTH}
+          </span>
+          <button
+            onClick={save}
+            disabled={saving || draft.trim().length > BIO_MAX_LENGTH}
+            className="text-sm text-red-500 hover:underline disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button
+            onClick={() => {
+              setDraft(bio ?? "");
+              setEditing(false);
+              setError(null);
+            }}
+            className="text-sm text-neutral-400 hover:text-white"
+          >
+            Cancel
+          </button>
+        </div>
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 flex items-start gap-3">
+      {bio ? (
+        <p className="max-w-xl text-sm whitespace-pre-wrap text-neutral-300">{bio}</p>
+      ) : (
+        <p className="text-sm text-neutral-500 italic">No bio yet.</p>
+      )}
+      <button
+        onClick={() => setEditing(true)}
+        className="shrink-0 text-xs text-neutral-400 hover:text-white"
+      >
+        {bio ? "Edit" : "Add a bio"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,1 @@
+export const BIO_MAX_LENGTH = 280;


### PR DESCRIPTION
## ⚠️ Touches the Prisma schema

Adds `User.bio` (nullable `String`, no DB-level length constraint) plus migration `20260816165338_add_user_bio`. Per repo convention, this should be merged/pulled before another schema-touching PR starts to avoid migration conflicts.

## Summary

Second step on the "Expand member profile" backlog item, after the tabbed reorganization (#73) — adds an optional bio to member profiles.

- 280-character cap (the familiar Twitter-bio length), enforced app-side only (`BIO_MAX_LENGTH` in `src/lib/profile.ts`), same pattern as `MEMBER_LIST_NAME_MAX_LENGTH` for list names.
- Public, same visibility as the username itself — shown to any visitor on the owner's profile, not just the owner. Only Favorites/Watchlist/Pending Submissions stay owner-only.
- Empty string clears back to `null` rather than being stored as `""`, so an explicitly-cleared bio and a never-set one both render the same "no bio" state.
- New `PATCH /api/profile/bio` endpoint, mirroring `PATCH /api/lists/[listId]`'s shape (auth check, trim, length validation, single update) but always targets `session.user.id` rather than a resource ID from the URL.
- Inline editor (`MemberBioEditor`) on the owner's own profile, mirroring `MemberListManager`'s existing edit/save/cancel pattern.

## Checklist

- [x] `README.md` updated — Member Lists & Profiles section now describes the bio field, its length cap, and its visibility
- [x] `.env.example` updated — not applicable, no new env var
- [x] `DECISIONS.md` updated — documents the length-cap/visibility/empty-string judgment calls; backlog entry updated to reflect what's shipped vs. still open
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` both clean
- Verified in a real browser against a local Postgres dev server: applied the migration, added a bio via the inline editor as the `member` seed account, confirmed it persists across a page reload, confirmed it's visible on the profile to other visitors, and confirmed a bio-less profile (`admin`) shows nothing rather than an empty section

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_