### PR TITLE
Fix mobile Details card ordering, restructure rating scores

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -501,7 +501,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
                 <p className="text-sm text-neutral-400">Editors&rsquo; Score</p>
                 <p className="text-2xl font-bold text-amber-500">
                   {editorsRating.average?.toFixed(1)}{" "}
-                  <span className="text-sm font-normal text-neutral-500">/ 10 ({editorsRating.count})</span>
+                  <span className="text-sm font-normal text-neutral-500">({editorsRating.count})</span>
                 </p>
               </div>
             )}
@@ -510,20 +510,30 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           {RATING_CATEGORIES.some(
             ({ key }) => subcategoryRating[key].count > 0 || subcategoryEditorsRating[key].count > 0,
           ) && (
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-500">
+            <div className="mt-2 flex max-w-xs flex-col gap-0.5 text-xs">
               {RATING_CATEGORIES.map(({ key, label }) => {
                 const community = subcategoryRating[key];
                 const editors = subcategoryEditorsRating[key];
                 if (community.count === 0 && editors.count === 0) return null;
                 return (
-                  <span key={key}>
-                    {label}:{" "}
-                    {community.count > 0 && (
-                      <span className="text-yellow-500">{community.average!.toFixed(1)}</span>
-                    )}
-                    {community.count > 0 && editors.count > 0 && " / "}
-                    {editors.count > 0 && <span className="text-amber-500">{editors.average!.toFixed(1)}</span>}
-                  </span>
+                  <div
+                    key={key}
+                    className="flex items-center justify-between"
+                    title={`Community: ${community.count > 0 ? community.average!.toFixed(1) : "—"}, Editors: ${
+                      editors.count > 0 ? editors.average!.toFixed(1) : "—"
+                    }`}
+                  >
+                    <span className="text-neutral-400">{label}</span>
+                    <span className="text-neutral-500">
+                      {community.count > 0 && (
+                        <span className="text-yellow-500">{community.average!.toFixed(1)}</span>
+                      )}
+                      {community.count > 0 && editors.count > 0 && " / "}
+                      {editors.count > 0 && (
+                        <span className="text-amber-500">{editors.average!.toFixed(1)}</span>
+                      )}
+                    </span>
+                  </div>
                 );
               })}
             </div>

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -266,6 +266,71 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   const isFavorite = myListEntries.some((e) => e.listType === "FAVORITE");
   const isOnWatchlist = myListEntries.some((e) => e.listType === "WATCHLIST");
 
+  // Rendered twice below: alongside the poster on desktop (sm:flex-row), but
+  // after the overview on mobile -- on a single-column layout it would
+  // otherwise land between the poster and the title (same DOM order as the
+  // sidebar), showing Studio/Country/etc. before you've even seen what movie
+  // you're looking at.
+  const movieDetailsCard = (movie.studio ||
+    movie.country ||
+    movie.originalLanguage ||
+    !!movie.revenue ||
+    (movie.collectionName && collectionSiblings.length > 0)) && (
+    <div className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
+      <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">Details</h3>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+        {movie.studio && (
+          <>
+            <dt className="text-neutral-500">Studio</dt>
+            <dd className="text-neutral-300">{movie.studio}</dd>
+          </>
+        )}
+        {movie.country && (
+          <>
+            <dt className="text-neutral-500">Country</dt>
+            <dd className="text-neutral-300">{movie.country}</dd>
+          </>
+        )}
+        {movie.originalLanguage && (
+          <>
+            <dt className="text-neutral-500">Language</dt>
+            <dd className="text-neutral-300">{movie.originalLanguage}</dd>
+          </>
+        )}
+        {!!movie.revenue && (
+          <>
+            <dt className="text-neutral-500">Box Office</dt>
+            <dd className="text-neutral-300">
+              {new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 0,
+              }).format(movie.revenue)}
+            </dd>
+          </>
+        )}
+        {movie.collectionName && collectionSiblings.length > 0 && (
+          <>
+            <dt className="text-neutral-500">Collection</dt>
+            <dd>
+              {collectionSiblings.map((sibling, i) => (
+                <span key={sibling.id}>
+                  <Link
+                    href={`/movies/${sibling.id}`}
+                    className="text-red-500 underline decoration-red-800 underline-offset-2 hover:text-red-400"
+                  >
+                    {sibling.title}
+                  </Link>
+                  {i < collectionSiblings.length - 1 ? ", " : ""}
+                </span>
+              ))}
+            </dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+
   const serializedFightScenes = fightScenes.map((scene) => {
     const summary = fightSceneRatingSummaries.get(scene.id);
     const adminSummary = fightSceneAdminRatingSummaries.get(scene.id);
@@ -371,64 +436,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             <PosterOverrideControl movieId={movie.id} hasOverride={!!movie.posterOverrideUrl} />
           )}
 
-          {(movie.studio || movie.country || movie.originalLanguage || !!movie.revenue ||
-            (movie.collectionName && collectionSiblings.length > 0)) && (
-            <div className="mt-4 rounded-md border border-neutral-800 bg-neutral-900 p-3">
-              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
-                Details
-              </h3>
-              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
-                {movie.studio && (
-                  <>
-                    <dt className="text-neutral-500">Studio</dt>
-                    <dd className="text-neutral-300">{movie.studio}</dd>
-                  </>
-                )}
-                {movie.country && (
-                  <>
-                    <dt className="text-neutral-500">Country</dt>
-                    <dd className="text-neutral-300">{movie.country}</dd>
-                  </>
-                )}
-                {movie.originalLanguage && (
-                  <>
-                    <dt className="text-neutral-500">Language</dt>
-                    <dd className="text-neutral-300">{movie.originalLanguage}</dd>
-                  </>
-                )}
-                {!!movie.revenue && (
-                  <>
-                    <dt className="text-neutral-500">Box Office</dt>
-                    <dd className="text-neutral-300">
-                      {new Intl.NumberFormat("en-US", {
-                        style: "currency",
-                        currency: "USD",
-                        maximumFractionDigits: 0,
-                      }).format(movie.revenue)}
-                    </dd>
-                  </>
-                )}
-                {movie.collectionName && collectionSiblings.length > 0 && (
-                  <>
-                    <dt className="text-neutral-500">Collection</dt>
-                    <dd>
-                      {collectionSiblings.map((sibling, i) => (
-                        <span key={sibling.id}>
-                          <Link
-                            href={`/movies/${sibling.id}`}
-                            className="text-red-500 underline decoration-red-800 underline-offset-2 hover:text-red-400"
-                          >
-                            {sibling.title}
-                          </Link>
-                          {i < collectionSiblings.length - 1 ? ", " : ""}
-                        </span>
-                      ))}
-                    </dd>
-                  </>
-                )}
-              </dl>
-            </div>
-          )}
+          {movieDetailsCard && <div className="mt-4 hidden sm:block">{movieDetailsCard}</div>}
         </div>
 
         <div className="flex-1 pt-6 sm:pt-24">
@@ -522,6 +530,8 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           )}
 
           <p className="mt-4 max-w-2xl text-neutral-300">{movie.overview}</p>
