### PR TITLE
Fight scene permalink fixes: full-width card, bigger "more fights" chips

### DIFF
--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -188,25 +188,25 @@ export default async function FightScenePage({ params }: { params: Promise<Param
         {otherScenes.length > 0 && (
           <>
             <p className="mb-2 font-mono text-[11px] tracking-wide text-neutral-500 uppercase">More fights from this movie</p>
-            <div className="rail-scrollbar flex gap-3 overflow-x-auto pb-1">
+            <div className="rail-scrollbar flex gap-4 overflow-x-auto pb-1">
               {otherScenes.map((other) => {
                 const otherRating = otherSceneRatings.get(other.id);
                 return (
                   <Link
                     key={other.id}
                     href={`/movies/${movieId}/fight-scenes/${other.id}`}
-                    className="flex w-[240px] shrink-0 items-center gap-3 rounded-md border border-neutral-800 p-2 text-neutral-300 hover:border-neutral-600"
+                    className="flex w-[320px] shrink-0 items-center gap-3.5 rounded-md border border-neutral-800 p-3 text-neutral-300 hover:border-neutral-600"
                   >
-                    <div className="relative h-14 w-24 shrink-0 overflow-hidden rounded-sm bg-neutral-950">
-                      <YoutubeThumbnailImage videoId={other.youtubeVideoId} title={other.title} textClassName="text-[8px]" />
+                    <div className="relative h-16 w-28 shrink-0 overflow-hidden rounded-sm bg-neutral-950">
+                      <YoutubeThumbnailImage videoId={other.youtubeVideoId} title={other.title} textClassName="text-[9px]" />
                     </div>
                     <div className="min-w-0">
-                      <p className="font-mono text-[10px] tracking-wide text-neutral-500 uppercase">
+                      <p className="font-mono text-xs tracking-wide text-neutral-500 uppercase">
                         Round {roundNumbers.get(other.id) ?? "?"}
                       </p>
-                      <p className="truncate font-mono text-sm text-neutral-300">{other.title}</p>
+                      <p className="truncate font-mono text-base text-neutral-300">{other.title}</p>
                       {otherRating?.count ? (
-                        <p className="font-mono text-xs" style={{ color: "#a4291e" }}>
+                        <p className="font-mono text-sm" style={{ color: "#a4291e" }}>
                           {otherRating.average?.toFixed(1)} <span className="text-neutral-600">({otherRating.count})</span>
                         </p>
                       ) : null}

--- a/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
+++ b/src/app/movies/[id]/fight-scenes/[fightSceneId]/page.tsx
@@ -188,25 +188,25 @@ export default async function FightScenePage({ params }: { params: Promise<Param
         {otherScenes.length > 0 && (
           <>
             <p className="mb-2 font-mono text-[11px] tracking-wide text-neutral-500 uppercase">More fights from this movie</p>
-            <div className="rail-scrollbar flex gap-2 overflow-x-auto pb-1">
+            <div className="rail-scrollbar flex gap-3 overflow-x-auto pb-1">
               {otherScenes.map((other) => {
                 const otherRating = otherSceneRatings.get(other.id);
                 return (
                   <Link
                     key={other.id}
                     href={`/movies/${movieId}/fight-scenes/${other.id}`}
-                    className="flex w-[180px] shrink-0 items-center gap-2.5 rounded-md border border-neutral-800 p-1.5 text-neutral-300 hover:border-neutral-600"
+                    className="flex w-[240px] shrink-0 items-center gap-3 rounded-md border border-neutral-800 p-2 text-neutral-300 hover:border-neutral-600"
                   >
-                    <div className="relative h-9 w-16 shrink-0 overflow-hidden rounded-sm bg-neutral-950">
-                      <YoutubeThumbnailImage videoId={other.youtubeVideoId} title={other.title} textClassName="text-[6px]" />
+                    <div className="relative h-14 w-24 shrink-0 overflow-hidden rounded-sm bg-neutral-950">
+                      <YoutubeThumbnailImage videoId={other.youtubeVideoId} title={other.title} textClassName="text-[8px]" />
                     </div>
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] tracking-wide text-neutral-500 uppercase">
+                      <p className="font-mono text-[10px] tracking-wide text-neutral-500 uppercase">
                         Round {roundNumbers.get(other.id) ?? "?"}
                       </p>
-                      <p className="truncate font-mono text-xs text-neutral-300">{other.title}</p>
+                      <p className="truncate font-mono text-sm text-neutral-300">{other.title}</p>
                       {otherRating?.count ? (
-                        <p className="font-mono text-[10px]" style={{ color: "#a4291e" }}>
+                        <p className="font-mono text-xs" style={{ color: "#a4291e" }}>
                           {otherRating.average?.toFixed(1)} <span className="text-neutral-600">({otherRating.count})</span>
                         </p>
                       ) : null}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -569,7 +569,10 @@ export function FightSceneSection({
         </div>
       )}
 
-      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {/* detail mode is always a single scene meant to fill the page's width, not a grid
+          cell sized for scanning many cards — the multi-column grid defeats the point of
+          the bigger video if left on here. */}
+      <ul className={detail ? "grid grid-cols-1" : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"}>
         {visibleScenes.map((scene) => {
           const canEdit = currentUserId === scene.submittedById;
           const canDelete = canEdit || isAdmin;


### PR DESCRIPTION
## Summary

Two follow-ups from reviewing #94 on prod:

- **The detail card was stuck narrow.** The video wasn't actually growing to fill the page width as intended — it grew to fill its *grid cell*, but that cell was still capped by the movie page's `lg:grid-cols-3` layout, since the `<ul>` wrapper in `FightSceneSection` never got a single-column override for `detail` mode. Fixed: `<ul className={detail ? "grid grid-cols-1" : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"}>`. `detail` always renders a single scene meant to fill the page, never a grid of cards to scan.
- **"More fights from this movie" chips were too small.** Bumped from 180px to 240px wide, thumbnail from 36×64 to 56×96, and each text size up a notch.

No other behavior changes — the movie page's grid view (no `detail` prop) is unaffected by either change.

## Checklist

- [x] `README.md` — not applicable, layout/sizing fixes, not a behavior or feature change
- [x] `.env.example` — not applicable
- [x] `DECISIONS.md` — not applicable, mechanical fixes, not judgment calls
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` — clean.
- `npm run build` — compiles and typechecks clean.
- Grid-width bug confirmed from a prod screenshot after #94 merged, traced to the `<ul>` grid wrapper. Chip sizing was a direct ask. Same DB-less limitation as #94 — still haven't clicked through the live page myself, so worth a visual check on the preview deploy.