### PR TITLE
Shrink movie cards on member profile pages

### DIFF
--- a/src/app/members/[username]/page.tsx
+++ b/src/app/members/[username]/page.tsx
@@ -41,6 +41,7 @@ async function MovieRow({
             return (
               <MovieCard
                 key={movie.id}
+                size="compact"
                 movie={{
                   ...movie,
                   communityAverage: summary?.average ?? null,
@@ -257,7 +258,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
           ) : (
             <div className="flex flex-wrap gap-4">
               {list.movies.map((movie) => (
-                <MovieCard key={movie.id} movie={movie} />
+                <MovieCard key={movie.id} movie={movie} size="compact" />
               ))}
               {list.fightScenes.map((scene) => (
                 <FightSceneResultCard

--- a/src/components/member-list-manager.tsx
+++ b/src/components/member-list-manager.tsx
@@ -148,7 +148,7 @@ export function MemberListManager({
           ) : (
             <div className="flex flex-wrap gap-4">
               {list.movies.map((movie) => (
-                <MovieCard key={movie.id} movie={movie} />
+                <MovieCard key={movie.id} movie={movie} size="compact" />
               ))}
               {list.fightScenes.map((scene) => (
                 <FightSceneResultCard

--- a/src/components/movie-card.tsx
+++ b/src/components/movie-card.tsx
@@ -14,22 +14,29 @@ export type MovieCardData = Pick<
   recommendedBy?: MovieRecommender[];
 };
 
-export function MovieCard({ movie }: { movie: MovieCardData }) {
+// "compact" is used on the member profile page, where several sections of
+// (potentially long) movie grids sit behind tabs — smaller cards fit more
+// per row and per screen, which matters more there than on a page showing
+// one curated section at a time. Every other caller keeps the original size.
+const SIZE_CLASSES = {
+  default: { link: "w-40 sm:w-48", sizes: "(max-width: 640px) 160px, 192px" },
+  compact: { link: "w-28 sm:w-32", sizes: "(max-width: 640px) 112px, 128px" },
+} as const;
+
+export function MovieCard({ movie, size = "default" }: { movie: MovieCardData; size?: keyof typeof SIZE_CLASSES }) {
   const posterUrl = resolvePosterUrl(movie, "w342");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
+  const { link, sizes } = SIZE_CLASSES[size];
 
   return (
-    <Link
-      href={`/movies/${movie.id}`}
-      className="group flex w-40 shrink-0 flex-col gap-2 sm:w-48"
-    >
+    <Link href={`/movies/${movie.id}`} className={`group flex shrink-0 flex-col gap-2 ${link}`}>
       <div className="relative aspect-2/3 w-full overflow-hidden rounded-md bg-neutral-800">
         {posterUrl ? (
           <Image
             src={posterUrl}
             alt={movie.title}
             fill
-            sizes="(max-width: 640px) 160px, 192px"
+            sizes={sizes}
             className="object-cover transition group-hover:scale-105"
           />
         ) : (


### PR DESCRIPTION
## Summary

For scaling purposes on the member profile page, which already has several sections of potentially long movie grids behind tabs.

- Adds an optional `MovieCard` `size` prop (`"default" | "compact"`); every other caller (search, actors, movie-rail, list permalinks) keeps the original size unchanged — nothing about their layout changes.
- The member profile page's movie grids now use `"compact"`: Favorites/Watchlist/Pending tabs, and both the owner's (`MemberListManager`) and non-owner's Lists rendering paths.
- Fight scene cards (a differently-styled "ticket stub" component, by deliberate design per an earlier decision) are untouched — this only covers `MovieCard`.

## Checklist

- [x] `README.md` updated — not applicable, pure styling tweak, no capability or setup change
- [x] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated — not applicable, a straightforward sizing tweak with one clear approach, not a judgment call between alternatives
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` both clean
- Verified in a real browser against a local Postgres dev server: Favorites tab now renders visibly smaller, more compact cards while staying fully readable; every other page using `MovieCard` (search, lists, actor pages) unaffected

https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG

---
_Generated by [Claude Code](https://claude.ai/code/session_017E3bmtr9Qen6dzy9GK7TuG)_