### PR TITLE
Auto-link cast/franchise mentions in Fun Facts

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -965,6 +965,30 @@ protecting against for this project's actual pace of parallel work.
 
 ## Feature Decisions
 
+### Fun Fact mentions auto-link against a per-movie pool, not an @mention input
+**PR #TBD.** Wanted fun facts to be able to reference the movie's cast (or other movies
+in the same franchise) as links, without requiring people writing a short trivia snippet
+to learn or use any special syntax.
+
+- **Automatic text matching over an `@mention` autocomplete.** An explicit mention syntax
+  (type `@`, pick from a dropdown) would eliminate ambiguity entirely, but needs real UI
+  work (an autocomplete component) for a feature whose whole appeal is a plain one-line
+  textarea. Automatic detection means anyone typing a cast member's name in prose gets a
+  link for free.
+- **Matched only against this movie's own cast list and its `collectionTmdbId` siblings**
+  (`funFactMentionables` in `movies/[id]/page.tsx`), not the whole site's `Person`/`Movie`
+  tables. A site-wide match pool would risk false positives from common names or
+  incidental substring matches; a single movie's cast (typically ~30, capped at
+  `MAX_CAST`) is small and specific enough that an exact name match is almost always a
+  genuine reference.
+- **Longest-name-first matching** (`linkifyContent` in `fun-facts-section.tsx`) so a full
+  name like "Bruce Lee" is consumed whole rather than a shorter substring (e.g. a
+  hypothetical cast member surnamed "Lee") matching part of it first.
+- **List rows switched from `<button>` to `<div role="button">`** to legally nest an `<a>`
+  inside a clickable row — nesting anchors inside buttons is invalid HTML and behaves
+  unpredictably across browsers. The row's own click handler checks `e.target.closest("a")`
+  and defers to the link instead of also spotlighting the row.
+
 ### Fun Facts list collapsed behind "Show all N" to cap the section's default footprint
 **PR #TBD.** The spotlight + paginated-list design (see the original Fun Facts entry
 below) already capped the section's height regardless of how many facts a movie

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Below Fight Scenes on every movie page: an IMDB "Did you know"-style trivia sect
 - **Ranked by net score** (upvotes minus downvotes), ties broken by newest first — the highest-voted facts rise to the top, same idea as IMDB's own trivia section.
 - **Editing/deleting**: the submitter can edit or delete their own fact; admins can delete anyone's. Deletion is a soft-delete (keeps vote history intact) and the fact simply disappears from the list — unlike discussion posts, nothing else (no replies) depends on the row staying visible.
 - Requires a verified email to submit or vote, same bar as fight scenes and discussion posts.
