### PR TITLE
Add actor fun facts and tributes, mirroring movie versions

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2342,6 +2342,55 @@ regression, but tighter than wanted.
   still doesn't count against the cap, and playback still pauses entirely
   while the tab is hidden.
 
+### Actor Fun Facts and Tributes added, mirroring the movie versions exactly
+**PR #TBD.** Wanted a way for members to pay homage to an actor directly
+(trivia about them, a career/performance writeup), not just rate or discuss
+the movies they're in — the site had two existing member-content shapes
+(`FunFact`/`FunFactVote`, `MemberReview`/`MemberReviewVote`) already built
+for movies, so this reuses both shapes verbatim rather than inventing new
+ones.
+
+- **New models, not a `movieId`-nullable variant of the existing ones.**
+  `PersonFunFact`/`PersonFunFactVote` and `PersonTribute`/`PersonTributeVote`
+  are separate tables (`personId` instead of `movieId`) rather than making
+  `FunFact.movieId`/`MemberReview.movieId` nullable and adding an optional
+  `personId` alongside — a shared table would need every query to filter on
+  "which foreign key is set," and would tangle two conceptually distinct
+  feeds (per-movie vs. per-actor) into one table for no real benefit.
+- **`PersonTribute` kept the one-per-(person,author) unique constraint**,
+  same as `MemberReview`, even though the feature brief describes tributes
+  as being about "an actor's career **or** a specific performance" — which
+  could argue for allowing several tributes per member per actor (one per
+  performance). Went with the stricter mirror because there's no
+  `movieId`/performance field on the model to disambiguate multiple tributes
+  by the same member for the same actor, and adding one would be scope
+  beyond what was asked; a member wanting to cover several performances
+  writes about that in one longer tribute instead. Revisit if that turns out
+  to be a real limitation in practice.
+- **Fun Facts soft-delete, Tributes hard-delete** — same split as their
+  movie counterparts, made for the same reason: `PersonFunFactVote` rows
+  would otherwise lose their target on delete, while `PersonTributeVote`
+  rows cascade away with the tribute regardless, so there's no vote history
+  to preserve either way.
+- **No mention auto-linking on actor Fun Facts**, unlike movie Fun Facts
+  (which link mentions of the movie's own cast/franchise siblings). There's
+  no equivalent small, bounded pool to match against for a single actor —
+  linking against the whole site's cast/movie tables would reintroduce the
+  false-positive risk `funFactMentionables` was specifically built to avoid.
+  Not requested in the feature brief either, so left out rather than
+  guessing at a shape for it.
+- **Tributes get the same capped-rail-then-paginated-page pattern as member
+  reviews** (`ActorTributesSection` capped to
+  `PERSON_TRIBUTES_PREVIEW_COUNT = 2`, full list at
+  `/actors/[personId]/tributes`) — called out explicitly in the brief given
+  actors can accumulate tributes from many members the same way movies
+  accumulate reviews.
+- **New rate limiters** (`personFunFactSubmitLimiter`,
+  `personTributeSubmitLimiter`, 10 per 10 minutes) mirror
+  `funFactSubmitLimiter`/`memberReviewSubmitLimiter` rather than sharing
+  them — keeps a burst of actor-page activity from eating into a member's
+  movie-page submission budget and vice versa.
+
 ## Deferred & Backlog
 
 - **About page copy: mission, About the Creators, Contact/feedback, and

--- a/README.md
+++ b/README.md
@@ -281,6 +281,13 @@ Every credited person has a page at `/actors/[personId]` showing their Filmograp
 
 Biography, birthday, and place of birth (when TMDB has them) are shown under the actor's name, live-fetched via their `person.tmdbId` on each page view rather than stored in our own database — if TMDB is unreachable or has nothing on record, that section is simply omitted.
 
+Below Fight Scenes, every actor page also carries two member-content sections letting fans pay homage to the actor directly, not just to the movies they're in — **Tributes** and **Fun Facts**, `PersonTribute`/`PersonTributeVote` and `PersonFunFact`/`PersonFunFactVote` in the schema. Both reuse the same shapes, rules, and UI patterns as the equivalent movie-page features (see [Fun Facts](#fun-facts) and [Reviews](#reviews) above):
+
+- **Tributes** — a longer-form (5,000 character max) writeup appreciating an actor's career or a specific performance, the more literal "homage" feature. One per (actor, member) pair, edited in place rather than posting a second one. Shown as a horizontally-scrolling rail capped to the top 2 by net vote score (same `rail-scrollbar` card pattern as member movie reviews), with a **"View all N tributes →"** link once there are more, leading to a dedicated `/actors/[personId]/tributes` page listing every tribute in full, 10 per page. The author can edit or delete their own; admins can delete anyone's (hard-deleted — nothing else references a tribute).
+- **Fun Facts** — a short (500 character max) trivia snippet about the actor, same spotlight-card-plus-collapsed-list UI as movie Fun Facts, ranked by net vote score. The submitter can edit or delete their own; admins can delete anyone's (soft-deleted, keeping vote history intact). Unlike movie Fun Facts, actor fun facts don't auto-link mentions of other cast/movies — there's no small, per-actor-bounded pool of names to safely match against the way a single movie's own cast list provides one.
+- **Voting** on both is thumbs up/down, toggling the same way as their movie counterparts (voting the same direction again retracts it, the opposite direction switches it) — you can't vote on your own tribute or fun fact.
+- Both require a verified email to submit or vote, same bar as every other member-content feature.
+
 ## Reviews
 
 Shown alongside the cast list on every movie page: an admin review (unchanged from the original "Editorial Reviews" feature) plus one review per verified member, both in the same section.

--- a/prisma/migrations/20260822180000_add_person_fun_facts_and_tributes/migration.sql
+++ b/prisma/migrations/20260822180000_add_person_fun_facts_and_tributes/migration.sql
@@ -1,0 +1,92 @@
+-- CreateTable
+CREATE TABLE "PersonFunFact" (
+    "id" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "submittedById" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PersonFunFact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PersonFunFactVote" (
+    "id" TEXT NOT NULL,
+    "factId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PersonFunFactVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PersonTribute" (
+    "id" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "voteScore" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PersonTribute_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PersonTributeVote" (
+    "id" TEXT NOT NULL,
+    "tributeId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PersonTributeVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PersonFunFact_personId_idx" ON "PersonFunFact"("personId");
+
+-- CreateIndex
+CREATE INDEX "PersonFunFactVote_factId_idx" ON "PersonFunFactVote"("factId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PersonFunFactVote_userId_factId_key" ON "PersonFunFactVote"("userId", "factId");
+
+-- CreateIndex
+CREATE INDEX "PersonTribute_personId_voteScore_createdAt_idx" ON "PersonTribute"("personId", "voteScore", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PersonTribute_personId_authorId_key" ON "PersonTribute"("personId", "authorId");
+
+-- CreateIndex
+CREATE INDEX "PersonTributeVote_tributeId_idx" ON "PersonTributeVote"("tributeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PersonTributeVote_userId_tributeId_key" ON "PersonTributeVote"("userId", "tributeId");
+
+-- AddForeignKey
+ALTER TABLE "PersonFunFact" ADD CONSTRAINT "PersonFunFact_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonFunFact" ADD CONSTRAINT "PersonFunFact_submittedById_fkey" FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonFunFactVote" ADD CONSTRAINT "PersonFunFactVote_factId_fkey" FOREIGN KEY ("factId") REFERENCES "PersonFunFact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonFunFactVote" ADD CONSTRAINT "PersonFunFactVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonTribute" ADD CONSTRAINT "PersonTribute_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonTribute" ADD CONSTRAINT "PersonTribute_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonTributeVote" ADD CONSTRAINT "PersonTributeVote_tributeId_fkey" FOREIGN KEY ("tributeId") REFERENCES "PersonTribute"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonTributeVote" ADD CONSTRAINT "PersonTributeVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,10 @@ model User {
   funFactVotes        FunFactVote[]
   memberReviews       MemberReview[]
   memberReviewVotes   MemberReviewVote[]
+  personFunFacts      PersonFunFact[]
+  personFunFactVotes  PersonFunFactVote[]
+  personTributes      PersonTribute[]
+  personTributeVotes  PersonTributeVote[]
 }
 
 model Account {
@@ -243,6 +247,8 @@ model Person {
 
   castCredits CastCredit[]
   fightSceneAppearances FightSceneCast[]
+  funFacts    PersonFunFact[]
+  tributes    PersonTribute[]
 
   @@index([name])
   // See the matching comment on Movie above — backs the ILIKE actor-name
@@ -534,6 +540,88 @@ model FunFactVote {
 
   @@unique([userId, factId])
   @@index([factId])
+}
+
+// --- Actor Fun Facts & Tributes ---
+//
+// Person-scoped counterparts to FunFact/FunFactVote and MemberReview/
+// MemberReviewVote above, letting members pay homage to an actor directly
+// rather than only through the movies they appear in. Same shapes, same
+// vote-toggle behavior, same soft/hard-delete split as their movie
+// equivalents.
+
+// Short trivia snippet about an actor -- same flat, non-threaded shape and
+// soft-delete (to keep vote history intact) as FunFact.
+model PersonFunFact {
+  id            String   @id @default(cuid())
+  personId      String
+  submittedById String
+  content       String   @db.Text
+  isDeleted     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  person      Person              @relation(fields: [personId], references: [id], onDelete: Cascade)
+  submittedBy User                @relation(fields: [submittedById], references: [id], onDelete: Cascade)
+  votes       PersonFunFactVote[]
+
+  @@index([personId])
+}
+
+// One vote per member per fact, value +1 (up) or -1 (down) -- same toggle
+// behavior as FunFactVote.
+model PersonFunFactVote {
+  id        String   @id @default(cuid())
+  factId    String
+  userId    String
+  value     Int
+  createdAt DateTime @default(now())
+
+  fact PersonFunFact @relation(fields: [factId], references: [id], onDelete: Cascade)
+  user User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, factId])
+  @@index([factId])
+}
+
+// Longer-form member writeup appreciating an actor's career or a specific
+// performance -- one per (person, member) pair, edited in place rather than
+// posting a second one, same as MemberReview. No isDeleted/soft-delete:
+// hard-deletes and cascades its votes away, same as MemberReview.
+model PersonTribute {
+  id        String   @id @default(cuid())
+  personId  String
+  authorId  String
+  content   String   @db.Text
+  // Denormalized up-minus-down count, kept in sync by the vote endpoint --
+  // same reasoning as MemberReview.voteScore, needed because tributes are
+  // paginated at the DB level.
+  voteScore Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  person Person              @relation(fields: [personId], references: [id], onDelete: Cascade)
+  author User                @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  votes  PersonTributeVote[]
+
+  @@unique([personId, authorId])
+  @@index([personId, voteScore, createdAt])
+}
+
+// One vote per member per tribute, value +1 (up) or -1 (down) -- same toggle
+// behavior as MemberReviewVote.
+model PersonTributeVote {
+  id        String   @id @default(cuid())
+  tributeId String
+  userId    String
+  value     Int
+  createdAt DateTime @default(now())
+
+  tribute PersonTribute @relation(fields: [tributeId], references: [id], onDelete: Cascade)
+  user    User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, tributeId])
+  @@index([tributeId])
 }
 
 // --- Fight scenes ---

--- a/src/app/actors/[personId]/page.tsx
+++ b/src/app/actors/[personId]/page.tsx
@@ -9,6 +9,15 @@ import { getFightSceneRatingSummaries, getFightSceneAdminRatingSummaries, getFig
 import { MovieCard } from "@/components/movie-card";
 import { FightSceneResultCard } from "@/components/fight-scene-result-card";
 import { getRatingSummaries } from "@/lib/ratings";
+import { getFunFactsForPerson, getPersonFunFactVoteSummaries } from "@/lib/person-fun-facts";
+import {
+  getTopPersonTributes,
+  getPersonTributesCount,
+  getPersonTributeVoteSummaries,
+  PERSON_TRIBUTES_PREVIEW_COUNT,
+} from "@/lib/person-tributes";
+import { ActorFunFactsSection } from "@/components/actor-fun-facts-section";
+import { ActorTributesSection } from "@/components/actor-tributes-section";
 
 const getPerson = cache((personId: string) =>
   prisma.person.findUnique({
@@ -110,6 +119,66 @@ export default async function ActorPage({ params }: { params: Promise<{ personId
       })
     : [];
 
+  const [funFacts, topTributes, tributesCount, myTribute] = await Promise.all([
+    getFunFactsForPerson(personId),
+    getTopPersonTributes(personId, PERSON_TRIBUTES_PREVIEW_COUNT),
+    getPersonTributesCount(personId),
+    session?.user
+      ? prisma.personTribute.findUnique({
+          where: { personId_authorId: { personId, authorId: session.user.id } },
+        })
+      : null,
+  ]);
+
+  const funFactIds = funFacts.map((f) => f.id);
+  const topTributeIds = topTributes.map((t) => t.id);
+  const [funFactVoteSummaries, myFunFactVotes, tributeVoteSummaries, myTributeVotes] = await Promise.all([
+    getPersonFunFactVoteSummaries(funFactIds),
+    session?.user
+      ? prisma.personFunFactVote.findMany({
+          where: { userId: session.user.id, factId: { in: funFactIds } },
+        })
+      : [],
+    getPersonTributeVoteSummaries(topTributeIds),
+    session?.user
+      ? prisma.personTributeVote.findMany({
+          where: { userId: session.user.id, tributeId: { in: topTributeIds } },
+        })
+      : [],
+  ]);
+  const myFunFactVoteMap = new Map(myFunFactVotes.map((v) => [v.factId, v.value as 1 | -1]));
+  const myTributeVoteMap = new Map(myTributeVotes.map((v) => [v.tributeId, v.value as 1 | -1]));
+
+  const serializedFunFacts = funFacts.map((fact) => {
+    const summary = funFactVoteSummaries.get(fact.id);
+    return {
+      id: fact.id,
+      content: fact.content,
+      submittedById: fact.submittedById,
+      createdAt: fact.createdAt.toISOString(),
+      updatedAt: fact.updatedAt.toISOString(),
+      submittedBy: fact.submittedBy,
+      up: summary?.up ?? 0,
+      down: summary?.down ?? 0,
+      myVote: myFunFactVoteMap.get(fact.id) ?? null,
+    };
+  });
+
+  const serializedTributes = topTributes.map((tribute) => {
+    const summary = tributeVoteSummaries.get(tribute.id);
+    return {
+      id: tribute.id,
+      content: tribute.content,
+      authorId: tribute.authorId,
+      createdAt: tribute.createdAt.toISOString(),
+      updatedAt: tribute.updatedAt.toISOString(),
+      author: tribute.author,
+      up: summary?.up ?? 0,
+      down: summary?.down ?? 0,
+      myVote: myTributeVoteMap.get(tribute.id) ?? null,
+    };
+  });
+
   const sortedFightScenes = [...fightScenes].sort(
     (a, b) => (favoriteCounts.get(b.id) ?? 0) - (favoriteCounts.get(a.id) ?? 0),
   );
@@ -188,6 +257,24 @@ export default async function ActorPage({ params }: { params: Promise<{ personId
           })}
         </div>
       )}
+
+      <ActorTributesSection
+        personId={person.id}
+        initialTributes={serializedTributes}
+        tributesCount={tributesCount}
+        hasOwnTribute={!!myTribute}
+        signedIn={!!session?.user}
+        currentUserId={session?.user?.id ?? null}
+        isAdmin={session?.user?.role === "ADMIN"}
+      />
+
+      <ActorFunFactsSection
+        personId={person.id}
+        initialFacts={serializedFunFacts}
+        signedIn={!!session?.user}
+        currentUserId={session?.user?.id ?? null}
+        isAdmin={session?.user?.role === "ADMIN"}
+      />
     </div>
   );
 }

--- a/src/app/actors/[personId]/tributes/page.tsx
+++ b/src/app/actors/[personId]/tributes/page.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  getPersonTributesPage,
+  getPersonTributesCount,
+  getPersonTributeVoteSummaries,
+  PERSON_TRIBUTES_PAGE_SIZE,
+} from "@/lib/person-tributes";
+import { ActorTributesList } from "@/components/actor-tributes-list";
+
+function pageHref(personId: string, page: number) {
+  return page > 1 ? `/actors/${personId}/tributes?page=${page}` : `/actors/${personId}/tributes`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ personId: string }>;
+}): Promise<Metadata> {
+  const { personId } = await params;
+  const person = await prisma.person.findUnique({ where: { id: personId }, select: { name: true } });
+  return person ? { title: `Tributes — ${person.name}` } : {};
+}
+
+export default async function PersonTributesPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ personId: string }>;
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { personId } = await params;
+  const { page: pageParam } = await searchParams;
+  const session = await auth();
+
+  const person = await prisma.person.findUnique({ where: { id: personId }, select: { id: true, name: true } });
+  if (!person) {
+    notFound();
+  }
+
+  const totalCount = await getPersonTributesCount(personId);
+  const totalPages = Math.max(1, Math.ceil(totalCount / PERSON_TRIBUTES_PAGE_SIZE));
+  const page = Math.min(Math.max(1, Number(pageParam) || 1), totalPages);
+
+  const { tributes } = await getPersonTributesPage(personId, page);
+  const tributeIds = tributes.map((t) => t.id);
+
+  const [voteSummaries, myVotes] = await Promise.all([
+    getPersonTributeVoteSummaries(tributeIds),
+    session?.user
+      ? prisma.personTributeVote.findMany({
+          where: { userId: session.user.id, tributeId: { in: tributeIds } },
+        })
+      : [],
+  ]);
+  const myVoteMap = new Map(myVotes.map((v) => [v.tributeId, v.value as 1 | -1]));
+
+  const serializedTributes = tributes.map((tribute) => {
+    const summary = voteSummaries.get(tribute.id);
+    return {
+      id: tribute.id,
+      content: tribute.content,
+      authorId: tribute.authorId,
+      createdAt: tribute.createdAt.toISOString(),
+      updatedAt: tribute.updatedAt.toISOString(),
+      author: tribute.author,
+      up: summary?.up ?? 0,
+      down: summary?.down ?? 0,
+      myVote: myVoteMap.get(tribute.id) ?? null,
+    };
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-10">
+      <Link href={`/actors/${personId}`} className="text-sm text-red-500 hover:underline">
+        ← Back to {person.name}
+      </Link>
+      <h1 className="mb-6 mt-2 font-serif text-2xl font-bold text-white">
+        Tributes to {person.name}
+      </h1>
+
+      {serializedTributes.length === 0 ? (
+        <p className="text-neutral-400">No tributes yet.</p>
+      ) : (
+        <>
+          <ActorTributesList
+            personId={personId}
+            initialTributes={serializedTributes}
+            signedIn={!!session?.user}
+            currentUserId={session?.user?.id ?? null}
+            isAdmin={session?.user?.role === "ADMIN"}
+          />
+
+          {totalPages > 1 && (
+            <div className="mt-8 flex items-center justify-center gap-4 text-sm">
+              {page > 1 ? (
+                <Link href={pageHref(personId, page - 1)} className="text-red-500 hover:underline">
+                  ← Previous
+                </Link>
+              ) : (
+                <span className="text-neutral-600">← Previous</span>
+              )}
+              <span className="text-neutral-400">
+                Page {page} of {totalPages} ({totalCount} tributes)
+              </span>
+              {page < totalPages ? (
+                <Link href={pageHref(personId, page + 1)} className="text-red-500 hover:underline">
+                  Next →
+                </Link>
+              ) : (
+                <span className="text-neutral-600">Next →</span>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/actors/[personId]/fun-facts/[factId]/route.ts
+++ b/src/app/api/actors/[personId]/fun-facts/[factId]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { MAX_PERSON_FUN_FACT_LENGTH } from "@/lib/person-fun-facts";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { personId, factId } = await params;
+  const existing = await prisma.personFunFact.findUnique({ where: { id: factId } });
+  if (!existing || existing.personId !== personId) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+  if (existing.submittedById !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own fun facts." }, { status: 403 });
+  }
+  if (existing.isDeleted) {
+    return NextResponse.json({ error: "This fun fact has been deleted." }, { status: 400 });
+  }
+
+  const { content } = await request.json();
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_PERSON_FUN_FACT_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_PERSON_FUN_FACT_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const fact = await prisma.personFunFact.update({
+    where: { id: factId },
+    data: { content: trimmedContent },
+    include: { submittedBy: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ fact });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { personId, factId } = await params;
+  const existing = await prisma.personFunFact.findUnique({ where: { id: factId } });
+  if (!existing || existing.personId !== personId) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+
+  const isOwner = existing.submittedById === session.user.id;
+  const isAdmin = session.user.role === "ADMIN";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Soft-delete, same as movie FunFact -- keeps the row (and its vote
+  // history) intact rather than hard-deleting.
+  await prisma.personFunFact.update({
+    where: { id: factId },
+    data: { isDeleted: true, content: "" },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/actors/[personId]/fun-facts/[factId]/vote/route.ts
+++ b/src/app/api/actors/[personId]/fun-facts/[factId]/vote/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; factId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to vote." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before voting." }, { status: 403 });
+  }
+
+  const { personId, factId } = await params;
+  const { value } = await request.json();
+  if (value !== 1 && value !== -1) {
+    return NextResponse.json({ error: "value must be 1 or -1." }, { status: 400 });
+  }
+
+  const fact = await prisma.personFunFact.findUnique({ where: { id: factId } });
+  if (!fact || fact.personId !== personId || fact.isDeleted) {
+    return NextResponse.json({ error: "Fun fact not found." }, { status: 404 });
+  }
+  if (fact.submittedById === session.user.id) {
+    return NextResponse.json({ error: "You can't vote on your own fun fact." }, { status: 403 });
+  }
+
+  const existing = await prisma.personFunFactVote.findUnique({
+    where: { userId_factId: { userId: session.user.id, factId } },
+  });
+
+  let myVote: number | null;
+  if (!existing) {
+    await prisma.personFunFactVote.create({ data: { userId: session.user.id, factId, value } });
+    myVote = value;
+  } else if (existing.value === value) {
+    // Voting the same direction again retracts it, same toggle behavior as
+    // movie FunFact voting.
+    await prisma.personFunFactVote.delete({ where: { id: existing.id } });
+    myVote = null;
+  } else {
+    await prisma.personFunFactVote.update({ where: { id: existing.id }, data: { value } });
+    myVote = value;
+  }
+
+  const [up, down] = await Promise.all([
+    prisma.personFunFactVote.count({ where: { factId, value: 1 } }),
+    prisma.personFunFactVote.count({ where: { factId, value: -1 } }),
+  ]);
+
+  return NextResponse.json({ myVote, up, down });
+}

--- a/src/app/api/actors/[personId]/fun-facts/route.ts
+++ b/src/app/api/actors/[personId]/fun-facts/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+import { MAX_PERSON_FUN_FACT_LENGTH } from "@/lib/person-fun-facts";
+import { checkRateLimit, personFunFactSubmitLimiter } from "@/lib/rate-limit";
+
+export async function POST(request: Request, { params }: { params: Promise<{ personId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a fun fact." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a fun fact." }, { status: 403 });
+  }
+
+  const rateLimit = await checkRateLimit(personFunFactSubmitLimiter, session.user.id);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      { error: "You're adding facts too quickly. Try again shortly." },
+      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } },
+    );
+  }
+
+  const { personId } = await params;
+  const { content } = await request.json();
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_PERSON_FUN_FACT_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_PERSON_FUN_FACT_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const person = await prisma.person.findUnique({ where: { id: personId }, select: { id: true } });
+  if (!person) {
+    return NextResponse.json({ error: "Actor not found." }, { status: 404 });
+  }
+
+  const fact = await prisma.personFunFact.create({
+    data: { personId, submittedById: session.user.id, content: trimmedContent },
+    include: { submittedBy: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ fact });
+}

--- a/src/app/api/actors/[personId]/tributes/[tributeId]/route.ts
+++ b/src/app/api/actors/[personId]/tributes/[tributeId]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { MAX_PERSON_TRIBUTE_LENGTH } from "@/lib/person-tributes";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; tributeId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { personId, tributeId } = await params;
+  const existing = await prisma.personTribute.findUnique({ where: { id: tributeId } });
+  if (!existing || existing.personId !== personId) {
+    return NextResponse.json({ error: "Tribute not found." }, { status: 404 });
+  }
+  if (existing.authorId !== session.user.id) {
+    return NextResponse.json({ error: "You can only edit your own tribute." }, { status: 403 });
+  }
+
+  const { content } = await request.json();
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_PERSON_TRIBUTE_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_PERSON_TRIBUTE_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const tribute = await prisma.personTribute.update({
+    where: { id: tributeId },
+    data: { content: trimmedContent },
+    include: { author: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ tribute });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; tributeId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  const { personId, tributeId } = await params;
+  const existing = await prisma.personTribute.findUnique({ where: { id: tributeId } });
+  if (!existing || existing.personId !== personId) {
+    return NextResponse.json({ error: "Tribute not found." }, { status: 404 });
+  }
+
+  const isOwner = existing.authorId === session.user.id;
+  const isAdmin = session.user.role === "ADMIN";
+  if (!isOwner && !isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Hard delete -- same as MemberReview, nothing else needs the row to
+  // stick around; its votes cascade away with it.
+  await prisma.personTribute.delete({ where: { id: tributeId } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/actors/[personId]/tributes/[tributeId]/vote/route.ts
+++ b/src/app/api/actors/[personId]/tributes/[tributeId]/vote/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ personId: string; tributeId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to vote." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before voting." }, { status: 403 });
+  }
+
+  const { personId, tributeId } = await params;
+  const { value } = await request.json();
+  if (value !== 1 && value !== -1) {
+    return NextResponse.json({ error: "value must be 1 or -1." }, { status: 400 });
+  }
+
+  const tribute = await prisma.personTribute.findUnique({ where: { id: tributeId } });
+  if (!tribute || tribute.personId !== personId) {
+    return NextResponse.json({ error: "Tribute not found." }, { status: 404 });
+  }
+  if (tribute.authorId === session.user.id) {
+    return NextResponse.json({ error: "You can't vote on your own tribute." }, { status: 403 });
+  }
+
+  const existing = await prisma.personTributeVote.findUnique({
+    where: { userId_tributeId: { userId: session.user.id, tributeId } },
+  });
+
+  let myVote: number | null;
+  if (!existing) {
+    await prisma.personTributeVote.create({ data: { userId: session.user.id, tributeId, value } });
+    myVote = value;
+  } else if (existing.value === value) {
+    // Voting the same direction again retracts it, same toggle behavior as
+    // Fun Fact / member review voting.
+    await prisma.personTributeVote.delete({ where: { id: existing.id } });
+    myVote = null;
+  } else {
+    await prisma.personTributeVote.update({ where: { id: existing.id }, data: { value } });
+    myVote = value;
+  }
+
+  const [up, down] = await Promise.all([
+    prisma.personTributeVote.count({ where: { tributeId, value: 1 } }),
+    prisma.personTributeVote.count({ where: { tributeId, value: -1 } }),
+  ]);
+
+  // voteScore is denormalized onto the tribute row so pagination can sort by
+  // it at the DB level -- keep it in sync every time a vote changes.
+  await prisma.personTribute.update({ where: { id: tributeId }, data: { voteScore: up - down } });
+
+  return NextResponse.json({ myVote, up, down });
+}

--- a/src/app/api/actors/[personId]/tributes/route.ts
+++ b/src/app/api/actors/[personId]/tributes/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isEmailVerified } from "@/lib/verification";
+import { MAX_PERSON_TRIBUTE_LENGTH } from "@/lib/person-tributes";
+import { checkRateLimit, personTributeSubmitLimiter } from "@/lib/rate-limit";
+
+export async function POST(request: Request, { params }: { params: Promise<{ personId: string }> }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Sign in to add a tribute." }, { status: 401 });
+  }
+  if (!(await isEmailVerified(session.user.id))) {
+    return NextResponse.json({ error: "Verify your email before adding a tribute." }, { status: 403 });
+  }
+
+  const rateLimit = await checkRateLimit(personTributeSubmitLimiter, session.user.id);
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      { error: "You're adding tributes too quickly. Try again shortly." },
+      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } },
+    );
+  }
+
+  const { personId } = await params;
+  const { content } = await request.json();
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required." }, { status: 400 });
+  }
+  const trimmedContent = content.trim();
+  if (trimmedContent.length > MAX_PERSON_TRIBUTE_LENGTH) {
+    return NextResponse.json(
+      { error: `content must be ${MAX_PERSON_TRIBUTE_LENGTH} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const person = await prisma.person.findUnique({ where: { id: personId }, select: { id: true } });
+  if (!person) {
+    return NextResponse.json({ error: "Actor not found." }, { status: 404 });
+  }
+
+  const existing = await prisma.personTribute.findUnique({
+    where: { personId_authorId: { personId, authorId: session.user.id } },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "You've already written a tribute for this actor — edit your existing one instead." },
+      { status: 409 },
+    );
+  }
+
+  const tribute = await prisma.personTribute.create({
+    data: { personId, authorId: session.user.id, content: trimmedContent },
+    include: { author: { select: { username: true } } },
+  });
+
+  return NextResponse.json({ tribute });
+}

--- a/src/components/actor-fun-facts-section.tsx
+++ b/src/components/actor-fun-facts-section.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useState } from "react";
+
+const MAX_CONTENT_LENGTH = 500;
+const PAGE_SIZE = 5;
+
+export interface PersonFunFactItem {
+  id: string;
+  content: string;
+  submittedById: string;
+  createdAt: string;
+  updatedAt: string;
+  submittedBy: { username: string };
+  up: number;
+  down: number;
+  myVote: 1 | -1 | null;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function wasEdited(item: PersonFunFactItem) {
+  return new Date(item.updatedAt).getTime() - new Date(item.createdAt).getTime() > 1000;
+}
+
+// Highest net score (up - down) first; ties broken by newest first -- same
+// ordering as the movie FunFactsSection.
+function byNetScore(a: PersonFunFactItem, b: PersonFunFactItem) {
+  const scoreDiff = b.up - b.down - (a.up - a.down);
+  if (scoreDiff !== 0) return scoreDiff;
+  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+}
+
+export function ActorFunFactsSection({
+  personId,
+  initialFacts,
+  signedIn,
+  currentUserId,
+  isAdmin,
+}: {
+  personId: string;
+  initialFacts: PersonFunFactItem[];
+  signedIn: boolean;
+  currentUserId: string | null;
+  isAdmin: boolean;
+}) {
+  const [facts, setFacts] = useState(initialFacts);
+  const [newContent, setNewContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  // Tracked by id rather than array index, same reasoning as the movie
+  // FunFactsSection -- voting re-sorts `facts` by net score.
+  const [spotlightId, setSpotlightId] = useState<string | null>(initialFacts[0]?.id ?? null);
+  const [page, setPage] = useState(1);
+  const [showList, setShowList] = useState(false);
+
+  function updateFact(id: string, updater: (item: PersonFunFactItem) => PersonFunFactItem) {
+    setFacts((prev) => prev.map((f) => (f.id === id ? updater(f) : f)).sort(byNetScore));
+  }
+
+  async function submit() {
+    if (!newContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/fun-facts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: newContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fact } = await res.json();
+    const newFact = { ...fact, up: 0, down: 0, myVote: null };
+    const next = [newFact, ...facts].sort(byNetScore);
+    setFacts(next);
+    if (facts.length === 0) setSpotlightId(newFact.id);
+    setPage(Math.floor(next.findIndex((f) => f.id === newFact.id) / PAGE_SIZE) + 1);
+    setNewContent("");
+  }
+
+  function startEdit(item: PersonFunFactItem) {
+    setEditingId(item.id);
+    setEditContent(item.content);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditContent("");
+  }
+
+  async function saveEdit(id: string) {
+    if (!editContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/fun-facts/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: editContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { fact } = await res.json();
+    updateFact(id, (item) => ({ ...item, content: fact.content, updatedAt: fact.updatedAt }));
+    cancelEdit();
+  }
+
+  async function deleteFact(id: string) {
+    if (!window.confirm("Delete this fun fact? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/fun-facts/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const remaining = facts.filter((f) => f.id !== id);
+    setFacts(remaining);
+    if (spotlightId === id) setSpotlightId(remaining[0]?.id ?? null);
+  }
+
+  async function vote(id: string, value: 1 | -1) {
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/fun-facts/${id}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { myVote, up, down } = await res.json();
+    updateFact(id, (item) => ({ ...item, myVote, up, down }));
+  }
+
+  function shiftSpotlight(direction: 1 | -1) {
+    if (facts.length === 0) return;
+    const currentIndex = facts.findIndex((f) => f.id === spotlightId);
+    const base = currentIndex === -1 ? 0 : currentIndex;
+    const nextIndex = (base + direction + facts.length) % facts.length;
+    setSpotlightId(facts[nextIndex].id);
+    setPage(Math.floor(nextIndex / PAGE_SIZE) + 1);
+  }
+
+  const spotlightIndex = Math.max(
+    0,
+    facts.findIndex((f) => f.id === spotlightId),
+  );
+  const spotlightFact = facts[spotlightIndex] ?? null;
+
+  const entryNumbers = new Map(
+    [...facts]
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      .map((f, i) => [f.id, i + 1]),
+  );
+
+  const totalPages = Math.max(1, Math.ceil(facts.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageFacts = facts.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  return (
+    <section className="mt-10 max-w-2xl">
+      <h2 className="mb-4 font-serif text-xl font-bold text-white">Fun Facts</h2>
+
+      <div className="overflow-hidden rounded-md border border-neutral-800 bg-neutral-900">
+        {signedIn ? (
+          <div className="flex flex-col gap-2 border-b border-neutral-800 p-3">
+            <textarea
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              placeholder="Did you know…?"
+              rows={2}
+              maxLength={MAX_CONTENT_LENGTH}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            />
+            <div className="flex items-center gap-3">
+              <button
+                onClick={submit}
+                disabled={submitting || !newContent.trim()}
+                className="w-fit rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+              >
+                Add fun fact
+              </button>
+              <span className="text-xs text-neutral-500">
+                {newContent.length}/{MAX_CONTENT_LENGTH}
+              </span>
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
+          </div>
+        ) : (
+          <p className="border-b border-neutral-800 p-3 text-sm text-neutral-400">
+            <a href="/login" className="text-red-500 hover:underline">
+              Sign in
+            </a>{" "}
+            to add a fun fact.
+          </p>
+        )}
+
+        {spotlightFact ? (
+          (() => {
+            const fact = spotlightFact;
+            const canEdit = currentUserId === fact.submittedById;
+            const canDelete = canEdit || isAdmin;
+            const canVote = signedIn && !canEdit;
+
+            return (
+              <div className="flex gap-3 border-b border-l-4 border-neutral-800 border-l-red-700 p-4">
+                <span className="font-serif text-4xl leading-[0.6] text-red-700/70">&ldquo;</span>
+                <div className="min-w-0 flex-1">
+                  {editingId === fact.id ? (
+                    <div className="flex flex-col gap-2">
+                      <textarea
+                        value={editContent}
+                        onChange={(e) => setEditContent(e.target.value)}
+                        rows={2}
+                        maxLength={MAX_CONTENT_LENGTH}
+                        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => saveEdit(fact.id)}
+                          disabled={submitting || !editContent.trim()}
+                          className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={cancelEdit}
+                          className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-lg text-neutral-100">{fact.content}</p>
+                  )}
+
+                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-xs text-neutral-500">
+                      — {fact.submittedBy.username} · {formatDate(fact.createdAt)}
+                      {wasEdited(fact) && " (edited)"}
+                    </p>
+
+                    <div className="flex items-center gap-3 text-sm">
+                      {facts.length > 1 && (
+                        <button
+                          onClick={() => shiftSpotlight(-1)}
+                          className="text-neutral-500 hover:text-neutral-300"
+                        >
+                          ‹
+                        </button>
+                      )}
+                      <button
+                        onClick={() => (canVote ? vote(fact.id, 1) : undefined)}
+                        disabled={!canVote}
+                        title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                        className={`flex items-center gap-1 rounded px-1 leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                          fact.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"
+                        }`}
+                      >
+                        👍 {fact.up}
+                      </button>
+                      <button
+                        onClick={() => (canVote ? vote(fact.id, -1) : undefined)}
+                        disabled={!canVote}
+                        title={canEdit ? "You can't vote on your own fun fact" : undefined}
+                        className={`flex items-center gap-1 rounded px-1 leading-none transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                          fact.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"
+                        }`}
+                      >
+                        👎 {fact.down}
+                      </button>
+                      {facts.length > 1 && (
+                        <button
+                          onClick={() => shiftSpotlight(1)}
+                          className="text-neutral-500 hover:text-neutral-300"
+                        >
+                          ›
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {(canEdit || canDelete) && editingId !== fact.id && (
+                    <div className="mt-1.5 flex items-center gap-2">
+                      {canEdit && (
+                        <button
+                          onClick={() => startEdit(fact)}
+                          className="text-xs text-neutral-400 hover:text-white"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => deleteFact(fact.id)}
+                          className="text-xs text-neutral-400 hover:text-red-400"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })()
+        ) : (
+          <p className="border-b border-neutral-800 p-5 text-center text-sm text-neutral-500">
+            No fun facts yet. Be the first to add one.
+          </p>
+        )}
+
+        {facts.length > 1 && (
+          <button
+            onClick={() => setShowList((v) => !v)}
+            className="w-full border-t border-neutral-800 py-2 text-center text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+          >
+            {showList ? "Hide fun facts list" : `Show all ${facts.length} fun facts →`}
+          </button>
+        )}
+
+        {showList && facts.length > 0 && (
+          <>
+            <ul className="divide-y divide-neutral-800 border-t border-neutral-800">
+              {pageFacts.map((fact) => (
+                <li key={fact.id}>
+                  <button
+                    onClick={() => setSpotlightId(fact.id)}
+                    className={`flex w-full flex-col gap-1 px-3 py-2 text-left text-sm transition hover:bg-neutral-800/50 ${
+                      fact.id === spotlightId ? "bg-neutral-800/40" : ""
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 text-xs text-neutral-500">
+                      <span className="shrink-0 text-neutral-600">#{entryNumbers.get(fact.id)}</span>
+                      <span className={fact.myVote === 1 ? "text-green-500" : "text-neutral-600"}>
+                        👍 {fact.up}
+                      </span>
+                      <span className={fact.myVote === -1 ? "text-red-500" : "text-neutral-600"}>
+                        👎 {fact.down}
+                      </span>
+                      <span className="shrink-0 font-medium text-neutral-100">{fact.submittedBy.username}</span>
+                      <span className="ml-auto shrink-0 text-neutral-600">{formatDate(fact.createdAt)}</span>
+                    </div>
+                    <p className="text-neutral-300">{fact.content}</p>
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-4 border-t border-neutral-800 py-2 text-sm">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  ‹
+                </button>
+                <div className="flex items-center gap-1">
+                  {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setPage(n)}
+                      className={`rounded border px-2 py-0.5 ${
+                        n === currentPage
+                          ? "border-red-700 bg-red-700 text-white"
+                          : "border-neutral-700 text-neutral-300 hover:bg-neutral-800"
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  ›
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/actor-tributes-list.tsx
+++ b/src/components/actor-tributes-list.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import type { PersonTributeData } from "@/components/actor-tributes-section";
+
+const MAX_TRIBUTE_LENGTH = 5000;
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+}
+
+function PersonTributeListItem({
+  tribute,
+  canEdit,
+  canDelete,
+  canVote,
+  isEditing,
+  editContent,
+  submitting,
+  onStartEdit,
+  onEditContentChange,
+  onSaveEdit,
+  onCancelEdit,
+  onDelete,
+  onVote,
+}: {
+  tribute: PersonTributeData;
+  canEdit: boolean;
+  canDelete: boolean;
+  canVote: boolean;
+  isEditing: boolean;
+  editContent: string;
+  submitting: boolean;
+  onStartEdit: () => void;
+  onEditContentChange: (value: string) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+  onVote: (value: 1 | -1) => void;
+}) {
+  return (
+    <div className="rounded-md border border-neutral-800 bg-neutral-900 p-4">
+      {isEditing ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            value={editContent}
+            onChange={(e) => onEditContentChange(e.target.value)}
+            rows={8}
+            maxLength={MAX_TRIBUTE_LENGTH}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onSaveEdit}
+              disabled={submitting || !editContent.trim()}
+              className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              Save
+            </button>
+            <button
+              onClick={onCancelEdit}
+              className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <p className="whitespace-pre-wrap text-sm text-neutral-300">{tribute.content}</p>
+      )}
+
+      <div className="mt-3 flex items-center gap-3 text-xs">
+        <button
+          onClick={() => (canVote ? onVote(1) : undefined)}
+          disabled={!canVote}
+          title={canEdit ? "You can't vote on your own tribute" : undefined}
+          className={`${tribute.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"} disabled:cursor-not-allowed disabled:hover:text-neutral-500`}
+        >
+          👍 {tribute.up}
+        </button>
+        <button
+          onClick={() => (canVote ? onVote(-1) : undefined)}
+          disabled={!canVote}
+          title={canEdit ? "You can't vote on your own tribute" : undefined}
+          className={`${tribute.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"} disabled:cursor-not-allowed disabled:hover:text-neutral-500`}
+        >
+          👎 {tribute.down}
+        </button>
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+        <span>
+          {tribute.author.username} &middot; {formatDate(tribute.createdAt)}
+        </span>
+        {(canEdit || canDelete) && !isEditing && (
+          <span className="inline-flex gap-2">
+            {canEdit && (
+              <button onClick={onStartEdit} className="text-neutral-400 hover:text-white">
+                Edit
+              </button>
+            )}
+            {canDelete && (
+              <button onClick={onDelete} className="text-neutral-400 hover:text-red-400">
+                Delete
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActorTributesList({
+  personId,
+  initialTributes,
+  signedIn,
+  currentUserId,
+  isAdmin,
+}: {
+  personId: string;
+  initialTributes: PersonTributeData[];
+  signedIn: boolean;
+  currentUserId: string | null;
+  isAdmin: boolean;
+}) {
+  const [tributes, setTributes] = useState(initialTributes);
+  const [editingTributeId, setEditingTributeId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function startEdit(tribute: PersonTributeData) {
+    setEditingTributeId(tribute.id);
+    setEditContent(tribute.content);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingTributeId(null);
+    setEditContent("");
+  }
+
+  async function saveEdit(id: string) {
+    if (!editContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: editContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { tribute } = await res.json();
+    setTributes((prev) => prev.map((t) => (t.id === id ? { ...t, ...tribute } : t)));
+    cancelEdit();
+  }
+
+  async function deleteTribute(id: string) {
+    if (!window.confirm("Delete this tribute? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    setTributes((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  async function vote(id: string, value: 1 | -1) {
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { myVote, up, down } = await res.json();
+    setTributes((prev) => prev.map((t) => (t.id === id ? { ...t, myVote, up, down } : t)));
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      {tributes.map((tribute) => (
+        <PersonTributeListItem
+          key={tribute.id}
+          tribute={tribute}
+          canEdit={currentUserId === tribute.authorId}
+          canDelete={currentUserId === tribute.authorId || isAdmin}
+          canVote={signedIn && currentUserId !== tribute.authorId}
+          isEditing={editingTributeId === tribute.id}
+          editContent={editContent}
+          submitting={submitting}
+          onStartEdit={() => startEdit(tribute)}
+          onEditContentChange={setEditContent}
+          onSaveEdit={() => saveEdit(tribute.id)}
+          onCancelEdit={cancelEdit}
+          onDelete={() => deleteTribute(tribute.id)}
+          onVote={(value) => vote(tribute.id, value)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/actor-tributes-section.tsx
+++ b/src/components/actor-tributes-section.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useState } from "react";
+import type { PersonTribute as PersonTributeModel, User } from "@/generated/prisma/client";
+
+const MAX_TRIBUTE_LENGTH = 5000;
+
+type TributeAuthor = Pick<User, "username">;
+
+// updatedAt/createdAt cross the server-to-client boundary as strings (JSON),
+// same reasoning as MemberReviewData.
+export type PersonTributeData = Pick<PersonTributeModel, "id" | "content" | "authorId"> & {
+  createdAt: string;
+  updatedAt: string;
+  author: TributeAuthor;
+  up: number;
+  down: number;
+  myVote: 1 | -1 | null;
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+}
+
+// Highest net score (up - down) first, ties broken by newest -- same
+// ordering as ReviewsSection's byNetScore.
+function byNetScore(a: PersonTributeData, b: PersonTributeData) {
+  const scoreDiff = b.up - b.down - (a.up - a.down);
+  if (scoreDiff !== 0) return scoreDiff;
+  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+}
+
+// Same clamp threshold as MemberReviewCard.
+const CARD_CLAMP_THRESHOLD = 160;
+
+function PersonTributeCard({
+  tribute,
+  canEdit,
+  canDelete,
+  canVote,
+  isEditing,
+  editContent,
+  submitting,
+  onStartEdit,
+  onEditContentChange,
+  onSaveEdit,
+  onCancelEdit,
+  onDelete,
+  onVote,
+}: {
+  tribute: PersonTributeData;
+  canEdit: boolean;
+  canDelete: boolean;
+  canVote: boolean;
+  isEditing: boolean;
+  editContent: string;
+  submitting: boolean;
+  onStartEdit: () => void;
+  onEditContentChange: (value: string) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+  onVote: (value: 1 | -1) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = tribute.content.length > CARD_CLAMP_THRESHOLD;
+
+  return (
+    <div className="w-72 shrink-0 rounded-md border border-neutral-800 bg-neutral-900 p-3">
+      {isEditing ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            value={editContent}
+            onChange={(e) => onEditContentChange(e.target.value)}
+            rows={6}
+            maxLength={MAX_TRIBUTE_LENGTH}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onSaveEdit}
+              disabled={submitting || !editContent.trim()}
+              className="w-fit rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              Save
+            </button>
+            <button
+              onClick={onCancelEdit}
+              className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <p className={`whitespace-pre-wrap text-sm text-neutral-300 ${!expanded && isLong ? "line-clamp-4" : ""}`}>
+            {tribute.content}
+          </p>
+          {isLong && (
+            <button
+              onClick={() => setExpanded((e) => !e)}
+              className="mt-1 text-xs font-medium text-red-500 hover:underline"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="mt-2 flex items-center gap-3 text-xs">
+        <button
+          onClick={() => (canVote ? onVote(1) : undefined)}
+          disabled={!canVote}
+          title={canEdit ? "You can't vote on your own tribute" : undefined}
+          className={`${tribute.myVote === 1 ? "text-green-500" : "text-neutral-500 hover:text-neutral-300"} disabled:cursor-not-allowed disabled:hover:text-neutral-500`}
+        >
+          👍 {tribute.up}
+        </button>
+        <button
+          onClick={() => (canVote ? onVote(-1) : undefined)}
+          disabled={!canVote}
+          title={canEdit ? "You can't vote on your own tribute" : undefined}
+          className={`${tribute.myVote === -1 ? "text-red-500" : "text-neutral-500 hover:text-neutral-300"} disabled:cursor-not-allowed disabled:hover:text-neutral-500`}
+        >
+          👎 {tribute.down}
+        </button>
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+        <span>
+          {tribute.author.username} &middot; {formatDate(tribute.createdAt)}
+        </span>
+        {(canEdit || canDelete) && !isEditing && (
+          <span className="inline-flex gap-2">
+            {canEdit && (
+              <button onClick={onStartEdit} className="text-neutral-400 hover:text-white">
+                Edit
+              </button>
+            )}
+            {canDelete && (
+              <button onClick={onDelete} className="text-neutral-400 hover:text-red-400">
+                Delete
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActorTributesSection({
+  personId,
+  initialTributes,
+  tributesCount,
+  hasOwnTribute,
+  signedIn,
+  currentUserId,
+  isAdmin,
+}: {
+  personId: string;
+  initialTributes: PersonTributeData[];
+  tributesCount: number;
+  hasOwnTribute: boolean;
+  signedIn: boolean;
+  currentUserId: string | null;
+  isAdmin: boolean;
+}) {
+  const [tributes, setTributes] = useState(initialTributes);
+  const [count, setCount] = useState(tributesCount);
+  const [hasTribute, setHasTribute] = useState(hasOwnTribute);
+  const [showWriteForm, setShowWriteForm] = useState(false);
+  const [newContent, setNewContent] = useState("");
+  const [editingTributeId, setEditingTributeId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submitNewTribute() {
+    if (!newContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: newContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { tribute } = await res.json();
+    const withVotes: PersonTributeData = { ...tribute, up: 0, down: 0, myVote: null };
+    setTributes((prev) => [withVotes, ...prev].sort(byNetScore).slice(0, initialTributes.length || 2));
+    setCount((c) => c + 1);
+    setHasTribute(true);
+    setNewContent("");
+    setShowWriteForm(false);
+  }
+
+  function startEdit(tribute: PersonTributeData) {
+    setEditingTributeId(tribute.id);
+    setEditContent(tribute.content);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingTributeId(null);
+    setEditContent("");
+  }
+
+  async function saveEdit(id: string) {
+    if (!editContent.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: editContent }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { tribute } = await res.json();
+    setTributes((prev) => prev.map((t) => (t.id === id ? { ...t, ...tribute } : t)));
+    cancelEdit();
+  }
+
+  async function deleteTribute(id: string) {
+    if (!window.confirm("Delete this tribute? This can't be undone.")) return;
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const wasMine = tributes.find((t) => t.id === id)?.authorId === currentUserId;
+    setTributes((prev) => prev.filter((t) => t.id !== id));
+    setCount((c) => Math.max(0, c - 1));
+    if (wasMine) setHasTribute(false);
+  }
+
+  async function vote(id: string, value: 1 | -1) {
+    setError(null);
+    const res = await fetch(`/api/actors/${personId}/tributes/${id}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? "Something went wrong.");
+      return;
+    }
+    const { myVote, up, down } = await res.json();
+    setTributes((prev) => prev.map((t) => (t.id === id ? { ...t, myVote, up, down } : t)).sort(byNetScore));
+  }
+
+  return (
+    <section className="mb-8">
+      <h2 className="mb-4 text-xl font-bold text-white">Tributes</h2>
+
+      {signedIn ? (
+        !hasTribute && (
+          <div className="mb-4">
+            {showWriteForm ? (
+              <div className="flex flex-col gap-2">
+                <textarea
+                  value={newContent}
+                  onChange={(e) => setNewContent(e.target.value)}
+                  rows={6}
+                  maxLength={MAX_TRIBUTE_LENGTH}
+                  placeholder="Write a tribute to their career, or a performance you loved…"
+                  className="w-full max-w-2xl rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                />
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={submitNewTribute}
+                    disabled={submitting || !newContent.trim()}
+                    className="w-fit rounded-md bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+                  >
+                    {submitting ? "Posting…" : "Post tribute"}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowWriteForm(false);
+                      setNewContent("");
+                    }}
+                    className="w-fit rounded-md border border-neutral-700 px-4 py-1.5 text-sm text-neutral-300 hover:bg-neutral-800"
+                  >
+                    Cancel
+                  </button>
+                  <span className="text-xs text-neutral-500">
+                    {newContent.length}/{MAX_TRIBUTE_LENGTH}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowWriteForm(true)}
+                className="w-fit rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+              >
+                Write a tribute
+              </button>
+            )}
+          </div>
+        )
+      ) : (
+        <p className="mb-4 text-sm text-neutral-400">
+          <a href="/login" className="text-red-500 hover:underline">
+            Sign in
+          </a>{" "}
+          to write a tribute.
+        </p>
+      )}
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      {tributes.length > 0 ? (
+        <>
+          <div className="rail-scrollbar flex gap-4 overflow-x-auto pb-2">
+            {tributes.map((tribute) => (
+              <PersonTributeCard
+                key={tribute.id}
+                tribute={tribute}
+                canEdit={currentUserId === tribute.authorId}
+                canDelete={currentUserId === tribute.authorId || isAdmin}
+                canVote={signedIn && currentUserId !== tribute.authorId}
+                isEditing={editingTributeId === tribute.id}
+                editContent={editContent}
+                submitting={submitting}
+                onStartEdit={() => startEdit(tribute)}
+                onEditContentChange={setEditContent}
+                onSaveEdit={() => saveEdit(tribute.id)}
+                onCancelEdit={cancelEdit}
+                onDelete={() => deleteTribute(tribute.id)}
+                onVote={(value) => vote(tribute.id, value)}
+              />
+            ))}
+          </div>
+          {count > tributes.length && (
+            <a
+              href={`/actors/${personId}/tributes`}
+              className="mt-3 inline-block text-sm text-red-500 hover:underline"
+            >
+              View all {count} tributes →
+            </a>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-neutral-500">No tributes yet. Be the first to pay one.</p>
+      )}
+    </section>
+  );
+}

--- a/src/lib/person-fun-facts.ts
+++ b/src/lib/person-fun-facts.ts
@@ -1,0 +1,42 @@
+import { prisma } from "@/lib/prisma";
+
+// Same cap as movie Fun Facts (MAX_FUN_FACT_LENGTH in fun-facts.ts) -- a
+// trivia snippet about the actor, not a full writeup.
+export const MAX_PERSON_FUN_FACT_LENGTH = 500;
+
+export function getFunFactsForPerson(personId: string) {
+  return prisma.personFunFact.findMany({
+    where: { personId, isDeleted: false },
+    orderBy: { createdAt: "desc" },
+    include: { submittedBy: { select: { username: true } } },
+  });
+}
+
+export interface PersonFunFactVoteSummary {
+  up: number;
+  down: number;
+}
+
+// Same in-memory groupBy tradeoff as getFunFactVoteSummaries -- no SQL-level
+// up-minus-down aggregate, and actor fun facts aren't paginated at the DB
+// level either.
+export async function getPersonFunFactVoteSummaries(
+  factIds: string[],
+): Promise<Map<string, PersonFunFactVoteSummary>> {
+  if (factIds.length === 0) return new Map();
+
+  const rows = await prisma.personFunFactVote.groupBy({
+    by: ["factId", "value"],
+    where: { factId: { in: factIds } },
+    _count: { _all: true },
+  });
+
+  const map = new Map<string, PersonFunFactVoteSummary>();
+  for (const row of rows) {
+    const summary = map.get(row.factId) ?? { up: 0, down: 0 };
+    if (row.value === 1) summary.up = row._count._all;
+    else if (row.value === -1) summary.down = row._count._all;
+    map.set(row.factId, summary);
+  }
+  return map;
+}

--- a/src/lib/person-tributes.ts
+++ b/src/lib/person-tributes.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
+
+// Same cap as MAX_MEMBER_REVIEW_LENGTH -- a full writeup, not a trivia
+// snippet.
+export const MAX_PERSON_TRIBUTE_LENGTH = 5000;
+
+// How many tributes show inline on the actor page itself before linking out
+// to the full paginated list, same reasoning as MEMBER_REVIEWS_PREVIEW_COUNT.
+export const PERSON_TRIBUTES_PREVIEW_COUNT = 2;
+
+export const PERSON_TRIBUTES_PAGE_SIZE = 10;
+
+const personTributeOrderBy: Prisma.PersonTributeOrderByWithRelationInput[] = [
+  { voteScore: "desc" },
+  { createdAt: "desc" },
+];
+
+export function getTopPersonTributes(personId: string, limit: number = PERSON_TRIBUTES_PREVIEW_COUNT) {
+  return prisma.personTribute.findMany({
+    where: { personId },
+    orderBy: personTributeOrderBy,
+    take: limit,
+    include: { author: { select: { username: true } } },
+  });
+}
+
+export function getPersonTributesCount(personId: string) {
+  return prisma.personTribute.count({ where: { personId } });
+}
+
+export async function getPersonTributesPage(personId: string, page: number) {
+  const [tributes, totalCount] = await Promise.all([
+    prisma.personTribute.findMany({
+      where: { personId },
+      orderBy: personTributeOrderBy,
+      skip: (page - 1) * PERSON_TRIBUTES_PAGE_SIZE,
+      take: PERSON_TRIBUTES_PAGE_SIZE,
+      include: { author: { select: { username: true } } },
+    }),
+    getPersonTributesCount(personId),
+  ]);
+  return { tributes, totalCount };
+}
+
+export interface PersonTributeVoteSummary {
+  up: number;
+  down: number;
+}
+
+export async function getPersonTributeVoteSummaries(
+  tributeIds: string[],
+): Promise<Map<string, PersonTributeVoteSummary>> {
+  if (tributeIds.length === 0) return new Map();
+
+  const rows = await prisma.personTributeVote.groupBy({
+    by: ["tributeId", "value"],
+    where: { tributeId: { in: tributeIds } },
+    _count: { _all: true },
+  });
+
+  const map = new Map<string, PersonTributeVoteSummary>();
+  for (const row of rows) {
+    const summary = map.get(row.tributeId) ?? { up: 0, down: 0 };
+    if (row.value === 1) summary.up = row._count._all;
+    else if (row.value === -1) summary.down = row._count._all;
+    map.set(row.tributeId, summary);
+  }
+  return map;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -43,6 +43,8 @@ export const listCreateLimiter = makeLimiter("list-create", 10, "10 m");
 export const fightCountEditLimiter = makeLimiter("fight-count-edit", 10, "10 m");
 export const funFactSubmitLimiter = makeLimiter("fun-fact-submit", 10, "10 m");
 export const memberReviewSubmitLimiter = makeLimiter("member-review-submit", 10, "10 m");
+export const personFunFactSubmitLimiter = makeLimiter("person-fun-fact-submit", 10, "10 m");
+export const personTributeSubmitLimiter = makeLimiter("person-tribute-submit", 10, "10 m");
 
 export interface RateLimitResult {
   success: boolean;


### PR DESCRIPTION
## Summary

Adds two new member-content features for actors, mirroring the existing movie-scoped equivalents:

- **Fun Facts**: Short trivia snippets (≤500 chars) about an actor, with upvote/downvote voting
- **Tributes**: Longer-form writeups (≤5000 chars) celebrating an actor's career/performances, with upvote/downvote voting

Both features appear on actor pages (`/actors/[personId]`) with inline previews, and tributes have a full paginated list view at `/actors/[personId]/tributes`. The implementation reuses the exact same shapes, voting behavior, and soft-delete patterns as their movie counterparts (`FunFact`/`MemberReview`), just scoped to `Person` instead of `Movie`.

## Changes

**Schema & Migrations:**
- Added `PersonFunFact`, `PersonFunFactVote`, `PersonTribute`, `PersonTributeVote` tables
- One-per-(person,author) unique constraint on tributes (same as `MemberReview`)
- Soft-delete via `isDeleted` boolean on fun facts (same as `FunFact`)
- Vote toggle behavior: voting with the same value removes the vote; opposite value flips it

**Components:**
- `ActorFunFactsSection`: Spotlight carousel with navigation, inline submission, edit/delete, voting
- `ActorTributesSection`: Horizontal card carousel preview with link to full list
- `ActorTributesList`: Paginated full list view with edit/delete/voting

**API Routes:**
- `POST /api/actors/[personId]/fun-facts` — Submit fun fact (rate-limited, email-verified)
- `PATCH /api/actors/[personId]/fun-facts/[factId]` — Edit (author only)
- `DELETE /api/actors/[personId]/fun-facts/[factId]` — Delete (author or admin)
- `POST /api/actors/[personId]/fun-facts/[factId]/vote` — Vote (email-verified, not author)
- `POST /api/actors/[personId]/tributes` — Submit tribute (rate-limited, email-verified, one per author)
- `PATCH /api/actors/[personId]/tributes/[tributeId]` — Edit (author only)
- `DELETE /api/actors/[personId]/tributes/[tributeId]` — Delete (author or admin)
- `POST /api/actors/[personId]/tributes/[tributeId]/vote` — Vote (email-verified, not author)

**Library Functions:**
- `lib/person-fun-facts.ts`: Fetch fun facts, vote summaries
- `lib/person-tributes.ts`: Fetch tributes (paginated and preview), vote summaries, count
- Rate limiters added to `lib/rate-limit.ts`

**Pages:**
- Updated `/actors/[personId]` to fetch and render fun facts and tribute previews
- New `/actors/[personId]/tributes` page for full paginated tribute list

## Checklist

- [x] `README.md` updated (added "Fun Facts and Tributes" section under Actor Pages)
- [x] `.env.example` not needed (no new env vars)
- [x] `DECISIONS.md` updated (documented the design choice to use separate tables rather than nullable variants)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

Verified locally:
- Fun facts can be submitted, edited, deleted, and voted on from the actor page
- Tributes can be submitted, edited, deleted, and voted on from the actor page
- Full tribute list pagination works at `/actors/[personId]/tributes`
- Vote toggle behavior works (same value removes vote, opposite value flips)
- Rate limiting and email verification checks are enforced
- Soft-deleted fun facts don't appear in lists
- One-per-author tribute constraint is enforced
- Admin can delete any fun fact or tribute; authors can only delete their own

https://claude.ai/code/session_01BSBNeoss3o6BsvuBhUd3S4