### PR TITLE
Move the bio editor into its own Profile tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ Two dedicated search pages, both with a vertical sidebar of filters, pagination,
 
 ## Member Lists & Profiles
 
-Every member has a profile page at `/members/[username]`. Viewing your own shows a tabbed layout — Favorites, Watchlist, Pending Submissions, Favorite Fight Scenes, and your custom lists (with full management controls: create/rename/delete), each tab labeled with a live count; viewing someone else's shows only their public custom lists, read-only, with no tabs. `/my-lists` still works as a link — it just redirects to your own profile.
+Every member has a profile page at `/members/[username]`. Viewing your own shows a tabbed layout — Profile, Favorites, Watchlist, Pending Submissions, Favorite Fight Scenes, and your custom lists (with full management controls: create/rename/delete), each tab labeled with a live count where applicable; viewing someone else's shows only their public custom lists, read-only, with no tabs. `/my-lists` still works as a link — it just redirects to your own profile.
 
-Every profile also has an optional bio (up to 280 characters), editable only by its owner directly on their own profile page and shown publicly to anyone who visits it — same visibility as the username itself. An unset bio shows nothing on someone else's profile, and an "Add a bio" prompt on your own.
+Every profile also has an optional bio (up to 280 characters), editable from the Profile tab of your own profile and shown publicly to anyone who visits it — same visibility as the username itself. On someone else's profile it's shown directly under their username (they have no tabs); an unset bio shows nothing there, and an "Add a bio" prompt on your own.
 
 Beyond the built-in Favorites and Watchlist, members can create any number of their own named lists (e.g. "Best One-vs-Many Fights") from the "+ Add to list" control on a movie page, and manage them from their own profile. Lists hold fight scenes as well as movies — every fight scene card, wherever it appears (a movie page, its own permalink, fight scene search results, or another member's list), has its own bookmark-icon "save to list" control alongside the share icon.
 

--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -276,17 +276,21 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10">
-      <h1 className="mb-2 text-2xl font-bold text-white">{profileUser.username}</h1>
+      <h1 className="mb-6 text-2xl font-bold text-white">{profileUser.username}</h1>
 
-      {isOwner ? (
-        <MemberBioEditor initialBio={profileUser.bio} />
-      ) : (
-        profileUser.bio && <p className="mb-6 max-w-xl text-sm whitespace-pre-wrap text-neutral-300">{profileUser.bio}</p>
-      )}
+      {!isOwner &&
+        profileUser.bio && (
+          <p className="mb-6 max-w-xl text-sm whitespace-pre-wrap text-neutral-300">{profileUser.bio}</p>
+        )}
 
       {isOwner ? (
         <ProfileTabs
           tabs={[
+            {
+              key: "profile",
+              label: "Profile",
+              content: <MemberBioEditor initialBio={profileUser.bio} />,
+            },
             {
               key: "favorites",
               label: `Favorites (${favorites.length})`,


### PR DESCRIPTION
## Summary

Follow-up to #74 — the bio editor was rendered above the tab bar on the owner's own profile, separate from the tabbed sections it sits alongside. Moves it into a new "Profile" tab instead (first in the list, default-active), so it's part of the same tabbed layout rather than sitting apart from it.

- Non-owner view is unchanged: no tabs there, bio still shows directly under the username as before.
- No component logic changed — `MemberBioEditor` is unchanged, just relocated into the `ProfileTabs` array.

## Checklist

- [x] `README.md` updated — Member Lists & Profiles section now lists "Profile" as the first tab and clarifies where bio shows on each view
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — not applicable, this is a placement tweak on an already-documented feature, not a new judgment call
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` both clean
- Verified in a real browser against a local Postgres dev server: Profile tab shows first, is active by default, and correctly displays the previously-saved bio with its Edit control

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_