+- **Mentions of this movie's own cast or franchise siblings auto-link**, no `@mention` syntax to type — writing "Bruce Lee" in a fact about *Enter the Dragon* links straight to his actor page, and mentioning another movie in the same collection links to it. Only matched against this movie's own cast list and its `collectionTmdbId` siblings (not the whole site's actor/movie tables), keeping false-positive risk low without needing an autocomplete input.
 
 ## Actor Pages
 

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -399,6 +399,15 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
 
+  // Auto-link pool for Fun Facts: this movie's own cast and franchise
+  // siblings only, not the whole site's actor/movie tables -- a small,
+  // per-movie-bounded pool keeps false-positive matches unlikely without
+  // needing an @mention-style input UI.
+  const funFactMentionables = [
+    ...movie.cast.map((credit) => ({ name: credit.person.name, href: `/actors/${credit.person.id}` })),
+    ...collectionSiblings.map((sibling) => ({ name: sibling.title, href: `/movies/${sibling.id}` })),
+  ];
+
   const serializedPosts = discussionPage.posts.map((post) => ({
     ...post,
     createdAt: post.createdAt.toISOString(),
@@ -644,6 +653,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
           signedIn={!!session?.user}
           currentUserId={session?.user?.id ?? null}
           isAdmin={session?.user?.role === "ADMIN"}
+          mentionables={funFactMentionables}
         />
       </div>
 

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 
 const MAX_CONTENT_LENGTH = 500;
 const PAGE_SIZE = 5;
@@ -15,6 +16,50 @@ export interface FunFactItem {
   up: number;
   down: number;
   myVote: 1 | -1 | null;
+}
+
+export interface FunFactMentionable {
+  name: string;
+  href: string;
+}
+
+// Auto-links mentions of this movie's own cast or franchise siblings inside a
+// fact's plain text -- no special @mention syntax to type, since matching
+// against a small, bounded, per-movie pool (not the whole site's actor/movie
+// tables) keeps false-positive risk low without needing an autocomplete UI.
+function linkifyContent(content: string, mentionables: FunFactMentionable[]): React.ReactNode {
+  if (mentionables.length === 0) return content;
+
+  // Longest names first, so e.g. "Bruce Lee" matches whole rather than a
+  // shorter substring like "Lee" greedily consuming part of it.
+  const sorted = [...mentionables].sort((a, b) => b.name.length - a.name.length);
+  const pattern = sorted.map((m) => m.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const regex = new RegExp(`\\b(${pattern})\\b`, "g");
+
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  while ((match = regex.exec(content)) !== null) {
+    if (match.index > lastIndex) parts.push(content.slice(lastIndex, match.index));
+    const mentionable = sorted.find((m) => m.name === match![0]);
+    parts.push(
+      mentionable ? (
+        <Link
+          key={`mention-${key++}`}
+          href={mentionable.href}
+          className="text-red-500 underline decoration-red-800 underline-offset-2 hover:text-red-400"
+        >
+          {match[0]}
+        </Link>
+      ) : (
+        match[0]
+      ),
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < content.length) parts.push(content.slice(lastIndex));
+  return parts;
 }
 
 function formatDate(iso: string) {
@@ -38,12 +83,14 @@ export function FunFactsSection({
   signedIn,
   currentUserId,
   isAdmin,
+  mentionables = [],
 }: {
   movieId: string;
   initialFacts: FunFactItem[];
   signedIn: boolean;
   currentUserId: string | null;
   isAdmin: boolean;
+  mentionables?: FunFactMentionable[];
 }) {
   const [facts, setFacts] = useState(initialFacts);
   const [newContent, setNewContent] = useState("");
@@ -259,7 +306,7 @@ export function FunFactsSection({
                       </div>
                     </div>
                   ) : (
-                    <p className="text-lg text-neutral-100">{fact.content}</p>
+                    <p className="text-lg text-neutral-100">{linkifyContent(fact.content, mentionables)}</p>
                   )}
 
                   <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
@@ -352,9 +399,23 @@ export function FunFactsSection({
             <ul className="divide-y divide-neutral-800 border-t border-neutral-800">
               {pageFacts.map((fact) => (
                 <li key={fact.id}>
-                  <button
-                    onClick={() => setSpotlightId(fact.id)}
-                    className={`flex w-full flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      // Let a mention link's own navigation happen instead of
+                      // also spotlighting this row -- clicking a link inside
+                      // a clickable row should go to the link, not both.
+                      if ((e.target as HTMLElement).closest("a")) return;
+                      setSpotlightId(fact.id);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSpotlightId(fact.id);
+                      }
+                    }}
+                    className={`flex w-full cursor-pointer flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
                       fact.id === spotlightId ? "bg-neutral-800/40" : ""
                     }`}
                   >
@@ -369,8 +430,8 @@ export function FunFactsSection({
                       <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
                       <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
                     </div>
-                    <p className="text-neutral-300">{fact.content}</p>
-                  </button>
+                    <p className="text-neutral-300">{linkifyContent(fact.content, mentionables)}</p>
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

Mentioning a movie's own cast member (or a movie in the same collection) by name in a fun fact now renders as a link to their actor/movie page — no `@mention` syntax to type.

- Matched only against this movie's own cast list and its `collectionTmdbId` siblings (not the whole site's actor/movie tables), keeping false-positive risk low without needing an autocomplete input UI.
- Longest-name-first matching so a full name (e.g. "Bruce Lee") is consumed whole rather than a shorter substring matching part of it first.
- List rows switch from `<button>` to `<div role="button">` so an `<a>` can nest inside legally (nesting anchors inside buttons is invalid HTML) — the row's click handler checks whether the click originated from a link and defers to it instead of also spotlighting the row.

## Checklist

- [x] `README.md` updated to reflect this change (added a bullet to the Fun Facts section)
- [x] `.env.example` updated if a new environment variable was added — n/a
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — added an entry covering automatic-matching-vs-@mention-input, the per-movie-bounded pool, and the button→div accessibility fix
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Verified a fact mentioning "Bruce Lee" renders as a link in both the spotlight and the list view, and clicking it navigates to that actor's real page (confirmed via `page.waitForURL`, not just a screenshot — an initial test using `networkidle` gave a false negative due to Next.js's client-side RSC transition not triggering a traditional load event).
- Verified clicking a non-link part of a list row still jumps the spotlight to that fact, without the link's presence in the row breaking anything or causing a double-action.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPdhUJjLe77hobXWqEFMHu)_