### PR TITLE
Mark TMDB-hosted images unoptimized to remove them from the quota

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -56,6 +56,7 @@ one.
 - [Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production](#weekly-trending-carousels-cron-had-never-run-cron_secret-was-never-configured-in-production)
 - [Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch](#preview-database-made-static-across-prs-trading-back-the-migration-collision-risk-to-stop-re-seeding-every-branch)
 - [`images.imageSizes` narrowed to match actual usage, after the free tier's Image Optimization quota was hit](#imagesimagesizes-narrowed-to-match-actual-usage-after-the-free-tiers-image-optimization-quota-was-hit)
+- [TMDB-hosted images marked `unoptimized`, removing them from the Image Optimization quota entirely](#tmdb-hosted-images-marked-unoptimized-removing-them-from-the-image-optimization-quota-entirely)
 
 **Feature Decisions**
 
@@ -991,6 +992,51 @@ it again.
   real, if small, user-facing tradeoffs. Left as backlog if the quota
   becomes a recurring problem after this change; upgrading to Vercel Pro is
   the other lever if it does.
+- **Update, same day**: this reset the cache keys for every image (the
+  bucket widths changed), so live traffic re-triggered a full-catalog
+  re-transformation the moment it deployed and re-exhausted the
+  just-reset quota within hours — see the follow-up entry below for the
+  actual fix and the reasoning that superseded this one.
+
+### TMDB-hosted images marked `unoptimized`, removing them from the Image Optimization quota entirely
+Follow-up to the entry above: narrowing `imageSizes` turned out not to be
+a meaningful reduction (see that entry's update) and didn't address the
+underlying scaling problem — transformation usage was still tied to
+catalog size and traffic. This is the structural fix.
+
+- **Key finding**: `src/lib/tmdb.ts`'s `tmdbImageUrl`/`resolvePosterUrl`
+  already request a specific pre-sized TMDB CDN bucket (`w200`, `w342`,
+  etc.) — TMDB serves these for free, outside Vercel's quota entirely.
+  Vercel's optimizer was redundantly resizing an image TMDB had already
+  sized. Only admin-uploaded poster overrides (Vercel Blob,
+  `posterOverrideUrl`) lack this and still benefit from real optimization.
+- **Fix applied**: every `<Image>` sourced from `image.tmdb.org` now sets
+  `unoptimized` (added `isTmdbUrl()` in `tmdb.ts` to detect this per-URL,
+  since `resolvePosterUrl` can return either a TMDB or a Blob URL; call
+  sites that only ever use `tmdbImageUrl` directly, with no override path,
+  set it unconditionally). Confirmed from Next 16.3's own source
+  (`get-img-props.js`) that `unoptimized` skips the optimizer route
+  entirely for external URLs and has no conflict with `fill`/`sizes`.
+- **Backdrops changed from `"original"` to `"w1280"`**: the two
+  `sizes="100vw"` backdrop images (`hero-carousel.tsx`,
+  `movies/[id]/page.tsx`) requested TMDB's unbounded `original` size:
+  raw source images up to 3840×2160. Without Vercel resizing that in
+  front of the browser, `unoptimized` alone would have made backdrops
+  *worse*, not better. `w1280` is a real, documented TMDB `backdrop_sizes`
+  bucket, bounded and reasonable even for large viewports.
+- **Accepted tradeoff**: `unoptimized` images skip Next's automatic
+  AVIF/WebP conversion, so TMDB's plain JPEGs are served as-is — modestly
+  heavier than the optimized version. Traded deliberately for removing
+  the majority of the site's image volume from the quota permanently,
+  independent of catalog growth.
+- **Not verified**: what fraction of movies actually carry a
+  `posterOverrideUrl` (no production database access in the session that
+  made this change) — doesn't affect correctness, only how large the
+  reduction turns out to be. A live TMDB request couldn't be tested
+  directly either (this session's network egress blocks `image.tmdb.org`);
+  the existing `w200`/`w342`/`w500` size codes were kept as-is rather than
+  retuned, since the app's own production history is the proof they
+  already work.
 
 ## Feature Decisions
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -55,6 +55,7 @@ one.
 - [Vercel preview deployments deleted on PR close, to stop Neon preview-branch pileup](#vercel-preview-deployments-deleted-on-pr-close-to-stop-neon-preview-branch-pileup)
 - [Weekly Trending Carousel's cron had never run — `CRON_SECRET` was never configured in Production](#weekly-trending-carousels-cron-had-never-run-cron_secret-was-never-configured-in-production)
 - [Preview database made static across PRs, trading back the migration-collision risk to stop re-seeding every branch](#preview-database-made-static-across-prs-trading-back-the-migration-collision-risk-to-stop-re-seeding-every-branch)
+- [`images.imageSizes` narrowed to match actual usage, after the free tier's Image Optimization quota was hit](#imagesimagesizes-narrowed-to-match-actual-usage-after-the-free-tiers-image-optimization-quota-was-hit)
 
 **Feature Decisions**
 
@@ -964,6 +965,32 @@ protecting against for this project's actual pace of parallel work.
   Free-plan branch-count limit from that same incident doesn't get
   re-triggered by deployment pileup), but no longer cascades into deleting
   a Neon branch, since no single deployment owns the shared one anymore.
+
+### `images.imageSizes` narrowed to match actual usage, after the free tier's Image Optimization quota was hit
+The `kfmdb` Vercel team hit 100% of the Hobby plan's 5,000/month Image
+Optimization transformations, which returns a 402 for any new (uncached)
+image and shows the `alt` text instead of the picture — happened to reset
+the same day, so no production impact, but the same growth rate would hit
+it again.
+
+- **Root cause**: `next.config.ts` left `images.imageSizes` at Next's
+  default `[16, 32, 48, 64, 96, 128, 256, 384]`, which doesn't match this
+  app's actual fixed-pixel `sizes` values (28–224px across movie-card,
+  actor/leaderboard rows, feeds, search). Each mismatched bucket Next
+  generates for a source image counts as a separate billed transformation.
+- **Fix applied**: `imageSizes` set explicitly to the widths the app
+  actually renders — `[28, 32, 36, 40, 56, 64, 96, 112, 128, 160, 192,
+  224]`. Next always rounds up to the nearest bucket ≥ the requested size,
+  so this is a zero-tradeoff change: no image renders differently, it just
+  stops generating variants nobody requests.
+- **Deliberately not changed**: `images.deviceSizes` (used only by the two
+  `sizes="100vw"` backdrop/hero images) and `images.formats` (AVIF+WebP).
+  Both would cut further into the transformation count, but trimming
+  `deviceSizes`' top bucket softens backdrops on 4K/ultra-wide monitors,
+  and dropping AVIF makes every image modestly heavier for most visitors —
+  real, if small, user-facing tradeoffs. Left as backlog if the quota
+  becomes a recurring problem after this change; upgrading to Vercel Pro is
+  the other lever if it does.
 
 ## Feature Decisions
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1037,6 +1037,15 @@ catalog size and traffic. This is the structural fix.
   the existing `w200`/`w342`/`w500` size codes were kept as-is rather than
   retuned, since the app's own production history is the proof they
   already work.
+- **Follow-up, same day**: `recommended-badge.tsx`'s admin badge icon —
+  the one `<Image>` in the app sourced from a local `public/` file, not
+  TMDB or Blob — was missed by this entry's scope (it isn't a TMDB URL, so
+  `isTmdbUrl()` doesn't apply). Any `next/image` usage, local or remote,
+  goes through the same Vercel optimizer and the same team-wide quota
+  unless marked `unoptimized`, so this one small static asset was still
+  exposed to the same 402 failures whenever the quota was exhausted. Since
+  it's a tiny, fixed-size, developer-controlled file that never changes,
+  Vercel's resizing wasn't buying anything — marked `unoptimized` too.
 
 ## Feature Decisions
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,12 @@ const SECURITY_HEADERS = [
 
 const nextConfig: NextConfig = {
   images: {
+    // Matches every fixed-pixel `sizes` value actually used in the app
+    // (movie-card, actor/leaderboard rows, feeds, search). Next's default
+    // imageSizes list doesn't line up with these, so it was generating
+    // extra width variants nobody needed — each one counts against
+    // Vercel's Image Optimization transformation quota.
+    imageSizes: [28, 32, 36, 40, 56, 64, 96, 112, 128, 160, 192, 224],
     remotePatterns: [
       {
         protocol: "https",

--- a/src/app/actors/[personId]/page.tsx
+++ b/src/app/actors/[personId]/page.tsx
@@ -419,7 +419,14 @@ export default async function ActorPage({ params }: { params: Promise<{ personId
       <div className="mb-6 flex items-center gap-4">
         <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-full bg-neutral-800">
           {person.profilePath && (
-            <Image src={tmdbImageUrl(person.profilePath, "w200") ?? ""} alt={person.name} fill sizes="96px" className="object-cover" />
+            <Image
+              src={tmdbImageUrl(person.profilePath, "w200") ?? ""}
+              alt={person.name}
+              fill
+              unoptimized
+              sizes="96px"
+              className="object-cover"
+            />
           )}
         </div>
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -95,6 +95,7 @@ export default async function LeaderboardPage() {
                       src={tmdbImageUrl(actor.profilePath, "w200") ?? ""}
                       alt={actor.name}
                       fill
+                      unoptimized
                       sizes="36px"
                       className="object-cover"
                     />

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next";
 import type { Session } from "next-auth";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { tmdbImageUrl, resolvePosterUrl } from "@/lib/tmdb";
+import { tmdbImageUrl, resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 import { truncate } from "@/lib/text";
 import {
   getCommunityRatingSummary,
@@ -285,7 +285,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       : [],
   ]);
 
-  const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
+  const backdropUrl = tmdbImageUrl(movie.backdropPath, "w1280");
   const posterUrl = resolvePosterUrl(movie, "w342");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
   const isFavorite = myListEntries.some((e) => e.listType === "FAVORITE");
@@ -464,7 +464,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     <div className="flex flex-1 flex-col">
       <div className="relative h-64 w-full sm:h-80">
         {backdropUrl ? (
-          <Image src={backdropUrl} alt="" fill priority sizes="100vw" className="object-cover" />
+          <Image src={backdropUrl} alt="" fill priority unoptimized sizes="100vw" className="object-cover" />
         ) : (
           <div className="h-full w-full bg-neutral-900" />
         )}
@@ -475,7 +475,14 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
         <div className="w-40 shrink-0 sm:w-56">
           <div className="relative aspect-2/3 overflow-hidden rounded-md bg-neutral-800 shadow-xl">
             {posterUrl ? (
-              <Image src={posterUrl} alt={movie.title} fill sizes="224px" className="object-cover" />
+              <Image
+                src={posterUrl}
+                alt={movie.title}
+                fill
+                unoptimized={isTmdbUrl(posterUrl)}
+                sizes="224px"
+                className="object-cover"
+              />
             ) : (
               <div className="flex h-full items-center justify-center px-2 text-center text-xs text-neutral-500">
                 {movie.title}
@@ -642,6 +649,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
                         src={tmdbImageUrl(credit.person.profilePath, "w200") ?? ""}
                         alt={credit.person.name}
                         fill
+                        unoptimized
                         sizes="112px"
                         className="object-cover"
                       />

--- a/src/components/activity-feed.tsx
+++ b/src/components/activity-feed.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { resolvePosterUrl } from "@/lib/tmdb";
+import { resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 import type {
   DiscussionActivityItem,
   FightSceneActivityItem,
@@ -35,7 +35,16 @@ function PosterThumb({ movie }: { movie: { id: string; title: string; posterPath
   return (
     <Link href={`/movies/${movie.id}`} className="shrink-0">
       <div className="relative aspect-2/3 w-10 overflow-hidden rounded bg-neutral-800">
-        {posterUrl ? <Image src={posterUrl} alt={movie.title} fill sizes="40px" className="object-cover" /> : null}
+        {posterUrl ? (
+          <Image
+            src={posterUrl}
+            alt={movie.title}
+            fill
+            unoptimized={isTmdbUrl(posterUrl)}
+            sizes="40px"
+            className="object-cover"
+          />
+        ) : null}
       </div>
     </Link>
   );

--- a/src/components/actor-signature-vote.tsx
+++ b/src/components/actor-signature-vote.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useMemo, useState, type ReactNode } from "re
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { resolvePosterUrl } from "@/lib/tmdb";
+import { resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 import { YoutubeThumbnailImage } from "@/components/fight-scene-thumbnail";
 
 // Below this many combined votes in a category, no leader is shown --
@@ -146,6 +146,7 @@ export function SignatureSpotlight() {
 
   const movie = movieLeader ? movies.find((m) => m.id === movieLeader.id) : undefined;
   const scene = fightSceneLeader ? fightScenes.find((s) => s.id === fightSceneLeader.id) : undefined;
+  const moviePosterUrl = movie ? resolvePosterUrl(movie, "w342") : null;
 
   if (!movie && !scene) return null;
 
@@ -162,8 +163,15 @@ export function SignatureSpotlight() {
           share={Math.round((movieLeader.votes / movieLeader.total) * 100)}
           imageClassName="aspect-2/3 w-16"
           image={
-            resolvePosterUrl(movie, "w342") ? (
-              <Image src={resolvePosterUrl(movie, "w342")!} alt={movie.title} fill sizes="64px" className="object-cover" />
+            moviePosterUrl ? (
+              <Image
+                src={moviePosterUrl}
+                alt={movie.title}
+                fill
+                unoptimized={isTmdbUrl(moviePosterUrl)}
+                sizes="64px"
+                className="object-cover"
+              />
             ) : (
               <div className="flex h-full items-center justify-center px-1 text-center text-[10px] text-neutral-500">
                 {movie.title}

--- a/src/components/admin-keyword-import.tsx
+++ b/src/components/admin-keyword-import.tsx
@@ -306,7 +306,7 @@ export function AdminKeywordImport() {
                   />
                   <div className="relative aspect-2/3 w-14 shrink-0 overflow-hidden rounded bg-neutral-800">
                     {posterUrl && (
-                      <Image src={posterUrl} alt={movie.title} fill sizes="56px" className="object-cover" />
+                      <Image src={posterUrl} alt={movie.title} fill unoptimized sizes="56px" className="object-cover" />
                     )}
                   </div>
                   <div className="min-w-0">

--- a/src/components/filmography-list.tsx
+++ b/src/components/filmography-list.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { resolvePosterUrl } from "@/lib/tmdb";
+import { resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 import { SignatureVoteButton } from "@/components/actor-signature-vote";
 
 export interface FilmographyRow {
@@ -62,7 +62,14 @@ export function FilmographyList({ rows }: { rows: FilmographyRow[] }) {
                   className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-neutral-800"
                 >
                   {posterUrl && (
-                    <Image src={posterUrl} alt={row.title} fill sizes="32px" className="object-cover" />
+                    <Image
+                      src={posterUrl}
+                      alt={row.title}
+                      fill
+                      unoptimized={isTmdbUrl(posterUrl)}
+                      sizes="32px"
+                      className="object-cover"
+                    />
                   )}
                 </Link>
                 <div className="min-w-0 flex-1">

--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -38,7 +38,7 @@ function clipEmbedUrl(videoId: string, startSeconds: number | null) {
 }
 
 function Slide({ movie, active, playClip }: { movie: FeaturedMovie; active: boolean; playClip: boolean }) {
-  const backdropUrl = tmdbImageUrl(movie.backdropPath, "original");
+  const backdropUrl = tmdbImageUrl(movie.backdropPath, "w1280");
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
   const showClip = active && playClip && !!movie.fightSceneClip;
 
@@ -56,6 +56,7 @@ function Slide({ movie, active, playClip }: { movie: FeaturedMovie; active: bool
           alt={movie.title}
           fill
           priority
+          unoptimized
           sizes="100vw"
           className={`object-cover transition-opacity ${showClip ? "opacity-0" : "opacity-100"}`}
           style={{ transitionDuration: `${FADE_MS}ms` }}

--- a/src/components/movie-card.tsx
+++ b/src/components/movie-card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { resolvePosterUrl } from "@/lib/tmdb";
+import { resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 import { RecommendedBadges } from "@/components/recommended-badge";
 import type { MovieRecommender } from "@/lib/movie-recommendations";
 import type { Movie } from "@/generated/prisma/client";
@@ -36,6 +36,7 @@ export function MovieCard({ movie, size = "default" }: { movie: MovieCardData; s
             src={posterUrl}
             alt={movie.title}
             fill
+            unoptimized={isTmdbUrl(posterUrl)}
             sizes={sizes}
             className="object-cover transition group-hover:scale-105"
           />

--- a/src/components/recent-reviews-feed.tsx
+++ b/src/components/recent-reviews-feed.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { resolvePosterUrl } from "@/lib/tmdb";
+import { resolvePosterUrl, isTmdbUrl } from "@/lib/tmdb";
 
 // Tailwind's class scanner needs the full class name literally in source
 // (not built from a template string) to generate its CSS, so this isn't a
@@ -75,7 +75,14 @@ export function RecentReviewsFeed({ reviews }: { reviews: RecentReviewItem[] }) 
                 <Link href={`/movies/${review.movie.id}`} className="shrink-0">
                   <div className="relative aspect-2/3 w-10 overflow-hidden rounded bg-neutral-800">
                     {posterUrl ? (
-                      <Image src={posterUrl} alt={review.movie.title} fill sizes="40px" className="object-cover" />
+                      <Image
+                        src={posterUrl}
+                        alt={review.movie.title}
+                        fill
+                        unoptimized={isTmdbUrl(posterUrl)}
+                        sizes="40px"
+                        className="object-cover"
+                      />
                     ) : null}
                   </div>
                 </Link>

--- a/src/components/recommended-badge.tsx
+++ b/src/components/recommended-badge.tsx
@@ -35,6 +35,7 @@ export function RecommendedBadges({
               title={`Recommended by ${recommender.username}`}
               width={pixels}
               height={pixels}
+              unoptimized
               className={`${dimensionClass} shrink-0 rounded-md border-2 border-neutral-950 object-contain bg-white`}
             />
           );

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -137,7 +137,7 @@ export function SearchBar({ initialQuery = "" }: { initialQuery?: string }) {
                 >
                   <div className="relative h-10 w-7 shrink-0 overflow-hidden rounded-sm bg-neutral-800">
                     {posterUrl && (
-                      <Image src={posterUrl} alt="" fill sizes="28px" className="object-cover" />
+                      <Image src={posterUrl} alt="" fill unoptimized sizes="28px" className="object-cover" />
                     )}
                   </div>
                   <span className="truncate text-neutral-100">

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -26,7 +26,10 @@ async function tmdbFetch<T>(path: string, params: Record<string, string> = {}): 
   return res.json() as Promise<T>;
 }
 
-export function tmdbImageUrl(path: string | null | undefined, size: "w200" | "w342" | "w500" | "w780" | "original" = "w500") {
+export function tmdbImageUrl(
+  path: string | null | undefined,
+  size: "w200" | "w342" | "w500" | "w780" | "w1280" | "original" = "w500",
+) {
   if (!path) return null;
   return `${TMDB_IMAGE_BASE_URL}/${size}${path}`;
 }
@@ -34,9 +37,19 @@ export function tmdbImageUrl(path: string | null | undefined, size: "w200" | "w3
 // An admin-uploaded poster always wins over whatever TMDB happens to have.
 export function resolvePosterUrl(
   movie: { posterPath: string | null; posterOverrideUrl: string | null },
-  size: "w200" | "w342" | "w500" | "w780" | "original" = "w500",
+  size: "w200" | "w342" | "w500" | "w780" | "w1280" | "original" = "w500",
 ) {
   return movie.posterOverrideUrl || tmdbImageUrl(movie.posterPath, size);
+}
+
+// TMDB's own CDN already serves pre-sized image buckets for free, outside
+// Vercel's Image Optimization quota — so TMDB-hosted images are marked
+// `unoptimized` at their call sites to skip Vercel's transformation
+// pipeline entirely. Admin-uploaded posters (Vercel Blob) don't have that,
+// so they still need real optimization; this tells call sites which case
+// they're in.
+export function isTmdbUrl(url: string | null | undefined): boolean {
+  return !!url && url.startsWith(TMDB_IMAGE_BASE_URL);
 }
 
 export interface TmdbMovieSearchResult {


### PR DESCRIPTION
## Summary

Follow-up to #105. Narrowing `images.imageSizes` turned out not to meaningfully reduce transformation usage (see the `DECISIONS.md` update in this PR), and didn't address the real problem: usage scales with catalog size and traffic no matter how the buckets are tuned.

`src/lib/tmdb.ts`'s `tmdbImageUrl`/`resolvePosterUrl` already request a pre-sized TMDB CDN bucket (`w200`, `w342`, etc.) — TMDB serves these for free, outside Vercel's quota. Vercel's optimizer was redundantly re-resizing an image TMDB had already sized. This PR marks every `<Image>` sourced from `image.tmdb.org` `unoptimized`, removing it from the quota entirely and permanently — independent of catalog growth. Admin-uploaded poster overrides (Vercel Blob, `posterOverrideUrl`) are left on Vercel's optimizer, since Blob has no presized variants and actually benefits from it.

Backdrops (`hero-carousel.tsx`, `movies/[id]/page.tsx`) also move from TMDB's unbounded `"original"` size to the documented `"w1280"` bucket — without that, skipping Vercel's resize would have served raw up-to-4K source images instead of a capped one.

A second commit closes one more gap found during manual testing: `recommended-badge.tsx` renders a local `public/` file, not a TMDB or Blob URL, so it wasn't covered by the `isTmdbUrl()` check — but it still went through the same Vercel optimizer and the same quota as everything else. Marked `unoptimized` too, since it's a small static asset that never changes.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no user-facing feature, env var, setup step, or seed data changed)
- [x] `.env.example` updated if a new environment variable was added
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npx tsc --noEmit`, `npm run lint`, and `npm run build` all pass.
- Manually verified against the deployed preview: TMDB-sourced posters, avatars, cast photos, and backdrops render correctly; the one remaining Vercel-optimized path (admin poster override) was confirmed still correctly routed through the optimizer, and its current broken state is due to the account's Image Optimization quota still being exhausted from before this fix (expected to self-resolve on the next reset, not a regression from this PR).

https://claude.ai/code/session_013jt2DY2HHSfWQVYQmCRen9

---
_Generated by [Claude Code](https://claude.ai/code/session_013jt2DY2HHSfWQVYQmCRen9)_