### PR TITLE
Collapse Fun Facts list, redesign spotlight as testimonial card

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -965,6 +965,25 @@ protecting against for this project's actual pace of parallel work.
 
 ## Feature Decisions
 
+### Fun Facts list collapsed behind "Show all N" to cap the section's default footprint
+**PR #TBD.** The spotlight + paginated-list design (see the original Fun Facts entry
+below) already capped the section's height regardless of how many facts a movie
+accumulates, but the list was always visible by default, so the section's own footprint
+was still fairly heavy for a secondary feature, particularly as the movie page picked up
+more sections over time (You Might Also Like, the Details sidebar, etc.). The list and its
+pagination controls now render only after clicking "Show all N fun facts" — the spotlight
+(with prev/next, voting, edit/delete) stays visible unconditionally, since prev/next lets
+someone browse every fact one at a time without needing the list at all, and removing it
+wouldn't have saved any height anyway.
+
+- **Considered shrinking the spotlight itself to a one-line teaser** for an even smaller
+  default footprint, but that would have lost the spotlight's visual presence (the quote
+  styling, vote buttons) entirely until expanded — kept the full spotlight card instead,
+  since the actual space savings come from hiding the list, not the spotlight.
+- **Toggle only appears when there's more than one fact.** With a single fact, the
+  spotlight already shows everything there is to show — a "Show all 1 fun facts" toggle
+  would just be a dead click.
+
 ### "You Might Also Like" built from our own data, not TMDB's recommendations endpoint
 **PR #TBD.** TMDB offers `/movie/{id}/recommendations` and `/movie/{id}/similar` for free,
 but both reflect TMDB's general-audience similarity model, not this catalog's data or its

--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ See `DECISIONS.md` for the fuller reasoning, including the aggregation-based alt
 
 ## Fun Facts
 
-Above the Discussion thread on every movie page: an IMDB "Did you know"-style trivia section. Any verified member can add a short fun fact (500 characters max — a trivia snippet, not a full discussion post), and any other verified member can vote it up or down.
+Below Fight Scenes on every movie page: an IMDB "Did you know"-style trivia section. Any verified member can add a short fun fact (500 characters max — a trivia snippet, not a full discussion post), and any other verified member can vote it up or down.
 
