### PR TITLE
Add Fun Facts section with thumbs up/down voting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,13 @@ deployment and request adjustments before a PR lands on `master`. Only merge
 once they've explicitly said so in the conversation (e.g. "merge",
 "merge it," "go ahead and merge") — a green CI check alone is not
 authorization to merge.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -842,6 +842,37 @@ forgets to wait), revisit adding the GitHub-side requirement too.
 
 ## Feature Decisions
 
+### Fun Facts: flat content shape from Discussion, first bidirectional vote in the app
+**PR #TBD.** An IMDB "Did you know"-style trivia section above the Discussion
+thread — members add short entries, other members vote them up or down.
+
+- Content shape (`content` + `isDeleted` soft delete) mirrors `DiscussionPost`
+  directly, minus the `parentId`/`replies` threading — a fun fact is a flat
+  list, there's no concept of replying to one.
+- **Voting is the first bidirectional (up/down) pattern in the codebase.**
+  Every existing vote-like mechanic is one-directional: `MemberListLike` is a
+  toggle-on/toggle-off like with no dislike, and `Rating`/`FightSceneRating`
+  are 1–10 scores, not votes. `FunFactVote.value` (+1/-1) with a
+  `@@unique([userId, factId])` constraint reuses `MemberListLike`'s
+  toggle-to-retract behavior in both directions: voting the same way twice
+  retracts it, voting the other way switches it.
+- **Ranked by net score, computed in memory** — same tradeoff already made
+  for Top Curators and fuzzy-search ranking: `groupBy(["factId", "value"])`
+  gives per-fact up/down counts, and the up-minus-down sort happens
+  server-side after that, not as a single SQL aggregate.
+- **Self-voting blocked**, matching `MemberListLike`'s self-like block, for
+  the same reason — stops a submitter inflating their own fact's score.
+- **Soft-deleted facts are excluded server-side** (`isDeleted: false` in the
+  query), unlike discussion posts, which stay visible as "[deleted]"
+  indefinitely because replies can hang off a deleted parent and need
+  somewhere to render. A fun fact has no replies, so once it's gone there's
+  nothing depending on the row staying visible — it's simply excluded on
+  reload, and the client removes it from the list immediately on delete
+  rather than showing a placeholder that would only ever appear pre-refresh.
+- **500-character cap**, well below `MAX_DISCUSSION_CONTENT_LENGTH` (5000)
+  — a fun fact is meant to be a short, scannable trivia snippet, not a full
+  post.
+
 ### Community Activity feed merges three existing tables, no new schema
 **PR #65.** Backlog ask was for a homepage strip surfacing recent member
 activity to make the site "feel alive" — deliberately scoped to be cheap:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - [Member Movie Submissions](#member-movie-submissions)
 - [Fight Scenes](#fight-scenes)
 - [Fight Count](#fight-count)
+- [Fun Facts](#fun-facts)
 - [Actor Pages](#actor-pages)
 - [Editorial Reviews](#editorial-reviews)
 - [Admin Recommendations](#admin-recommendations)
@@ -50,6 +51,7 @@ An IMDB-style website for kung fu and martial arts films, built for martial arts
 - Movie pages with cast, synopsis, a community rating, a separate admin-only "Editors' Score", an admin-authored editorial review, and a per-movie discussion thread (with spoiler tags, edit/delete on your own posts, and admin moderation). Members and admins can also rate a movie by category (Fight Choreography, Story, Acting) alongside the overall score, shown as a per-category average when at least one rating exists — see [Ratings](#ratings) below
 - **Fight Scenes**: members tag specific fight scenes within a movie — YouTube clip (with an optional start timestamp), the actors involved (picked from that movie's cast), and category tags (e.g. "Weapon Duel", "One vs. Many") — with their own member rating, a separate admin rating, admin verification, and a shareable permalink page (see [Fight Scenes](#fight-scenes) below)
 - **Fight Count**: a member-maintained "true" fight count on every movie page, separate from the count of cataloged Fight Scenes — see [Fight Count](#fight-count) below
+- **Fun Facts**: an IMDB "Did you know"-style trivia section above the Discussion thread — members add individual entries, and other members thumbs-up/down each one, ranked by net vote score — see [Fun Facts](#fun-facts) below
 - Actor pages (`/actors/[personId]`) showing an actor's filmography and every fight scene they're tagged in, linked from a movie's cast list and a scene's "Featuring" line (see [Actor Pages](#actor-pages) below)
 - Member accounts via email/password (with email verification and self-service password recovery) or Google sign-in, identified publicly by a chosen username rather than their email or real name (see [Usernames](#usernames) and [Password Recovery](#password-recovery) below)
 - Member capabilities: rate movies and fight scenes, maintain a Favorites list and a Watchlist for movies (fight scenes get a Favorite only — see below), create their own public named lists on a profile page at `/members/[username]` and save both movies and fight scenes to them (see [Member Lists & Profiles](#member-lists--profiles) below), post/reply in movie discussions, submit fight scenes, and submit a movie missing from the catalog for admin review (see [Member Movie Submissions](#member-movie-submissions) below)
@@ -257,6 +259,15 @@ This is deliberately a single shared value, not an aggregate of individual membe
 - **Full edit history**, visible to everyone on the movie page (not just admins) — who changed it, from what value to what, and when. The value itself has no approval step, so this history is the only accountability trail; anyone can use it to spot and revert a bad edit, not just moderators.
 
 See `DECISIONS.md` for the fuller reasoning, including the aggregation-based alternative (à la ratings) that was considered and explicitly rejected in favor of this simpler model.
+
+## Fun Facts
+
+Above the Discussion thread on every movie page: an IMDB "Did you know"-style trivia section. Any verified member can add a short fun fact (500 characters max — a trivia snippet, not a full discussion post), and any other verified member can vote it up or down.
+
+- **Voting is thumbs up/down, not a 1–10 score** — the first bidirectional vote in the app (`MemberList` likes are one-directional). Voting the same direction again retracts your vote; voting the other direction switches it. You can't vote on your own fun fact.
+- **Ranked by net score** (upvotes minus downvotes), not chronologically — the highest-voted facts rise to the top, same idea as IMDB's own trivia section.
+- **Editing/deleting**: the submitter can edit or delete their own fact; admins can delete anyone's. Deletion is a soft-delete (keeps vote history intact) and the fact simply disappears from the list — unlike discussion posts, nothing else (no replies) depends on the row staying visible.
+- Requires a verified email to submit or vote, same bar as fight scenes and discussion posts.
 
 ## Actor Pages
 

--- a/prisma/migrations/20260817205509_add_fun_facts/migration.sql
+++ b/prisma/migrations/20260817205509_add_fun_facts/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "FunFact" (
+    "id" TEXT NOT NULL,
+    "movieId" TEXT NOT NULL,
+    "submittedById" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FunFact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FunFactVote" (
+    "id" TEXT NOT NULL,
+    "factId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FunFactVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FunFact_movieId_idx" ON "FunFact"("movieId");
+
+-- CreateIndex
+CREATE INDEX "FunFactVote_factId_idx" ON "FunFactVote"("factId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FunFactVote_userId_factId_key" ON "FunFactVote"("userId", "factId");
+
+-- AddForeignKey
+ALTER TABLE "FunFact" ADD CONSTRAINT "FunFact_movieId_fkey" FOREIGN KEY ("movieId") REFERENCES "Movie"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FunFact" ADD CONSTRAINT "FunFact_submittedById_fkey" FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FunFactVote" ADD CONSTRAINT "FunFactVote_factId_fkey" FOREIGN KEY ("factId") REFERENCES "FunFact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FunFactVote" ADD CONSTRAINT "FunFactVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,8 @@ model User {
   memberListLikes     MemberListLike[]
   movieRecommendations MovieRecommendation[]
   fightCountEdits     FightCountEdit[]
+  funFacts            FunFact[]
+  funFactVotes        FunFactVote[]
 }
 
 model Account {
@@ -165,6 +167,7 @@ model Movie {
   memberListEntries MemberListEntry[]
   recommendations MovieRecommendation[]
   fightCountEdits FightCountEdit[]
+  funFacts        FunFact[]
   submittedBy     User?   @relation(fields: [submittedById], references: [id], onDelete: SetNull)
 
   @@index([title])
@@ -421,6 +424,47 @@ model DiscussionPost {
   // userId, ordered by createdAt) — without this, that query has no index
   // to use at all and falls back to a full scan as posts grow.
   @@index([userId, createdAt])
+}
+
+// --- Fun Facts ("Did you know") ---
+//
+// Flat member-submitted trivia entries, ranked by thumbs up/down rather than
+// chronologically like discussion posts -- content shape (text + soft
+// delete) mirrors DiscussionPost, but with no threading and a vote model
+// instead of replies.
+
+model FunFact {
+  id            String   @id @default(cuid())
+  movieId       String
+  submittedById String
+  content       String   @db.Text
+  isDeleted     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  movie       Movie         @relation(fields: [movieId], references: [id], onDelete: Cascade)
+  submittedBy User          @relation(fields: [submittedById], references: [id], onDelete: Cascade)
+  votes       FunFactVote[]
+
+  @@index([movieId])
+}
+
+// One vote per member per fact, value +1 (up) or -1 (down) -- voting again
+// with the same value retracts it, the opposite value switches it, mirroring
+// the toggle behavior already established for MemberListLike (a simpler
+// one-directional version of the same idea).
+model FunFactVote {
+  id        String   @id @default(cuid())
+  factId    String
+  userId    String
+  value     Int
+  createdAt DateTime @default(now())
+
+  fact FunFact @relation(fields: [factId], references: [id], onDelete: Cascade)
+  user User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, factId])
+  @@index([factId])
 }
 
 // --- Fight scenes ---

--- a/src/app/api/movies/[id]/fun-facts/[factId]/route.ts
+++ b/src/app/api/movies/[id]/fun-facts/[factId]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { MAX_FUN_FACT_LENGTH } from "@/lib/fun-facts";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { id: movieId, factId } = await params;
+  const existing = await prisma.funFact.findUnique({ where: { id: factId } });
+  if (!existing || existing.movieId !== movieId) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+  if (existing.submittedById !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own fun facts." }, { status: 403 });
+  }
+  if (existing.isDeleted) {
+    return NextResponse.json({ error: "This fun fact has been deleted." }, { status: 400 });
+  }
+
+  const { content } = await request.json();
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_FUN_FACT_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_FUN_FACT_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const fact = await prisma.funFact.update({
+    where: { id: factId },
+    data: { content: trimmedContent },
+    include: { submittedBy: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ fact });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { id: movieId, factId } = await params;
+  const existing = await prisma.funFact.findUnique({ where: { id: factId } });
+  if (!existing || existing.movieId !== movieId) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+
+  const isOwner = existing.submittedById === session.user.id;
+  const isAdmin = session.user.role === "ADMIN";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Soft-delete, same as discussion posts -- keeps the row (and its vote
+  // history) intact rather than hard-deleting.
+  await prisma.funFact.update({
+    where: { id: factId },
+    data: { isDeleted: true, content: "" },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/movies/[id]/fun-facts/[factId]/vote/route.ts
+++ b/src/app/api/movies/[id]/fun-facts/[factId]/vote/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to vote." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before voting." }, { status: 403 });
+  }
+
+  const { id: movieId, factId } = await params;
+  const { value } = await request.json();
+  if (value !== 1 && value !== -1) {
+    return NextResponse.json({ error: "value must be 1 or -1." }, { status: 400 });
+  }
+
+  const fact = await prisma.funFact.findUnique({ where: { id: factId } });
+  if (!fact || fact.movieId !== movieId || fact.isDeleted) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+  if (fact.submittedById === session.user.id) {
+    return NextResponse.json({ error: "You can't vote on your own fun fact." }, { status: 403 });
+  }
+
+  const existing = await prisma.funFactVote.findUnique({
+    where: { userId_factId: { userId: session.user.id, factId } },
+  });
+
+  let myVote: number | null;
+  if (!existing) {
+    await prisma.funFactVote.create({ data: { userId: session.user.id, factId, value } });
+    myVote = value;
+  } else if (existing.value === value) {
+    // Voting the same direction again retracts it, same toggle behavior as
+    // liking a list a second time.
+    await prisma.funFactVote.delete({ where: { id: existing.id } });
+    myVote = null;
+  } else {
+    await prisma.funFactVote.update({ where: { id: existing.id }, data: { value } });
+    myVote = value;
+  }
+
+  const [up, down] = await Promise.all([
+    prisma.funFactVote.count({ where: { factId, value: 1 } }),
+    prisma.funFactVote.count({ where: { factId, value: -1 } }),
+  ]);
+
+  return NextResponse.json({ myVote, up, down });
+}

--- a/src/app/api/movies/[id]/fun-facts/route.ts
+++ b/src/app/api/movies/[id]/fun-facts/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+import { MAX_FUN_FACT_LENGTH } from "@/lib/fun-facts";
+import { checkRateLimit, funFactSubmitLimiter } from "@/lib/rate-limit";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a fun fact." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a fun fact." }, { status: 403 });
+  }
+
+  const rateLimit = await checkRateLimit(funFactSubmitLimiter, session.user.id);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      { error: "You're adding facts too quickly. Try again shortly." },
+      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } },
+    );
+  }
+
+  const { id: movieId } = await params;
+  const { content } = await request.json();
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_FUN_FACT_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_FUN_FACT_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const movie = await prisma.movie.findUnique({ where: { id: movieId }, select: { id: true } });
+  if (!movie) {
+    return NextResponse.json({ error: "Movie not found." }, { status: 404 });
+  }
+
+  const fact = await prisma.funFact.create({
+    data: { movieId, submittedById: session.user.id, content: trimmedContent },
+    include: { submittedBy: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ fact });
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -24,12 +24,14 @@ import {
   getFightSceneTags,
   getFightSceneRoundNumbers,
 } from "@/lib/fight-scenes";
+import { getFunFactsForMovie, getFunFactVoteSummaries } from "@/lib/fun-facts";
 import { RatingWidget } from "@/components/rating-widget";
 import { AdminRatingWidget } from "@/components/admin-rating-widget";
 import { ListButtons } from "@/components/list-buttons";
 import { AddToListControl } from "@/components/add-to-list-control";
 import { DiscussionThread } from "@/components/discussion-thread";
 import { FightSceneSection } from "@/components/fight-scene-section";
+import { FunFactsSection } from "@/components/fun-facts-section";
 import { EditorialReview } from "@/components/editorial-review";
 import { PosterOverrideControl } from "@/components/poster-override-control";
 import { RecommendationControl } from "@/components/recommendation-control";
@@ -129,6 +131,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     editorialReview,
     movieRecommenders,
     recentFightCountEdits,
+    funFacts,
   ] = await Promise.all([
     getCommunityRatingSummary(movie.id),
     getEditorsRatingSummary(movie.id),
@@ -176,6 +179,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       take: 5,
       include: { editedBy: { select: { username: true } } },
     }),
+    getFunFactsForMovie(movie.id),
   ]);
 
   const myMemberListItems = myMemberLists.map((list) => ({
@@ -213,12 +217,15 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   );
 
   const fightSceneIds = fightScenes.map((s) => s.id);
+  const funFactIds = funFacts.map((f) => f.id);
   const [
     fightSceneRatingSummaries,
     fightSceneAdminRatingSummaries,
     myFightSceneRatings,
     myFightSceneAdminRatings,
     fightSceneRoundNumbers,
+    funFactVoteSummaries,
+    myFunFactVotes,
   ] = await Promise.all([
     getFightSceneRatingSummaries(fightSceneIds),
     getFightSceneAdminRatingSummaries(fightSceneIds),
@@ -233,6 +240,12 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         })
       : [],
     getFightSceneRoundNumbers(movie.id),
+    getFunFactVoteSummaries(funFactIds),
+    session?.user
+      ? prisma.funFactVote.findMany({
+          where: { userId: session.user.id, factId: { in: funFactIds } },
+        })
+      : [],
   ]);
 
   const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
@@ -286,6 +299,25 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     createdAt: edit.createdAt.toISOString(),
     editedBy: edit.editedBy,
   }));
+
+  const myFunFactVoteMap = new Map(myFunFactVotes.map((v) => [v.factId, v.value as 1 | -1]));
+  const serializedFunFacts = funFacts
+    .map((fact) => {
+      const summary = funFactVoteSummaries.get(fact.id);
+      return {
+        id: fact.id,
+        content: fact.content,
+        submittedById: fact.submittedById,
+        isDeleted: fact.isDeleted,
+        createdAt: fact.createdAt.toISOString(),
+        updatedAt: fact.updatedAt.toISOString(),
+        submittedBy: fact.submittedBy,
+        up: summary?.up ?? 0,
+        down: summary?.down ?? 0,
+        myVote: myFunFactVoteMap.get(fact.id) ?? null,
+      };
+    })
+    .sort((a, b) => b.up - b.down - (a.up - a.down));
 
   const serializedPosts = discussionPage.posts.map((post) => ({
     ...post,
@@ -502,6 +534,14 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           myMemberLists={myMemberLists.map((list) => ({ id: list.id, name: list.name }))}
           mySavedListIdsByScene={mySavedFightSceneListIds}
           myFavoriteSceneIds={myFavoriteFightSceneIds}
+        />
+
+        <FunFactsSection
+          movieId={movie.id}
+          initialFacts={serializedFunFacts}
+          signedIn={!!session?.user}
+          currentUserId={session?.user?.id ?? null}
+          isAdmin={session?.user?.role === "ADMIN"}
         />
 
         <div id="discussion">

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -308,7 +308,6 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         id: fact.id,
         content: fact.content,
         submittedById: fact.submittedById,
-        isDeleted: fact.isDeleted,
         createdAt: fact.createdAt.toISOString(),
         updatedAt: fact.updatedAt.toISOString(),
         submittedBy: fact.submittedBy,

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -8,7 +8,6 @@ export interface FunFactItem {
   id: string;
   content: string;
   submittedById: string;
-  isDeleted: boolean;
   createdAt: string;
   updatedAt: string;
   submittedBy: { username: string };
@@ -122,7 +121,11 @@ export function FunFactsSection({
       setError(body.error ?? "Something went wrong.");
       return;
     }
-    updateFact(id, (item) => ({ ...item, isDeleted: true, content: "" }));
+    // Unlike discussion posts, nothing else references a fun fact (no
+    // replies), and the server already excludes soft-deleted ones on
+    // reload -- so just drop it from the list rather than showing a
+    // "[deleted]" placeholder that would only ever appear pre-refresh.
+    setFacts((prev) => prev.filter((f) => f.id !== id));
   }
 
   async function vote(id: string, value: 1 | -1) {
@@ -214,10 +217,8 @@ export function FunFactsSection({
                 <div className="mb-1 flex items-center gap-2 text-sm">
                   <span className="font-medium text-neutral-100">{fact.submittedBy.username}</span>
                   <span className="text-neutral-500">{timeAgo(fact.createdAt)}</span>
-                  {!fact.isDeleted && wasEdited(fact) && (
-                    <span className="text-xs text-neutral-600">(edited)</span>
-                  )}
-                  {!fact.isDeleted && (canEdit || canDelete) && (
+                  {wasEdited(fact) && <span className="text-xs text-neutral-600">(edited)</span>}
+                  {(canEdit || canDelete) && (
                     <span className="inline-flex gap-2">
                       {canEdit && (
                         <button
@@ -239,9 +240,7 @@ export function FunFactsSection({
                   )}
                 </div>
 
-                {fact.isDeleted ? (
-                  <p className="text-sm italic text-neutral-500">[deleted]</p>
-                ) : editingId === fact.id ? (
+                {editingId === fact.id ? (
                   <div className="flex flex-col gap-2">
                     <textarea
                       value={editContent}

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -56,6 +56,10 @@ export function FunFactsSection({
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState("");
+  // Tracked by id rather than array index, since voting re-sorts `facts` by
+  // net score -- an index would silently jump the spotlight to a different
+  // fact the moment the current one's score changes.
+  const [spotlightId, setSpotlightId] = useState<string | null>(initialFacts[0]?.id ?? null);
 
   function updateFact(id: string, updater: (item: FunFactItem) => FunFactItem) {
     setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
@@ -77,7 +81,9 @@ export function FunFactsSection({
       return;
     }
     const { fact } = await res.json();
-    setFacts((prev) => [{ ...fact, up: 0, down: 0, myVote: null }, ...prev].sort(byNetScore));
+    const newFact = { ...fact, up: 0, down: 0, myVote: null };
+    setFacts((prev) => [newFact, ...prev].sort(byNetScore));
+    if (facts.length === 0) setSpotlightId(newFact.id);
     setNewContent("");
   }
 
@@ -125,7 +131,9 @@ export function FunFactsSection({
     // replies), and the server already excludes soft-deleted ones on
     // reload -- so just drop it from the list rather than showing a
     // "[deleted]" placeholder that would only ever appear pre-refresh.
-    setFacts((prev) => prev.filter((f) => f.id !== id));
+    const remaining = facts.filter((f) => f.id !== id);
+    setFacts(remaining);
+    if (spotlightId === id) setSpotlightId(remaining[0]?.id ?? null);
   }
 
   async function vote(id: string, value: 1 | -1) {
@@ -144,11 +152,25 @@ export function FunFactsSection({
     updateFact(id, (item) => ({ ...item, myVote, up, down }));
   }
 
+  function shiftSpotlight(direction: 1 | -1) {
+    if (facts.length === 0) return;
+    const currentIndex = facts.findIndex((f) => f.id === spotlightId);
+    const base = currentIndex === -1 ? 0 : currentIndex;
+    const nextIndex = (base + direction + facts.length) % facts.length;
+    setSpotlightId(facts[nextIndex].id);
+  }
+
+  const spotlightIndex = Math.max(
+    0,
+    facts.findIndex((f) => f.id === spotlightId),
+  );
+  const spotlightFact = facts[spotlightIndex] ?? null;
+
   return (
     <section className="mt-10 max-w-2xl">
       <h2 className="mb-4 font-serif text-xl font-bold text-white">Fun Facts</h2>
 
-      <div className="rounded-md border border-neutral-800 bg-neutral-900">
+      <div className="overflow-hidden rounded-md border border-neutral-800 bg-neutral-900">
         {signedIn ? (
           <div className="flex flex-col gap-2 border-b border-neutral-800 p-3">
             <textarea
@@ -182,67 +204,17 @@ export function FunFactsSection({
           </p>
         )}
 
-        <ul className="divide-y divide-neutral-800">
-          {facts.map((fact) => {
+        {spotlightFact ? (
+          (() => {
+            const fact = spotlightFact;
             const canEdit = currentUserId === fact.submittedById;
             const canDelete = canEdit || isAdmin;
             const canVote = signedIn && !canEdit;
 
             return (
-              <li key={fact.id} className="flex gap-3 p-3">
-                <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
-                <button
-                  onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
-                  disabled={!canVote}
-                  title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                  className={`rounded px-1.5 py-0.5 text-sm leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
-                    fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
-                  }`}
-                >
-                  👍
-                </button>
-                <span className="text-xs text-neutral-400">{fact.up - fact.down}</span>
-                <button
-                  onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
-                  disabled={!canVote}
-                  title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                  className={`rounded px-1.5 py-0.5 text-sm leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
-                    fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
-                  }`}
-                >
-                  👎
-                </button>
-              </div>
-
-              <div className="min-w-0 flex-1">
-                <div className="mb-1 flex items-center gap-2 text-sm">
-                  <span className="font-medium text-neutral-100">{fact.submittedBy.username}</span>
-                  <span className="text-neutral-500">{timeAgo(fact.createdAt)}</span>
-                  {wasEdited(fact) && <span className="text-xs text-neutral-600">(edited)</span>}
-                  {(canEdit || canDelete) && (
-                    <span className="inline-flex gap-2">
-                      {canEdit && (
-                        <button
-                          onClick={() => startEdit(fact)}
-                          className="text-xs text-neutral-400 hover:text-white"
-                        >
-                          Edit
-                        </button>
-                      )}
-                      {canDelete && (
-                        <button
-                          onClick={() => deleteFact(fact.id)}
-                          className="text-xs text-neutral-400 hover:text-red-400"
-                        >
-                          Delete
-                        </button>
-                      )}
-                    </span>
-                  )}
-                </div>
-
+              <div className="border-b border-neutral-800 bg-gradient-to-b from-red-950/20 to-transparent p-5 text-center">
                 {editingId === fact.id ? (
-                  <div className="flex flex-col gap-2">
+                  <div className="mx-auto flex max-w-md flex-col gap-2 text-left">
                     <textarea
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
@@ -267,16 +239,111 @@ export function FunFactsSection({
                     </div>
                   </div>
                 ) : (
-                  <p className="text-sm text-neutral-300">{fact.content}</p>
+                  <p className="text-lg text-neutral-100">&ldquo;{fact.content}&rdquo;</p>
+                )}
+
+                <p className="mt-2 text-xs text-neutral-500">
+                  — {fact.submittedBy.username}
+                  {spotlightIndex === 0 && ", highest voted"} · {timeAgo(fact.createdAt)}
+                  {wasEdited(fact) && " (edited)"}
+                </p>
+
+                <div className="mt-3 flex items-center justify-center gap-4">
+                  {facts.length > 1 && (
+                    <button
+                      onClick={() => shiftSpotlight(-1)}
+                      className="text-sm text-neutral-500 hover:text-neutral-300"
+                    >
+                      ‹ prev
+                    </button>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
+                      disabled={!canVote}
+                      title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                      className={`rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                        fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
+                      }`}
+                    >
+                      👍
+                    </button>
+                    <span className="text-sm text-neutral-400">{fact.up - fact.down}</span>
+                    <button
+                      onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
+                      disabled={!canVote}
+                      title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                      className={`rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                        fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
+                      }`}
+                    >
+                      👎
+                    </button>
+                  </div>
+                  {facts.length > 1 && (
+                    <button
+                      onClick={() => shiftSpotlight(1)}
+                      className="text-sm text-neutral-500 hover:text-neutral-300"
+                    >
+                      next ›
+                    </button>
+                  )}
+                </div>
+
+                {(canEdit || canDelete) && editingId !== fact.id && (
+                  <div className="mt-2 flex items-center justify-center gap-2">
+                    {canEdit && (
+                      <button
+                        onClick={() => startEdit(fact)}
+                        className="text-xs text-neutral-400 hover:text-white"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {canDelete && (
+                      <button
+                        onClick={() => deleteFact(fact.id)}
+                        className="text-xs text-neutral-400 hover:text-red-400"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
-              </li>
             );
-          })}
-          {facts.length === 0 && (
-            <li className="p-3 text-sm text-neutral-500">No fun facts yet. Be the first to add one.</li>
-          )}
-        </ul>
+          })()
+        ) : (
+          <p className="border-b border-neutral-800 p-5 text-center text-sm text-neutral-500">
+            No fun facts yet. Be the first to add one.
+          </p>
+        )}
+
+        {facts.length > 0 && (
+          <ul className="divide-y divide-neutral-800">
+            {facts.map((fact, i) => (
+              <li key={fact.id}>
+                <button
+                  onClick={() => setSpotlightId(fact.id)}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
+                    i === spotlightIndex ? "bg-neutral-800/40" : ""
+                  }`}
+                >
+                  <span
+                    className={
+                      fact.myVote === 1 ? "text-green-500" : fact.myVote === -1 ? "text-red-500" : "text-neutral-600"
+                    }
+                  >
+                    {fact.myVote === -1 ? "👎" : "👍"}
+                  </span>
+                  <span className="w-5 shrink-0 text-center text-xs text-neutral-500">{fact.up - fact.down}</span>
+                  <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
+                  <span className="min-w-0 flex-1 truncate text-neutral-400">{fact.content}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </section>
   );

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -145,51 +145,52 @@ export function FunFactsSection({
   }
 
   return (
-    <section className="mt-10">
+    <section className="mt-10 max-w-2xl">
       <h2 className="mb-4 font-serif text-xl font-bold text-white">Fun Facts</h2>
 
-      {signedIn ? (
-        <div className="mb-6 flex flex-col gap-2">
-          <textarea
-            value={newContent}
-            onChange={(e) => setNewContent(e.target.value)}
-            placeholder="Did you know…?"
-            rows={2}
-            maxLength={MAX_CONTENT_LENGTH}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
-          />
-          <div className="flex items-center gap-3">
-            <button
-              onClick={submit}
-              disabled={submitting || !newContent.trim()}
-              className="w-fit rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
-            >
-              Add fun fact
-            </button>
-            <span className="text-xs text-neutral-500">
-              {newContent.length}/{MAX_CONTENT_LENGTH}
-            </span>
+      <div className="rounded-md border border-neutral-800 bg-neutral-900">
+        {signedIn ? (
+          <div className="flex flex-col gap-2 border-b border-neutral-800 p-3">
+            <textarea
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              placeholder="Did you know…?"
+              rows={2}
+              maxLength={MAX_CONTENT_LENGTH}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            />
+            <div className="flex items-center gap-3">
+              <button
+                onClick={submit}
+                disabled={submitting || !newContent.trim()}
+                className="w-fit rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+              >
+                Add fun fact
+              </button>
+              <span className="text-xs text-neutral-500">
+                {newContent.length}/{MAX_CONTENT_LENGTH}
+              </span>
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
           </div>
-          {error && <p className="text-sm text-red-500">{error}</p>}
-        </div>
-      ) : (
-        <p className="mb-6 text-sm text-neutral-400">
-          <a href="/login" className="text-red-500 hover:underline">
-            Sign in
-          </a>{" "}
-          to add a fun fact.
-        </p>
-      )}
+        ) : (
+          <p className="border-b border-neutral-800 p-3 text-sm text-neutral-400">
+            <a href="/login" className="text-red-500 hover:underline">
+              Sign in
+            </a>{" "}
+            to add a fun fact.
+          </p>
+        )}
 
-      <ul className="flex flex-col gap-3">
-        {facts.map((fact) => {
-          const canEdit = currentUserId === fact.submittedById;
-          const canDelete = canEdit || isAdmin;
-          const canVote = signedIn && !canEdit;
+        <ul className="divide-y divide-neutral-800">
+          {facts.map((fact) => {
+            const canEdit = currentUserId === fact.submittedById;
+            const canDelete = canEdit || isAdmin;
+            const canVote = signedIn && !canEdit;
 
-          return (
-            <li key={fact.id} className="flex gap-3 rounded-md border border-neutral-800 bg-neutral-900 p-3">
-              <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
+            return (
+              <li key={fact.id} className="flex gap-3 p-3">
+                <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
                 <button
                   onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
                   disabled={!canVote}
@@ -269,13 +270,14 @@ export function FunFactsSection({
                   <p className="text-sm text-neutral-300">{fact.content}</p>
                 )}
               </div>
-            </li>
-          );
-        })}
-        {facts.length === 0 && (
-          <p className="text-sm text-neutral-500">No fun facts yet. Be the first to add one.</p>
-        )}
-      </ul>
+              </li>
+            );
+          })}
+          {facts.length === 0 && (
+            <li className="p-3 text-sm text-neutral-500">No fun facts yet. Be the first to add one.</li>
+          )}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+
+const MAX_CONTENT_LENGTH = 500;
+
+export interface FunFactItem {
+  id: string;
+  content: string;
+  submittedById: string;
+  isDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+  submittedBy: { username: string };
+  up: number;
+  down: number;
+  myVote: 1 | -1 | null;
+}
+
+function timeAgo(iso: string) {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function wasEdited(item: FunFactItem) {
+  return new Date(item.updatedAt).getTime() - new Date(item.createdAt).getTime() > 1000;
+}
+
+// Highest net score (up - down) first; stable otherwise, so ties keep
+// whatever order they arrived in (newest-submitted first, from the server).
+function byNetScore(a: FunFactItem, b: FunFactItem) {
+  return b.up - b.down - (a.up - a.down);
+}
+
+export function FunFactsSection({
+  movieId,
+  initialFacts,
+  signedIn,
+  currentUserId,
+  isAdmin,
+}: {
+  movieId: string;
+  initialFacts: FunFactItem[];
+  signedIn: boolean;
+  currentUserId: string | null;
+  isAdmin: boolean;
+}) {
+  const [facts, setFacts] = useState(initialFacts);
+  const [newContent, setNewContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+
+  function updateFact(id: string, updater: (item: FunFactItem) => FunFactItem) {
+    setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
+  }
+
+  async function submit() {
+    if (!newContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fun-facts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: newContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fact } = await res.json();
+    setFacts((prev) => [{ ...fact, up: 0, down: 0, myVote: null }, ...prev].sort(byNetScore));
+    setNewContent("");
+  }
+
+  function startEdit(item: FunFactItem) {
+    setEditingId(item.id);
+    setEditContent(item.content);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditContent("");
+  }
+
+  async function saveEdit(id: string) {
+    if (!editContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fun-facts/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: editContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fact } = await res.json();
+    updateFact(id, (item) => ({ ...item, content: fact.content, updatedAt: fact.updatedAt }));
+    cancelEdit();
+  }
+
+  async function deleteFact(id: string) {
+    if (!window.confirm("Delete this fun fact? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fun-facts/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    updateFact(id, (item) => ({ ...item, isDeleted: true, content: "" }));
+  }
+
+  async function vote(id: string, value: 1 | -1) {
+    setError(null);
+    const res = await fetch(`/api/movies/${movieId}/fun-facts/${id}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { myVote, up, down } = await res.json();
+    updateFact(id, (item) => ({ ...item, myVote, up, down }));
+  }
+
+  return (
+    <section className="mt-10">
+      <h2 className="mb-4 font-serif text-xl font-bold text-white">Fun Facts</h2>
+
+      {signedIn ? (
+        <div className="mb-6 flex flex-col gap-2">
+          <textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="Did you know…?"
+            rows={2}
+            maxLength={MAX_CONTENT_LENGTH}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              onClick={submit}
+              disabled={submitting || !newContent.trim()}
+              className="w-fit rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              Add fun fact
+            </button>
+            <span className="text-xs text-neutral-500">
+              {newContent.length}/{MAX_CONTENT_LENGTH}
+            </span>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+      ) : (
+        <p className="mb-6 text-sm text-neutral-400">
+          <a href="/login" className="text-red-500 hover:underline">
+            Sign in
+          </a>{" "}
+          to add a fun fact.
+        </p>
+      )}
+
+      <ul className="flex flex-col gap-3">
+        {facts.map((fact) => {
+          const canEdit = currentUserId === fact.submittedById;
+          const canDelete = canEdit || isAdmin;
+          const canVote = signedIn && !canEdit;
+
+          return (
+            <li key={fact.id} className="flex gap-3 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+              <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
+                <button
+                  onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
+                  disabled={!canVote}
+                  title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                  className={`rounded px-1.5 py-0.5 text-sm leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                    fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
+                  }`}
+                >
+                  👍
+                </button>
+                <span className="text-xs text-neutral-400">{fact.up - fact.down}</span>
+                <button
+                  onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
+                  disabled={!canVote}
+                  title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                  className={`rounded px-1.5 py-0.5 text-sm leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                    fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
+                  }`}
+                >
+                  👎
+                </button>
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex items-center gap-2 text-sm">
+                  <span className="font-medium text-neutral-100">{fact.submittedBy.username}</span>
+                  <span className="text-neutral-500">{timeAgo(fact.createdAt)}</span>
+                  {!fact.isDeleted && wasEdited(fact) && (
+                    <span className="text-xs text-neutral-600">(edited)</span>
+                  )}
+                  {!fact.isDeleted && (canEdit || canDelete) && (
+                    <span className="inline-flex gap-2">
+                      {canEdit && (
+                        <button
+                          onClick={() => startEdit(fact)}
+                          className="text-xs text-neutral-400 hover:text-white"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => deleteFact(fact.id)}
+                          className="text-xs text-neutral-400 hover:text-red-400"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </span>
+                  )}
+                </div>
+
+                {fact.isDeleted ? (
+                  <p className="text-sm italic text-neutral-500">[deleted]</p>
+                ) : editingId === fact.id ? (
+                  <div className="flex flex-col gap-2">
+                    <textarea
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      rows={2}
+                      maxLength={MAX_CONTENT_LENGTH}
+                      className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => saveEdit(fact.id)}
+                        disabled={submitting || !editContent.trim()}
+                        className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={cancelEdit}
+                        className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-neutral-300">{fact.content}</p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+        {facts.length === 0 && (
+          <p className="text-sm text-neutral-500">No fun facts yet. Be the first to add one.</p>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/fun-facts.ts
+++ b/src/lib/fun-facts.ts
@@ -1,0 +1,41 @@
+import { prisma } from "@/lib/prisma";
+
+// Short trivia snippet, not a discussion post — capped well below
+// MAX_DISCUSSION_CONTENT_LENGTH (5000) to keep entries scannable, matching
+// the length of a typical IMDB "Did you know" item.
+export const MAX_FUN_FACT_LENGTH = 500;
+
+export function getFunFactsForMovie(movieId: string) {
+  return prisma.funFact.findMany({
+    where: { movieId, isDeleted: false },
+    orderBy: { createdAt: "desc" },
+    include: { submittedBy: { select: { username: true } } },
+  });
+}
+
+export interface FunFactVoteSummary {
+  up: number;
+  down: number;
+}
+
+// No SQL-level up-minus-down aggregate spanning the group-by result, so the
+// net score used for sorting is computed in memory from these counts — same
+// tradeoff already made for Top Curators and fuzzy-search ranking.
+export async function getFunFactVoteSummaries(factIds: string[]): Promise<Map<string, FunFactVoteSummary>> {
+  if (factIds.length === 0) return new Map();
+
+  const rows = await prisma.funFactVote.groupBy({
+    by: ["factId", "value"],
+    where: { factId: { in: factIds } },
+    _count: { _all: true },
+  });
+
+  const map = new Map<string, FunFactVoteSummary>();
+  for (const row of rows) {
+    const summary = map.get(row.factId) ?? { up: 0, down: 0 };
+    if (row.value === 1) summary.up = row._count._all;
+    else if (row.value === -1) summary.down = row._count._all;
+    map.set(row.factId, summary);
+  }
+  return map;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -41,6 +41,7 @@ export const fightSceneSubmitLimiter = makeLimiter("fight-scene-submit", 10, "10
 export const movieSubmitLimiter = makeLimiter("movie-submit", 10, "10 m");
 export const listCreateLimiter = makeLimiter("list-create", 10, "10 m");
 export const fightCountEditLimiter = makeLimiter("fight-count-edit", 10, "10 m");
+export const funFactSubmitLimiter = makeLimiter("fun-fact-submit", 10, "10 m");
 
 export interface RateLimitResult {
   success: boolean;


### PR DESCRIPTION
## Summary

Adds an IMDB "Did you know"-style Fun Facts section above the Discussion thread on every movie page. Verified members can submit short trivia entries (500 chars max) and vote them up or down; other members can't vote on their own entries. The container is a spotlight + list design: the highest-voted fact rotates in a featured card (prev/next nav, vote/edit/delete controls), with a compact list of all facts below it — clicking a row jumps the spotlight to that fact.

**⚠️ Schema-touching PR**: adds `FunFact` and `FunFactVote` models plus a migration (`20260817205509_add_fun_facts`). Please merge/pull before starting another schema-touching PR to avoid migration conflicts.

- `FunFactVote` is the first **bidirectional** vote in the app (thumbs up/down, retract-on-repeat, switch-on-opposite) — existing `MemberListLike` is one-directional only.
- Ranked by net score (upvotes − downvotes) via `groupBy`, same in-memory-aggregate tradeoff as Top Curators and fuzzy search.
- Soft-delete (`isDeleted`), but unlike discussion posts the query filters `isDeleted: false` at the source (no replies depend on a fun fact staying visible), so a deleted fact just drops out of the list rather than showing a "[deleted]" placeholder.
- Requires a verified email to submit or vote, same bar as fight scenes/discussion posts.

## Checklist

- [x] `README.md` updated to reflect this change
- [x] `.env.example` updated if a new environment variable was added — n/a, no new env var
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Exhaustive functional verification via curl with two authenticated cookie jars (admin, member): create, self-vote-block (403), vote-up, vote-up-again-retract, vote-down-switch, cross-user-edit-block (403), owner-edit, 500-char-limit (400), admin-delete-any, post-delete-exclusion-on-reload.
- Playwright screenshots of the live rendered UI confirming: sort order by net score, conditional Edit/Delete visibility, the spotlight defaulting to the highest-voted fact, prev/next nav correctly cycling the spotlight, and clicking a list row jumping the spotlight to it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_