### PR TITLE
Paginate Fun Facts list, show down-votes, trim spotlight byline

### DIFF
--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 const MAX_CONTENT_LENGTH = 500;
+const PAGE_SIZE = 5;
 
 export interface FunFactItem {
   id: string;
@@ -54,6 +55,7 @@ export function FunFactsSection({
   // net score -- an index would silently jump the spotlight to a different
   // fact the moment the current one's score changes.
   const [spotlightId, setSpotlightId] = useState<string | null>(initialFacts[0]?.id ?? null);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   function updateFact(id: string, updater: (item: FunFactItem) => FunFactItem) {
     setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
@@ -76,8 +78,13 @@ export function FunFactsSection({
     }
     const { fact } = await res.json();
     const newFact = { ...fact, up: 0, down: 0, myVote: null };
-    setFacts((prev) => [newFact, ...prev].sort(byNetScore));
+    const next = [newFact, ...facts].sort(byNetScore);
+    setFacts(next);
     if (facts.length === 0) setSpotlightId(newFact.id);
+    // Keep the fact you just posted visible in the list even if it landed
+    // past the current page (a brand-new, unvoted fact can sort anywhere
+    // among other 0-net-score facts).
+    setVisibleCount((v) => Math.max(v, next.findIndex((f) => f.id === newFact.id) + 1));
     setNewContent("");
   }
 
@@ -152,6 +159,9 @@ export function FunFactsSection({
     const base = currentIndex === -1 ? 0 : currentIndex;
     const nextIndex = (base + direction + facts.length) % facts.length;
     setSpotlightId(facts[nextIndex].id);
+    // Expand the visible page so the newly-spotlighted fact's list row is
+    // still shown and highlighted, rather than paginated out of view.
+    setVisibleCount((v) => Math.max(v, nextIndex + 1));
   }
 
   const spotlightIndex = Math.max(
@@ -324,32 +334,53 @@ export function FunFactsSection({
 
         {facts.length > 0 && (
           <ul className="divide-y divide-neutral-800">
-            {facts.map((fact, i) => (
+            {facts.slice(0, visibleCount).map((fact) => (
               <li key={fact.id}>
                 <button
                   onClick={() => setSpotlightId(fact.id)}
-                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
-                    i === spotlightIndex ? "bg-neutral-800/40" : ""
+                  className={`flex w-full flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
+                    fact.id === spotlightId ? "bg-neutral-800/40" : ""
                   }`}
                 >
-                  <span className="w-6 shrink-0 text-center text-xs text-neutral-600">
-                    #{entryNumbers.get(fact.id)}
-                  </span>
-                  <span
-                    className={
-                      fact.myVote === 1 ? "text-green-500" : fact.myVote === -1 ? "text-red-500" : "text-neutral-600"
-                    }
-                  >
-                    {fact.myVote === -1 ? "👎" : "👍"}
-                  </span>
-                  <span className="w-5 shrink-0 text-center text-xs text-neutral-500">{fact.up - fact.down}</span>
-                  <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
-                  <span className="min-w-0 flex-1 truncate text-neutral-400">{fact.content}</span>
-                  <span className="shrink-0 text-xs text-neutral-600">{formatDate(fact.createdAt)}</span>
+                  <div className="flex items-center gap-2 text-xs text-neutral-500">
+                    <span className="shrink-0 text-neutral-600">#{entryNumbers.get(fact.id)}</span>
+                    <span
+                      className={
+                        fact.myVote === 1
+                          ? "text-green-500"
+                          : fact.myVote === -1
+                            ? "text-red-500"
+                            : "text-neutral-600"
+                      }
+                    >
+                      {fact.myVote === -1 ? "👎" : "👍"}
+                    </span>
+                    <span className="w-4 shrink-0 text-center">{fact.up - fact.down}</span>
+                    <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
+                    <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
+                  </div>
+                  <p className="text-neutral-300">{fact.content}</p>
                 </button>
               </li>
             ))}
           </ul>
+        )}
+
+        {visibleCount < facts.length && (
+          <button
+            onClick={() => setVisibleCount((v) => v + PAGE_SIZE)}
+            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+          >
+            Show {Math.min(PAGE_SIZE, facts.length - visibleCount)} more
+          </button>
+        )}
+        {visibleCount > PAGE_SIZE && visibleCount >= facts.length && (
+          <button
+            onClick={() => setVisibleCount(PAGE_SIZE)}
+            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+          >
+            Show less
+          </button>
         )}
       </div>
     </section>

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -55,7 +55,7 @@ export function FunFactsSection({
   // net score -- an index would silently jump the spotlight to a different
   // fact the moment the current one's score changes.
   const [spotlightId, setSpotlightId] = useState<string | null>(initialFacts[0]?.id ?? null);
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [page, setPage] = useState(1);
 
   function updateFact(id: string, updater: (item: FunFactItem) => FunFactItem) {
     setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
@@ -81,10 +81,10 @@ export function FunFactsSection({
     const next = [newFact, ...facts].sort(byNetScore);
     setFacts(next);
     if (facts.length === 0) setSpotlightId(newFact.id);
-    // Keep the fact you just posted visible in the list even if it landed
-    // past the current page (a brand-new, unvoted fact can sort anywhere
-    // among other 0-net-score facts).
-    setVisibleCount((v) => Math.max(v, next.findIndex((f) => f.id === newFact.id) + 1));
+    // Jump to whichever page the fact you just posted landed on (a
+    // brand-new, unvoted fact can sort anywhere among other 0-net-score
+    // facts, not necessarily page 1).
+    setPage(Math.floor(next.findIndex((f) => f.id === newFact.id) / PAGE_SIZE) + 1);
     setNewContent("");
   }
 
@@ -159,9 +159,9 @@ export function FunFactsSection({
     const base = currentIndex === -1 ? 0 : currentIndex;
     const nextIndex = (base + direction + facts.length) % facts.length;
     setSpotlightId(facts[nextIndex].id);
-    // Expand the visible page so the newly-spotlighted fact's list row is
-    // still shown and highlighted, rather than paginated out of view.
-    setVisibleCount((v) => Math.max(v, nextIndex + 1));
+    // Jump to whichever page the newly-spotlighted fact's list row is on,
+    // rather than leaving it paginated out of view.
+    setPage(Math.floor(nextIndex / PAGE_SIZE) + 1);
   }
 
   const spotlightIndex = Math.max(
@@ -178,6 +178,10 @@ export function FunFactsSection({
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
       .map((f, i) => [f.id, i + 1]),
   );
+
+  const totalPages = Math.max(1, Math.ceil(facts.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageFacts = facts.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   return (
     <section className="mt-10 max-w-2xl">
@@ -270,27 +274,26 @@ export function FunFactsSection({
                       ‹ prev
                     </button>
                   )}
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-3">
                     <button
                       onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
                       disabled={!canVote}
                       title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                      className={`rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                      className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
                         fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
                       }`}
                     >
-                      👍
+                      👍 <span className="text-sm">{fact.up}</span>
                     </button>
-                    <span className="text-sm text-neutral-400">{fact.up - fact.down}</span>
                     <button
                       onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
                       disabled={!canVote}
                       title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                      className={`rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                      className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
                         fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
                       }`}
                     >
-                      👎
+                      👎 <span className="text-sm">{fact.down}</span>
                     </button>
                   </div>
                   {facts.length > 1 && (
@@ -334,7 +337,7 @@ export function FunFactsSection({
 
         {facts.length > 0 && (
           <ul className="divide-y divide-neutral-800">
-            {facts.slice(0, visibleCount).map((fact) => (
+            {pageFacts.map((fact) => (
               <li key={fact.id}>
                 <button
                   onClick={() => setSpotlightId(fact.id)}
@@ -344,18 +347,12 @@ export function FunFactsSection({
                 >
                   <div className="flex items-center gap-2 text-xs text-neutral-500">
                     <span className="shrink-0 text-neutral-600">#{entryNumbers.get(fact.id)}</span>
-                    <span
-                      className={
-                        fact.myVote === 1
-                          ? "text-green-500"
-                          : fact.myVote === -1
-                            ? "text-red-500"
-                            : "text-neutral-600"
-                      }
-                    >
-                      {fact.myVote === -1 ? "👎" : "👍"}
+                    <span className={fact.myVote === 1 ? "text-green-500" : "text-neutral-600"}>
+                      👍 {fact.up}
                     </span>
-                    <span className="w-4 shrink-0 text-center">{fact.up - fact.down}</span>
+                    <span className={fact.myVote === -1 ? "text-red-500" : "text-neutral-600"}>
+                      👎 {fact.down}
+                    </span>
                     <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
                     <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
                   </div>
@@ -366,21 +363,38 @@ export function FunFactsSection({
           </ul>
         )}
 
-        {visibleCount < facts.length && (
-          <button
-            onClick={() => setVisibleCount((v) => v + PAGE_SIZE)}
-            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
-          >
-            Show {Math.min(PAGE_SIZE, facts.length - visibleCount)} more
-          </button>
-        )}
-        {visibleCount > PAGE_SIZE && visibleCount >= facts.length && (
-          <button
-            onClick={() => setVisibleCount(PAGE_SIZE)}
-            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
-          >
-            Show less
-          </button>
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-4 border-t border-neutral-800 py-2 text-sm">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              ‹
+            </button>
+            <div className="flex items-center gap-1">
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setPage(n)}
+                  className={`rounded border px-2 py-0.5 ${
+                    n === currentPage
+                      ? "border-red-700 bg-red-700 text-white"
+                      : "border-neutral-700 text-neutral-300 hover:bg-neutral-800"
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+              className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              ›
+            </button>
+          </div>
         )}
       </div>
     </section>

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -260,8 +260,7 @@ export function FunFactsSection({
                 )}
 
                 <p className="mt-2 text-xs text-neutral-500">
-                  Fun Fact #{entryNumbers.get(fact.id)} — {fact.submittedBy.username}
-                  {spotlightIndex === 0 && ", highest voted"} · {formatDate(fact.createdAt)}
+                  — {fact.submittedBy.username} · {formatDate(fact.createdAt)}
                   {wasEdited(fact) && " (edited)"}
                 </p>
 


### PR DESCRIPTION
## Summary

Three follow-up refinements to the Fun Facts list/pagination area, based on live feedback after #86:

- **Pagination + no more truncation**: the compact list previously rendered every fact in one shot and single-line-truncated each entry with an ellipsis, cutting off longer text. It's now paginated with classic numbered page controls (prev/next + page numbers — went with this over a card-grid or cumulative "show more" after comparing mockups), and rows wrap fully instead of truncating. Jumping the spotlight (prev/next, or posting a new fact) jumps to whichever page that fact landed on.
- **Down-vote counts**: each entry now shows `👍 {up}` and `👎 {down}` separately, in both the spotlight and the list rows, instead of only a combined net score.
- **Simplified spotlight byline**: dropped the "Fun Fact #N" label and ", highest voted" annotation from the spotlighted fact's byline — just submitter and date now.

No schema or API changes — all display-layer, working from data already being fetched.

## Checklist

- [x] `README.md` updated to reflect this change — n/a, no user-facing feature/permission change, just display refinements to an existing feature
- [x] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — n/a, UI-only iteration, no schema/architecture decision
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Playwright screenshots against a live 7-fact test case confirming: numbered pagination across 2 pages, correct sort/highlighting per page, both up/down counts displaying correctly (including after a live downvote), full text wrapping with no truncation, and the trimmed spotlight byline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_