-- **Voting is thumbs up/down, not a 1–10 score** — the first bidirectional vote in the app (`MemberList` likes are one-directional). Voting the same direction again retracts your vote; voting the other direction switches it. You can't vote on your own fun fact.
-- **Ranked by net score** (upvotes minus downvotes), not chronologically — the highest-voted facts rise to the top, same idea as IMDB's own trivia section.
+- **Spotlight + collapsed list.** By default, only the single highest-voted fact shows, in a large "spotlight" card with prev/next arrows to cycle through every fact one at a time, vote buttons, and edit/delete controls for whoever can act on it — the same amount of space regardless of how many facts a movie has. The rest are hidden behind a "Show all N fun facts" toggle, which reveals a compact numbered list (entry number, both vote counts, submitter, date, full un-truncated text) paginated 5 per page with numbered page controls. This keeps the section's default footprint constant rather than growing with community activity.
+- **Voting is thumbs up/down, not a 1–10 score** — the first bidirectional vote in the app (`MemberList` likes are one-directional). Voting the same direction again retracts your vote; voting the other direction switches it. You can't vote on your own fun fact. Both the spotlight and the list show thumbs-up and thumbs-down counts separately, not just a combined net score.
+- **Ranked by net score** (upvotes minus downvotes), ties broken by newest first — the highest-voted facts rise to the top, same idea as IMDB's own trivia section.
 - **Editing/deleting**: the submitter can edit or delete their own fact; admins can delete anyone's. Deletion is a soft-delete (keeps vote history intact) and the fact simply disappears from the list — unlike discussion posts, nothing else (no replies) depends on the row staying visible.
 - Requires a verified email to submit or vote, same bar as fight scenes and discussion posts.
 

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -56,6 +56,7 @@ export function FunFactsSection({
   // fact the moment the current one's score changes.
   const [spotlightId, setSpotlightId] = useState<string | null>(initialFacts[0]?.id ?? null);
   const [page, setPage] = useState(1);
+  const [showList, setShowList] = useState(false);
 
   function updateFact(id: string, updater: (item: FunFactItem) => FunFactItem) {
     setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
@@ -334,66 +335,77 @@ export function FunFactsSection({
           </p>
         )}
 
-        {facts.length > 0 && (
-          <ul className="divide-y divide-neutral-800">
-            {pageFacts.map((fact) => (
-              <li key={fact.id}>
-                <button
-                  onClick={() => setSpotlightId(fact.id)}
-                  className={`flex w-full flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
-                    fact.id === spotlightId ? "bg-neutral-800/40" : ""
-                  }`}
-                >
-                  <div className="flex items-center gap-2 text-xs text-neutral-500">
-                    <span className="shrink-0 text-neutral-600">#{entryNumbers.get(fact.id)}</span>
-                    <span className={fact.myVote === 1 ? "text-green-500" : "text-neutral-600"}>
-                      👍 {fact.up}
-                    </span>
-                    <span className={fact.myVote === -1 ? "text-red-500" : "text-neutral-600"}>
-                      👎 {fact.down}
-                    </span>
-                    <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
-                    <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
-                  </div>
-                  <p className="text-neutral-300">{fact.content}</p>
-                </button>
-              </li>
-            ))}
-          </ul>
+        {facts.length > 1 && (
+          <button
+            onClick={() => setShowList((v) => !v)}
+            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+          >
+            {showList ? "Hide fun facts list" : `Show all ${facts.length} fun facts →`}
+          </button>
         )}
 
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-4 border-t border-neutral-800 py-2 text-sm">
-            <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={currentPage === 1}
-              className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              ‹
-            </button>
-            <div className="flex items-center gap-1">
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-                <button
-                  key={n}
-                  onClick={() => setPage(n)}
-                  className={`rounded border px-2 py-0.5 ${
-                    n === currentPage
-                      ? "border-red-700 bg-red-700 text-white"
-                      : "border-neutral-700 text-neutral-300 hover:bg-neutral-800"
-                  }`}
-                >
-                  {n}
-                </button>
+        {showList && facts.length > 0 && (
+          <>
+            <ul className="divide-y divide-neutral-800 border-t border-neutral-800">
+              {pageFacts.map((fact) => (
+                <li key={fact.id}>
+                  <button
+                    onClick={() => setSpotlightId(fact.id)}
+                    className={`flex w-full flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
+                      fact.id === spotlightId ? "bg-neutral-800/40" : ""
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 text-xs text-neutral-500">
+                      <span className="shrink-0 text-neutral-600">#{entryNumbers.get(fact.id)}</span>
+                      <span className={fact.myVote === 1 ? "text-green-500" : "text-neutral-600"}>
+                        👍 {fact.up}
+                      </span>
+                      <span className={fact.myVote === -1 ? "text-red-500" : "text-neutral-600"}>
+                        👎 {fact.down}
+                      </span>
+                      <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
+                      <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
+                    </div>
+                    <p className="text-neutral-300">{fact.content}</p>
+                  </button>
+                </li>
               ))}
-            </div>
-            <button
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-              disabled={currentPage === totalPages}
-              className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              ›
-            </button>
-          </div>
+            </ul>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-4 border-t border-neutral-800 py-2 text-sm">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  ‹
+                </button>
+                <div className="flex items-center gap-1">
+                  {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setPage(n)}
+                      className={`rounded border px-2 py-0.5 ${
+                        n === currentPage
+                          ? "border-red-700 bg-red-700 text-white"
+                          : "border-neutral-700 text-neutral-300 hover:bg-neutral-800"
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  ›
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </section>

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -230,102 +230,105 @@ export function FunFactsSection({
             const canVote = signedIn && !canEdit;
 
             return (
-              <div className="border-b border-neutral-800 bg-gradient-to-b from-red-950/20 to-transparent p-5 text-center">
-                {editingId === fact.id ? (
-                  <div className="mx-auto flex max-w-md flex-col gap-2 text-left">
-                    <textarea
-                      value={editContent}
-                      onChange={(e) => setEditContent(e.target.value)}
-                      rows={2}
-                      maxLength={MAX_CONTENT_LENGTH}
-                      className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
-                    />
-                    <div className="flex gap-2">
+              <div className="flex gap-3 border-b border-l-4 border-neutral-800 border-l-red-700 p-4">
+                <span className="font-serif text-4xl leading-[0.6] text-red-700/70">&ldquo;</span>
+                <div className="min-w-0 flex-1">
+                  {editingId === fact.id ? (
+                    <div className="flex flex-col gap-2">
+                      <textarea
+                        value={editContent}
+                        onChange={(e) => setEditContent(e.target.value)}
+                        rows={2}
+                        maxLength={MAX_CONTENT_LENGTH}
+                        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => saveEdit(fact.id)}
+                          disabled={submitting || !editContent.trim()}
+                          className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={cancelEdit}
+                          className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-lg text-neutral-100">{fact.content}</p>
+                  )}
+
+                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-xs text-neutral-500">
+                      — {fact.submittedBy.username} · {formatDate(fact.createdAt)}
+                      {wasEdited(fact) && " (edited)"}
+                    </p>
+
+                    <div className="flex items-center gap-3 text-sm">
+                      {facts.length > 1 && (
+                        <button
+                          onClick={() => shiftSpotlight(-1)}
+                          className="text-neutral-500 hover:text-neutral-300"
+                        >
+                          ‹
+                        </button>
+                      )}
                       <button
-                        onClick={() => saveEdit(fact.id)}
-                        disabled={submitting || !editContent.trim()}
-                        className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+                        onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
+                        disabled={!canVote}
+                        title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                        className={`flex items-center gap-1 rounded px-1 leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                          fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
+                        }`}
                       >
-                        Save
+                        👍 {fact.up}
                       </button>
                       <button
-                        onClick={cancelEdit}
-                        className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+                        onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
+                        disabled={!canVote}
+                        title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                        className={`flex items-center gap-1 rounded px-1 leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                          fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
+                        }`}
                       >
-                        Cancel
+                        👎 {fact.down}
                       </button>
+                      {facts.length > 1 && (
+                        <button
+                          onClick={() => shiftSpotlight(1)}
+                          className="text-neutral-500 hover:text-neutral-300"
+                        >
+                          ›
+                        </button>
+                      )}
                     </div>
                   </div>
-                ) : (
-                  <p className="text-lg text-neutral-100">&ldquo;{fact.content}&rdquo;</p>
-                )}
 
-                <p className="mt-2 text-xs text-neutral-500">
-                  — {fact.submittedBy.username} · {formatDate(fact.createdAt)}
-                  {wasEdited(fact) && " (edited)"}
-                </p>
-
-                <div className="mt-3 flex items-center justify-center gap-4">
-                  {facts.length > 1 && (
-                    <button
-                      onClick={() => shiftSpotlight(-1)}
-                      className="text-sm text-neutral-500 hover:text-neutral-300"
-                    >
-                      ‹ prev
-                    </button>
-                  )}
-                  <div className="flex items-center gap-3">
-                    <button
-                      onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
-                      disabled={!canVote}
-                      title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                      className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
-                        fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
-                      }`}
-                    >
-                      👍 <span className="text-sm">{fact.up}</span>
-                    </button>
-                    <button
-                      onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
-                      disabled={!canVote}
-                      title={canEdit ? "You can't vote on your own fun fact" : undefined}
-                      className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-base leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
-                        fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
-                      }`}
-                    >
-                      👎 <span className="text-sm">{fact.down}</span>
-                    </button>
-                  </div>
-                  {facts.length > 1 && (
-                    <button
-                      onClick={() => shiftSpotlight(1)}
-                      className="text-sm text-neutral-500 hover:text-neutral-300"
-                    >
-                      next ›
-                    </button>
+                  {(canEdit || canDelete) && editingId !== fact.id && (
+                    <div className="mt-1.5 flex items-center gap-2">
+                      {canEdit && (
+                        <button
+                          onClick={() => startEdit(fact)}
+                          className="text-xs text-neutral-400 hover:text-white"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => deleteFact(fact.id)}
+                          className="text-xs text-neutral-400 hover:text-red-400"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
                   )}
                 </div>
-
-                {(canEdit || canDelete) && editingId !== fact.id && (
-                  <div className="mt-2 flex items-center justify-center gap-2">
-                    {canEdit && (
-                      <button
-                        onClick={() => startEdit(fact)}
-                        className="text-xs text-neutral-400 hover:text-white"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {canDelete && (
-                      <button
-                        onClick={() => deleteFact(fact.id)}
-                        className="text-xs text-neutral-400 hover:text-red-400"
-                      >
-                        Delete
-                      </button>
-                    )}
-                  </div>
-                )}
               </div>
             );
           })()


### PR DESCRIPTION
## Summary

Two follow-ups to the Fun Facts feature, aimed at keeping the section condensed as the movie page picks up more sections over time:

- **Collapsed list**: the compact list and its pagination controls now render only after clicking "Show all N fun facts." The spotlight (prev/next, voting, edit/delete) stays visible unconditionally — prev/next already lets you browse every fact one at a time, so hiding it wouldn't have saved any height anyway. With a single fact, no toggle shows at all, since the spotlight already covers everything there is to see.
- **Left-aligned spotlight redesign**: replaces the centered quote + gradient background with a left-aligned "testimonial card" layout — a quote-mark accent, content and byline left-aligned, vote/prev-next controls on the same row as the byline instead of a separate centered row below. Chosen after comparing against a "Did you know?" badge style and a side-by-side layout with a vertical control rail; this one is the most vertically compact of the three.

## Checklist

- [x] `README.md` updated to reflect this change (Fun Facts section rewritten to describe the spotlight+collapsed-list structure)
- [x] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — added an entry for the collapse-behind-a-toggle decision and why the spotlight itself stays uncollapsed
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified collapsed state shows only the spotlight, with "Show all N fun facts" only appearing when there's more than one fact.
- Verified expanding reveals the list + pagination, and that navigating the spotlight (prev/next) while expanded keeps the list visible and correctly highlights/paginates to the corresponding row.
- Verified the left-aligned spotlight redesign renders correctly signed out, signed in as the fact's owner (Edit/Delete visible), and in edit mode (textarea + Save/Cancel).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_