### PR TITLE
Document static preview database decision and defer swipeable fight scenes

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -54,6 +54,7 @@ one.
 - [Reversed: Claude sessions no longer self-merge on green CI](#reversed-claude-sessions-no-longer-self-merge-on-green-ci)
 - [Vercel preview deployments deleted on PR close, to stop Neon preview-branch pileup](#vercel-preview-deployments-deleted-on-pr-close-to-stop-neon-preview-branch-pileup)
 - [Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production](#weekly-trending-carousels-cron-had-never-run-cron_secret-was-never-configured-in-production)
+- [Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch](#preview-database-made-static-across-prs-trading-back-the-migration-collision-risk-to-stop-re-seeding-every-branch)
 
 **Feature Decisions**
 
@@ -928,6 +929,39 @@ and nothing surfaced that failure anywhere a person would see it.
   deployment-environment secret, invisible because the endpoint fails
   silently (a 401 with no alerting) rather than surfacing anywhere an
   operator would notice a launch-day misconfiguration.
+
+### Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch
+**Infra-only change — no PR, no code diff.** Decided while staging a
+throwaway preview for the swipeable-fight-scenes backlog item: the
+per-branch Neon isolation from "Production migration incident" above means
+every new PR starts from a completely empty database, so getting an admin
+login and any real content into a preview meant re-running `prisma db seed`
+(or a manual SQL `UPDATE` for the account, plus manual data entry) on every
+single new branch. Decided that cost was worse than the risk it was
+protecting against for this project's actual pace of parallel work.
+
+- **What changes**: the Neon integration's per-git-branch auto-provisioning
+  is turned off for the Preview environment. One dedicated, long-lived Neon
+  branch (seeded once) is used for every preview deployment from here on,
+  via a static `DATABASE_URL` scoped to the Preview environment only —
+  the same pattern Production's own `DATABASE_URL` already uses (a
+  manually-set variable, narrowed to one environment), just applied to
+  Preview too.
+- **Production stays fully isolated** — this only merges Preview with
+  itself across PRs, not with Production. The original incident (one
+  connection string doing double duty for *both*) is not being
+  reintroduced.
+- **The tradeoff, explicitly accepted, not overlooked**: concurrent
+  unmerged PRs with different pending schema migrations now race against
+  the same shared tables again — the exact mechanism the per-branch
+  isolation was built to prevent. Mitigation is leaning harder on this
+  file's own "Stay in sync with master" and schema-touching-PR conventions
+  in `CLAUDE.md`, since Preview no longer absorbs that collision silently.
+- **`vercel-preview-cleanup.yml` still applies, just for a narrower job**:
+  it keeps deleting stale Vercel deployments on PR close (so the Neon
+  Free-plan branch-count limit from that same incident doesn't get
+  re-triggered by deployment pileup), but no longer cascades into deleting
+  a Neon branch, since no single deployment owns the shared one anymore.
 
 ## Feature Decisions
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2170,7 +2170,26 @@ regression, but tighter than wanted.
   vertically-scrollable/swipeable viewer that autoplays the next clip —
   same interaction pattern as YouTube Shorts/Instagram Reels/TikTok. A
   real UI paradigm shift from the existing list-based layout, not a
-  reskin — needs its own scoping pass (autoplay/mute behavior, how
-  rating/favoriting works in a full-screen single-clip view, how it
-  interacts with the existing movie-scoped `FightSceneSection` vs. the
-  cross-movie `/search/fight-scenes` page) before it's buildable.
+  reskin. Explored further (design review + a throwaway preview build on
+  PR #90, not merged), still deferred — not enough conviction yet to
+  commit to building the real feature:
+  - Three chrome-treatment concepts were mocked up (rail-and-caption,
+    ticket-stub overlay, minimal-chrome-tap-to-reveal); leaning toward the
+    ticket-stub overlay since it's the only one that carries the site's
+    existing "Fight Ticket" visual identity into full-screen rather than
+    reading as a generic short-video clone.
+  - A throwaway route (`/preview/fight-scene-feed` + `fight-scene-feed-preview.tsx`
+    on PR #90) confirmed the mechanics: native CSS scroll-snap +
+    `IntersectionObserver` for the active card, no new dependency needed;
+    `HeroCarousel`'s muted-autoplay/reduced-motion/tab-hidden pattern
+    reused directly. One real gotcha hit while building it: a full-bleed
+    route still renders inside the root layout's shared navbar/footer
+    unless it explicitly escapes with `fixed inset-0`.
+  - Still unscoped before this is buildable for real: a compact
+    rating/favorite overlay (the existing 10-button `RatingRow` and full
+    ticket card don't fit over video — porting `StarRatingPicker` is the
+    likely fix), a cursor-paginated fight-scene API (today's card-grid and
+    search page both slice an already-fetched array, which doesn't work
+    for a feed that must prefetch ahead of scroll position), and real
+    entry points from `FightSceneSection`/`/search/fight-scenes` (the
+    preview route is direct-navigate only, not linked from anywhere).


### PR DESCRIPTION
## Summary

Doc-only PR, split out of #90 so these two `DECISIONS.md` entries land on `master` independent of the deferred feature work:

- **Preview database made static across PRs** — records the already-live infra change (Vercel's Neon integration reconfigured so Preview points at one persistent branch instead of a fresh isolated branch per PR), why it was worth the tradeoff, and the migration-collision risk it reopens.
- **Swipeable fight scenes backlog entry, updated** — records what came out of a design review and a throwaway preview build (PR #90, not merged): the chrome-treatment direction, confirmed scroll-snap/autoplay mechanics, and what's still unscoped before the feature is buildable.

No code changes. `master`'s actual preview-deployment behavior already reflects the first entry; this just catches the documentation up to reality so other conversations working on this repo know Preview is shared now and why.

## Test plan

- [x] Cherry-picked cleanly from PR #90, no conflicts
- [x] Doc-only change, no build/lint impact


---
_Generated by [Claude Code](https://claude.ai/code/session_014YKEAVDuFVqPBHM5isvuRd)_