### PR TITLE
Raise trending carousel autoplay cap from 1 lap to 5

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -53,6 +53,7 @@ one.
 - [`master` protected by a GitHub ruleset, no required review](#master-protected-by-a-github-ruleset-no-required-review)
 - [Reversed: Claude sessions no longer self-merge on green CI](#reversed-claude-sessions-no-longer-self-merge-on-green-ci)
 - [Vercel preview deployments deleted on PR close, to stop Neon preview-branch pileup](#vercel-preview-deployments-deleted-on-pr-close-to-stop-neon-preview-branch-pileup)
+- [Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production](#weekly-trending-carousels-cron-had-never-run-cron_secret-was-never-configured-in-production)
 
 **Feature Decisions**
 
@@ -844,7 +845,7 @@ if it turns out sessions need a stronger backstop later (e.g. one
 forgets to wait), revisit adding the GitHub-side requirement too.
 
 ### Vercel preview deployments deleted on PR close, to stop Neon preview-branch pileup
-**PR #TBD.** Found while debugging a build failure ("Branch limit reached")
+**PR #88.** Found while debugging a build failure ("Branch limit reached")
 on an unrelated PR: Vercel's Neon integration only deletes a preview
 database branch when its *last associated Vercel deployment* is deleted —
 not when the PR closes or the git branch is removed. Left to Vercel's own
@@ -879,6 +880,54 @@ all.
   `VERCEL_TOKEN` (a credential that can delete deployments) for something
   this small; the whole call is a handful of transparent lines in the
   workflow file itself.
+
+### Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production
+**Not a code bug.** Reported: the homepage's Weekly Trending Carousel (see
+`README.md`) had shown the same movies since launch. `getFeaturedMovies()`
+(`src/lib/weekly-featured.ts`) falls back to a static `ORDER BY
+tmdbPopularity DESC` list whenever the `WeeklyFeatured` table is empty, and
+that table is only ever written by `/api/cron/weekly-featured` — which
+`isAuthorized()` gates behind `CRON_SECRET`, returning a plain 401 with no
+alerting if that env var isn't set. It never had been: the Vercel project
+had no `CRON_SECRET` configured in Production at all, so every scheduled
+Monday cron invocation (and any manual one) had silently 401'd since launch,
+and nothing surfaced that failure anywhere a person would see it.
+
+- **Fix was operational, not a code change**: generated separate random
+  values for `CRON_SECRET` in Production and Preview (deliberately
+  different — Vercel's scheduled cron only ever invokes Production, and
+  each preview deployment already has its own isolated Neon database
+  branch, so a leaked Preview value can't touch production data anyway;
+  no reason to share the value regardless). Configured both in Vercel's
+  Environment Variables, then manually triggered
+  `/api/cron/weekly-featured` once via `curl` to backfill `WeeklyFeatured`
+  immediately instead of waiting for the next scheduled Monday run.
+- **The debugging dead-end that cost the most time**: repeated
+  `{"error":"Unauthorized"}` responses even after setting the secret and
+  clicking "Redeploy," which looked like a value mismatch (copy-paste
+  whitespace, wrong environment scope, stale deployment) and was
+  extensively ruled out as each of those individually — scope was
+  confirmed correct in the dashboard, a hand-typed trivial value
+  (`test123`) on both sides still failed, and Vercel's Logs panel
+  confirmed the failing requests really were hitting the current
+  Production deployment (`Environment: production`, `Branch: master`) and
+  executing cleanly, not being intercepted by a proxy or hitting a stale
+  deployment. **The actual cause was simpler and easy to miss**: each
+  "Redeploy" click was checked against the *previous* curl attempt before
+  that specific redeploy had actually gone `Ready` — comparing Vercel's
+  Logs panel Deployment ID against a fresh redeploy's own Deployment ID
+  (not just eyeballing "I clicked redeploy already") is what finally
+  confirmed a genuinely-new deployment, and only *that* one had the
+  secret live.
+- **Verified end-to-end, not just "no more 401"**: the successful curl
+  response (`{"weekStart":"2026-08-17T00:00:00.000Z","movieIds":[...]}`)
+  confirms `computeWeeklyFeatured()` actually ran and wrote real ranked
+  data, not just that auth passed.
+- Nothing about `computeWeeklyFeatured()`, `vercel.json`'s cron schedule,
+  or `isAuthorized()` needed to change — this was purely a missing
+  deployment-environment secret, invisible because the endpoint fails
+  silently (a 401 with no alerting) rather than surfacing anywhere an
+  operator would notice a launch-day misconfiguration.
 
 ## Feature Decisions
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -105,6 +105,7 @@ one.
 - [Profile tab fields made directly editable, no click-to-expand](#profile-tab-fields-made-directly-editable-no-click-to-expand)
 - [Social platform icons for the website/social link field](#social-platform-icons-for-the-websitesocial-link-field)
 - [Trending carousel clip autoplay bounded to one lap, paused when the tab is hidden](#trending-carousel-clip-autoplay-bounded-to-one-lap-paused-when-the-tab-is-hidden)
+- [Trending carousel autoplay cap raised from 1 lap to 5](#trending-carousel-autoplay-cap-raised-from-1-lap-to-5)
 
 **Deferred & Backlog**
 
@@ -1937,7 +1938,7 @@ icon + label** in place of raw URL text.
   domain falls back to the generic "Website" icon rather than breaking.
 
 ### Trending carousel clip autoplay bounded to one lap, paused when the tab is hidden
-**PR #TBD.** Reported bug: real visitors were sometimes seeing YouTube's
+**PR #88.** Reported bug: real visitors were sometimes seeing YouTube's
 "Sign in to confirm you're not a bot" interstitial render inside a hero
 carousel clip instead of the preview playing.
 
@@ -1967,6 +1968,30 @@ carousel clip instead of the preview playing.
   warranted, since the reported failures were intermittent, not universal,
   and the "Trending this week" hero specifically wants to show its clip
   without requiring an interaction first.
+
+### Trending carousel autoplay cap raised from 1 lap to 5
+**PR #TBD.** Follow-up to the one-lap cap above, after a report that clips
+stopped playing (reverting to static backdrops) after the first cycle
+through the carousel — the one-lap cap working exactly as designed, not a
+regression, but tighter than wanted.
+
+- **No measured "safe" number exists to raise it to** — asked directly
+  whether there's a maximum lap count that stays under YouTube's bot-check
+  threshold, and there isn't one to find: YouTube doesn't publish that
+  threshold, it isn't a flat per-app counter (visitor IP reputation,
+  request timing, and per-session browser signals all plausibly factor in,
+  none of which this app controls or can observe), and the original fix's
+  root-cause attribution was already an inference by elimination, not a
+  confirmed mechanism — extending it into a precise number would be
+  fabricating false confidence. **5** is a judgment call (explicit
+  instruction, "set it to 5"), not a validated bound.
+- Implemented as `MAX_AUTOPLAY_LAPS` (`src/components/hero-carousel.tsx`)
+  multiplying `movies.length` in the `autoRotations` comparison, rather
+  than hardcoding the multiplier inline — makes the traded-off value a
+  named, single place to revisit if it needs adjusting again.
+- Everything else about the original fix is unchanged: manual navigation
+  still doesn't count against the cap, and playback still pauses entirely
+  while the tab is hidden.
 
 ## Deferred & Backlog
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Each slide prefers a fight scene clip over the static TMDB backdrop:
 - **Playback**: muted, looping, no player controls, starts immediately when its slide becomes active.
 - **Accessibility**: never plays for visitors with `prefers-reduced-motion` set — they always see the static backdrop.
 - **Fallback**: a movie with no verified fight scene keeps the static backdrop unchanged.
-- **Bounded autoplay**: clips only autoplay for one lap through the carousel (each movie's clip shown once) and pause entirely while the browser tab is hidden. An idle tab left open would otherwise keep mounting a fresh autoplaying YouTube embed every rotation indefinitely, an unattended-playback pattern that can get a visitor's session shown YouTube's "Sign in to confirm you're not a bot" interstitial in place of the clip. Manually clicking through slides doesn't count against the one-lap cap.
+- **Bounded autoplay**: clips only autoplay for up to 5 laps through the carousel (`MAX_AUTOPLAY_LAPS` in `hero-carousel.tsx`) and pause entirely while the browser tab is hidden. An idle tab left open would otherwise keep mounting a fresh autoplaying YouTube embed every rotation indefinitely, an unattended-playback pattern that can get a visitor's session shown YouTube's "Sign in to confirm you're not a bot" interstitial in place of the clip. Manually clicking through slides doesn't count against the lap cap. The lap count is a judgment call, not a measured-safe number — YouTube doesn't publish a threshold for this.
 
 ## Security
 

--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -16,6 +16,12 @@ const FADE_MS = 700;
 // above so a slide's clip gets to finish once before the carousel advances,
 // instead of always being cut off mid-loop.
 const CLIP_SECONDS = 15;
+// How many full laps through the carousel autoplay clips before settling on
+// static backdrops for the rest of the visit. Not a measured-safe number —
+// YouTube doesn't publish a threshold for how much unattended autoplay
+// triggers its bot-check interstitial, so this is a judgment call trading
+// off "more highlight reel" against "more unattended autoplay requests."
+const MAX_AUTOPLAY_LAPS = 5;
 
 function clipEmbedUrl(videoId: string, startSeconds: number | null) {
   const start = startSeconds ?? 0;
@@ -100,10 +106,10 @@ export function HeroCarousel({ movies }: { movies: FeaturedMovie[] }) {
   // indefinite stream of unattended autoplay embed requests — exactly the
   // repeated-automated-playback pattern that gets an anonymous visitor's
   // session challenged with YouTube's "Sign in to confirm you're not a bot"
-  // interstitial. Capping it to one lap (every movie's clip shown once) still
-  // delivers the highlight reel without looping forever unattended; manual
-  // navigation doesn't count against the cap since a human clicking through
-  // is proof this isn't unattended playback.
+  // interstitial. Capping it to MAX_AUTOPLAY_LAPS laps still delivers the
+  // highlight reel without looping forever unattended; manual navigation
+  // doesn't count against the cap since a human clicking through is proof
+  // this isn't unattended playback.
   const [autoRotations, setAutoRotations] = useState(0);
   const [reducedMotion, setReducedMotion] = useState(
     () => typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
@@ -140,7 +146,7 @@ export function HeroCarousel({ movies }: { movies: FeaturedMovie[] }) {
     return () => clearTimeout(timer);
   }, [index]);
 
-  const playClip = !reducedMotion && !tabHidden && autoRotations < movies.length;
+  const playClip = !reducedMotion && !tabHidden && autoRotations < movies.length * MAX_AUTOPLAY_LAPS;
 
   useEffect(() => {
     if (movies.length <= 1 || paused || tabHidden) return;


### PR DESCRIPTION
## Summary

Follow-up to #88. Reported issue: after the one-lap autoplay cap from that PR, hero carousel clips stopped playing (reverting to static backdrops) after the first cycle through — the cap working exactly as designed, just tighter than wanted.

- Raised the cap from 1 lap to 5, extracted to a named `MAX_AUTOPLAY_LAPS` constant in `src/components/hero-carousel.tsx`.
- There's no measured "safe" number to raise it to — YouTube doesn't publish a bot-check threshold, and it's very unlikely to be a flat per-app counter (visitor IP reputation, request timing, and per-session signals plausibly factor in, none of which this app controls). 5 is an explicit judgment call, not a validated bound — see `DECISIONS.md` for the full reasoning.
- Everything else from #88 is unchanged: manual navigation still doesn't count against the cap, and playback still pauses entirely while the tab is hidden.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no
      user-facing feature, env var, setup step, or seed data changed)
- [ ] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated if this involved a real judgment call, an
      architecture/schema-shaping change, or an explicit deferral (or not
      applicable — no such decision here)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Ran `npx eslint` and a full `npm run build` locally — both clean.
- No functional/behavioral testing beyond build/lint for this one (single-constant change, same logic path as the already-verified #88 fix).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzpkHbk1p4Ds2tEVGXwZNj)_