### PR TITLE
Require explicit "merge" before merging a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,24 @@ request, force-pushes and branch deletion are blocked, and the
 enforced by GitHub itself now, not just convention — a direct push to
 `master` will be rejected outright.
 
-There is deliberately **no required-approval review** — a passing
-`build-and-lint` is enough to merge. This is unchanged from how every PR in
-this repo has already been merged: open a PR, wait for `build-and-lint` to
-go green, merge it via the GitHub API once it does. No human needs to click
-approve first.
+There is deliberately **no GitHub-enforced required-approval review** — the
+ruleset itself doesn't block a merge on a human clicking Approve. That's a
+separate thing from whether *you* (the AI session working this repo) should
+merge on your own:
+
+## Wait for explicit "merge" before merging a PR
+
+Open the PR once `build-and-lint` is green, then **stop and wait** — don't
+call the merge API yourself. The site owner wants to preview the Vercel
+deployment and request adjustments before a PR lands on `master`. Only merge
+once they've explicitly said so in the conversation (e.g. "merge",
+"merge it," "go ahead and merge") — a green CI check alone is not
+authorization to merge.
+
+This reverses the earlier convention (see `DECISIONS.md`'s "`master`
+protected by a GitHub ruleset, no required review" entry) — that entry's
+GitHub-ruleset reasoning still holds, but the auto-merge-on-green-CI part of
+it doesn't apply anymore.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -726,6 +726,29 @@ fighting the very workflow this repo runs on. Documented in `CLAUDE.md` so
 future sessions know a direct push to `master` will now be rejected
 outright, not just discouraged by convention.
 
+### Reversed: Claude sessions no longer self-merge on green CI
+Partial reversal of the entry above. The GitHub ruleset itself is
+unchanged — no required-approval review at the GitHub level, PRs still
+required, `build-and-lint` still required to pass. What changed is a
+`CLAUDE.md` convention layered on top of it: an AI session working this
+repo now opens a PR and **stops once CI is green**, rather than merging
+immediately via the GitHub API.
+
+Reason for the reversal: the original "no review needed" call assumed
+CI passing was a sufficient merge gate. In practice the site owner wants
+to preview the Vercel deployment and request adjustments before a change
+lands on `master` — something a green `build-and-lint` run can't catch
+(it verifies the code builds and lints, not that the feature looks or
+behaves the way it's supposed to). A merge now requires the site owner
+explicitly saying so in the conversation, not just a passing check.
+
+Deliberately *not* re-enabling GitHub's own "require approvals" ruleset
+setting to enforce this — that would mean clicking Approve in GitHub's
+review UI for every PR, real friction for a workflow where "merge" typed
+in chat is enough. This is a chat-convention gate, not a technical one;
+if it turns out sessions need a stronger backstop later (e.g. one
+forgets to wait), revisit adding the GitHub-side requirement too.
+
 ## Feature Decisions
 
 ### Community Activity feed merges three existing tables, no new schema


### PR DESCRIPTION
## Summary

Reverses part of an earlier convention. Previously, an AI session working this repo would open a PR and merge it via the GitHub API as soon as `build-and-lint` went green, with no human approval step. The site owner asked to go back to approving merges themselves, so they can preview the Vercel deployment and request adjustments before a change lands on `master`.

- `CLAUDE.md` now says: open the PR, wait for CI to go green, then **stop** — only merge once the site owner explicitly says so in the conversation.
- The GitHub ruleset itself is unchanged: PRs still required, `build-and-lint` still required to pass, no GitHub-enforced "require approvals" setting added. This is a chat-convention gate, not a technical one, since typing "merge" is lower-friction than clicking Approve in GitHub's review UI for every PR.
- `DECISIONS.md` documents the reversal and why a green CI check alone was found to be an insufficient merge gate (it verifies the code builds and lints, not that a feature looks or behaves as intended).

No code changes.

## Checklist

- [x] `README.md` updated — not applicable, this is a repo-governance/process convention, not an app-facing feature
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — documents the reversal and reasoning, referencing the original ruleset-setup entry it partially reverses
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Docs-only change. `npm run lint` and `npm run build` both pass clean (no code touched).

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_