### PR TITLE
Preview: throwaway swipeable fight scene feed

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -54,6 +54,7 @@ one.
 - [Reversed: Claude sessions no longer self-merge on green CI](#reversed-claude-sessions-no-longer-self-merge-on-green-ci)
 - [Vercel preview deployments deleted on PR close, to stop Neon preview-branch pileup](#vercel-preview-deployments-deleted-on-pr-close-to-stop-neon-preview-branch-pileup)
 - [Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production](#weekly-trending-carousels-cron-had-never-run-cron_secret-was-never-configured-in-production)
+- [Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch](#preview-database-made-static-across-prs-trading-back-the-migration-collision-risk-to-stop-re-seeding-every-branch)
 
 **Feature Decisions**
 
@@ -928,6 +929,39 @@ and nothing surfaced that failure anywhere a person would see it.
   deployment-environment secret, invisible because the endpoint fails
   silently (a 401 with no alerting) rather than surfacing anywhere an
   operator would notice a launch-day misconfiguration.
+
+### Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch
+**Infra-only change — no PR, no code diff.** Decided while staging a
+throwaway preview for the swipeable-fight-scenes backlog item: the
+per-branch Neon isolation from "Production migration incident" above means
+every new PR starts from a completely empty database, so getting an admin
+login and any real content into a preview meant re-running `prisma db seed`
+(or a manual SQL `UPDATE` for the account, plus manual data entry) on every
+single new branch. Decided that cost was worse than the risk it was
+protecting against for this project's actual pace of parallel work.
+
+- **What changes**: the Neon integration's per-git-branch auto-provisioning
+  is turned off for the Preview environment. One dedicated, long-lived Neon
+  branch (seeded once) is used for every preview deployment from here on,
+  via a static `DATABASE_URL` scoped to the Preview environment only —
+  the same pattern Production's own `DATABASE_URL` already uses (a
+  manually-set variable, narrowed to one environment), just applied to
+  Preview too.
+- **Production stays fully isolated** — this only merges Preview with
+  itself across PRs, not with Production. The original incident (one
+  connection string doing double duty for *both*) is not being
+  reintroduced.
+- **The tradeoff, explicitly accepted, not overlooked**: concurrent
+  unmerged PRs with different pending schema migrations now race against
+  the same shared tables again — the exact mechanism the per-branch
+  isolation was built to prevent. Mitigation is leaning harder on this
+  file's own "Stay in sync with master" and schema-touching-PR conventions
+  in `CLAUDE.md`, since Preview no longer absorbs that collision silently.
+- **`vercel-preview-cleanup.yml` still applies, just for a narrower job**:
+  it keeps deleting stale Vercel deployments on PR close (so the Neon
+  Free-plan branch-count limit from that same incident doesn't get
+  re-triggered by deployment pileup), but no longer cascades into deleting
+  a Neon branch, since no single deployment owns the shared one anymore.
 
 ## Feature Decisions
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2170,7 +2170,26 @@ regression, but tighter than wanted.
   vertically-scrollable/swipeable viewer that autoplays the next clip —
   same interaction pattern as YouTube Shorts/Instagram Reels/TikTok. A
   real UI paradigm shift from the existing list-based layout, not a
-  reskin — needs its own scoping pass (autoplay/mute behavior, how
-  rating/favoriting works in a full-screen single-clip view, how it
-  interacts with the existing movie-scoped `FightSceneSection` vs. the
-  cross-movie `/search/fight-scenes` page) before it's buildable.
+  reskin. Explored further (design review + a throwaway preview build on
+  PR #90, not merged), still deferred — not enough conviction yet to
+  commit to building the real feature:
+  - Three chrome-treatment concepts were mocked up (rail-and-caption,
+    ticket-stub overlay, minimal-chrome-tap-to-reveal); leaning toward the
+    ticket-stub overlay since it's the only one that carries the site's
+    existing "Fight Ticket" visual identity into full-screen rather than
+    reading as a generic short-video clone.
+  - A throwaway route (`/preview/fight-scene-feed` + `fight-scene-feed-preview.tsx`
+    on PR #90) confirmed the mechanics: native CSS scroll-snap +
+    `IntersectionObserver` for the active card, no new dependency needed;
+    `HeroCarousel`'s muted-autoplay/reduced-motion/tab-hidden pattern
+    reused directly. One real gotcha hit while building it: a full-bleed
+    route still renders inside the root layout's shared navbar/footer
+    unless it explicitly escapes with `fixed inset-0`.
+  - Still unscoped before this is buildable for real: a compact
+    rating/favorite overlay (the existing 10-button `RatingRow` and full
+    ticket card don't fit over video — porting `StarRatingPicker` is the
+    likely fix), a cursor-paginated fight-scene API (today's card-grid and
+    search page both slice an already-fetched array, which doesn't work
+    for a feed that must prefetch ahead of scroll position), and real
+    entry points from `FightSceneSection`/`/search/fight-scenes` (the
+    preview route is direct-navigate only, not linked from anywhere).

--- a/src/app/preview/fight-scene-feed/page.tsx
+++ b/src/app/preview/fight-scene-feed/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { prisma } from "@/lib/prisma";
+import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries } from "@/lib/fight-scenes";
+import { FightSceneFeedPreview } from "@/components/fight-scene-feed-preview";
+
+// Throwaway route for the "swipeable fight scenes" backlog item — not linked
+// from anywhere in the app, just a direct-navigate preview so the swipe/
+// autoplay feel can be judged with real clips before deciding whether to
+// build the real feature. Delete this route (and the component it renders)
+// once the decision is made either way.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+const PREVIEW_SIZE = 15;
+
+export default async function FightSceneFeedPreviewPage() {
+  const scenes = await prisma.fightScene.findMany({
+    where: { isDeleted: false, isVerified: true },
+    orderBy: { createdAt: "desc" },
+    take: PREVIEW_SIZE,
+    include: {
+      movie: { select: { id: true, title: true, releaseDate: true } },
+      tags: true,
+      cast: { orderBy: { order: "asc" }, include: { person: true } },
+    },
+  });
+
+  const [memberSummaries, editorSummaries] = await Promise.all([
+    getFightSceneRatingSummaries(scenes.map((s) => s.id)),
+    getFightSceneAdminRatingSummaries(scenes.map((s) => s.id)),
+  ]);
+
+  const feedScenes = scenes.map((scene) => ({
+    id: scene.id,
+    title: scene.title,
+    youtubeVideoId: scene.youtubeVideoId,
+    youtubeStartSeconds: scene.youtubeStartSeconds,
+    movie: scene.movie,
+    cast: scene.cast.map((c) => ({ id: c.person.id, name: c.person.name })),
+    tags: scene.tags.map((t) => ({ id: t.id, name: t.name })),
+    memberRatingAverage: memberSummaries.get(scene.id)?.average ?? null,
+    memberRatingCount: memberSummaries.get(scene.id)?.count ?? 0,
+    editorRatingAverage: editorSummaries.get(scene.id)?.average ?? null,
+    editorRatingCount: editorSummaries.get(scene.id)?.count ?? 0,
+  }));
+
+  return <FightSceneFeedPreview scenes={feedScenes} />;
+}

--- a/src/components/fight-scene-feed-preview.tsx
+++ b/src/components/fight-scene-feed-preview.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { youtubeThumbnailUrl } from "@/lib/youtube";
+
+// Throwaway companion to src/app/preview/fight-scene-feed/page.tsx — see
+// that file's comment. Deliberately skips real favoriting/rating (no click
+// handlers, no API calls) since the only thing being judged here is the
+// swipe/autoplay feel, not the full feature.
+
+const TICKET_INK = "#1a1712";
+const TICKET_MUTED = "#6b6148";
+const TICKET_STAMP = "#a4291e";
+
+export interface FeedScene {
+  id: string;
+  title: string;
+  youtubeVideoId: string;
+  youtubeStartSeconds: number | null;
+  movie: { id: string; title: string; releaseDate: Date | string | null };
+  cast: { id: string; name: string }[];
+  tags: { id: string; name: string }[];
+  memberRatingAverage: number | null;
+  memberRatingCount: number;
+  editorRatingAverage: number | null;
+  editorRatingCount: number;
+}
+
+function embedUrl(videoId: string, startSeconds: number | null) {
+  const params = new URLSearchParams({
+    autoplay: "1",
+    mute: "1",
+    controls: "1",
+    playsinline: "1",
+    rel: "0",
+  });
+  if (startSeconds) params.set("start", String(startSeconds));
+  return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`;
+}
+
+function Card({ scene, active }: { scene: FeedScene; active: boolean }) {
+  const [reducedMotion, setReducedMotion] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  const [tabHidden, setTabHidden] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setReducedMotion(query.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  useEffect(() => {
+    const onVisibilityChange = () => setTabHidden(document.hidden);
+    onVisibilityChange();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
+  const year = scene.movie.releaseDate ? new Date(scene.movie.releaseDate).getFullYear() : null;
+  const playVideo = active && !reducedMotion && !tabHidden;
+
+  return (
+    <section className="relative h-dvh w-full shrink-0 snap-start snap-always bg-black">
+      {playVideo ? (
+        <iframe
+          key={scene.id}
+          src={embedUrl(scene.youtubeVideoId, scene.youtubeStartSeconds)}
+          title={scene.title}
+          allow="autoplay; encrypted-media"
+          className="absolute left-1/2 top-1/2 h-[130%] w-[130%] -translate-x-1/2 -translate-y-1/2 border-0"
+        />
+      ) : (
+        <div
+          className="absolute inset-0 bg-cover bg-center opacity-70"
+          style={{ backgroundImage: `url(${youtubeThumbnailUrl(scene.youtubeVideoId)})` }}
+        />
+      )}
+
+      {/* "Fight Ticket" overlay — same cream/ink/stamp palette as
+          fight-scene-result-card.tsx, carried into the full-screen view. */}
+      <div
+        className="absolute inset-x-0 bottom-0 px-4 pt-4 pb-6 font-mono"
+        style={{
+          color: TICKET_INK,
+          background: "rgba(232, 220, 196, 0.96)",
+          clipPath: "polygon(0 10px, 10px 0, calc(100% - 10px) 0, 100% 10px, 100% 100%, 0 100%)",
+        }}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-[10px] tracking-wider uppercase" style={{ color: TICKET_MUTED }}>
+              {scene.movie.title} {year && `(${year})`}
+            </p>
+            <p className="mt-0.5 truncate text-lg font-bold" style={{ fontFamily: "Georgia, serif" }}>
+              {scene.title}
+            </p>
+          </div>
+          {scene.memberRatingAverage !== null && (
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 text-sm font-bold"
+              style={{ borderColor: TICKET_STAMP, color: TICKET_STAMP, transform: "rotate(-8deg)" }}
+            >
+              {scene.memberRatingAverage.toFixed(1)}
+            </div>
+          )}
+        </div>
+        {scene.cast.length > 0 && (
+          <p className="mt-2 truncate text-[11px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
+            Featuring {scene.cast.map((c) => c.name).join(", ")}
+          </p>
+        )}
+        {scene.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {scene.tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="border px-2 py-0.5 text-[10px] tracking-wide uppercase"
+                style={{ borderColor: TICKET_INK }}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function FightSceneFeedPreview({ scenes }: { scenes: FeedScene[] }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio > 0.6) {
+            const index = cardRefs.current.findIndex((el) => el === entry.target);
+            if (index !== -1) setActiveIndex(index);
+          }
+        }
+      },
+      { threshold: [0, 0.6, 1] },
+    );
+    for (const el of cardRefs.current) {
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [scenes.length]);
+
+  if (scenes.length === 0) {
+    return (
+      <div className="flex h-dvh w-full items-center justify-center bg-neutral-950 text-neutral-400">
+        No verified fight scenes to preview yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Link
+        href="/search/fight-scenes"
+        className="fixed left-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white"
+        aria-label="Exit preview"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4">
+          <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </Link>
+      <div ref={containerRef} className="h-dvh w-full snap-y snap-mandatory overflow-y-scroll">
+        {scenes.map((scene, i) => (
+          <div key={scene.id} ref={(el) => { cardRefs.current[i] = el; }}>
+            <Card scene={scene} active={i === activeIndex} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/fight-scene-feed-preview.tsx
+++ b/src/components/fight-scene-feed-preview.tsx
@@ -155,14 +155,14 @@ export function FightSceneFeedPreview({ scenes }: { scenes: FeedScene[] }) {
 
   if (scenes.length === 0) {
     return (
-      <div className="flex h-dvh w-full items-center justify-center bg-neutral-950 text-neutral-400">
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950 text-neutral-400">
         No verified fight scenes to preview yet.
       </div>
     );
   }
 
   return (
-    <div className="relative">
+    <div className="fixed inset-0 z-50 bg-black">
       <Link
         href="/search/fight-scenes"
         className="fixed left-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white"


### PR DESCRIPTION
## Summary

Throwaway preview for the "swipeable fight scenes" backlog item — a direct-navigate-only route at `/preview/fight-scene-feed` (not linked anywhere in the app) so the swipe/autoplay feel can be judged against real clips before deciding whether to build the real feature.

- Full-screen, scroll-snap vertical feed over the 15 most recent verified fight scenes
- Muted autoplay on the active card only (`IntersectionObserver`), paused on tab-hidden and skipped under `prefers-reduced-motion` — same guards as `HeroCarousel`
- The existing cream/ink "Fight Ticket" overlay (from `fight-scene-result-card.tsx`) carried into full-screen, per the design discussion for this backlog item
- No favoriting/rating wiring, no new API, no schema changes — deliberately scoped down to just the swipe/playback mechanic

**Not meant to merge as-is.** This is scaffolding to look at, not a shipped feature — delete or supersede once a direction is picked.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the changed files
- [x] `npm run build` succeeds, route appears in the build output
- [ ] Open the Vercel preview URL on a phone and judge the swipe/autoplay feel


---
_Generated by [Claude Code](https://claude.ai/code/session_014YKEAVDuFVqPBHM5isvuRd)_