+
+          {movieDetailsCard && <div className="mt-4 max-w-2xl sm:hidden">{movieDetailsCard}</div>}
 
           <div className="mt-4 flex flex-wrap items-start gap-2">
             <ListButtons


### PR DESCRIPTION
## Summary

Two follow-ups to #96, found from live testing:

- **Mobile ordering fix**: the sidebar "Details" card (studio/country/language/box office/collection) lived in the same flex column as the poster, which stacks *before* the title column once the layout collapses to one column on mobile — reported live on a phone, showing Studio/Country/etc. before the movie's own title. Extracted the card into one JSX value rendered twice: hidden on mobile in the sidebar position, shown after the overview (hidden on desktop) instead — so mobile reads poster → title → ... → overview → details, while desktop's sidebar is unchanged.
- **Rating score restructure**: subcategory ratings (Fight Choreography/Story/Acting) ran together on one line — fine with one category populated, a dense run-on sentence once all three have both community and editor scores. Now one row per category, with a `title` tooltip spelling out the values as a lightweight accessibility backstop for the color-only community/editors distinction. Also dropped the redundant `/10` from Editors' Score (Community Score, right next to it, already establishes the scale) and confirmed subcategory rows never needed one either.

## Checklist

- [x] `README.md` updated to reflect this change — n/a, no user-facing feature/permission change, both are display-only fixes to features already documented
- [x] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — n/a, no schema change; both are bug-fix/polish, not judgment calls beyond what's already documented for the original features
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Reproduced the mobile ordering bug locally at a 390×844 viewport (matching the live report), confirmed the fix restores poster → title → ... → details reading order, and confirmed desktop's sidebar placement is unchanged.
- Seeded worst-case subcategory rating data (all three categories, both community and editor scores) and confirmed the stacked-row layout stays readable, Editors' Score shows without `/10`, and Community Score still shows `/10`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_