### PR TITLE
Revisit and defer actor-anchored lists as a discoverability problem

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -3330,6 +3330,21 @@ other") instead of presenting one name as if it were the clear answer.
   member-created ones, or a "follow a member's lists" mechanic tied into
   the notifications backlog item if that gets built. Needs a real
   brainstorming pass before committing to any of these.
+  - **The "themed admin-curated collections" idea revisited and narrowed
+    (still deferred)**: worked through a concrete example ("Essential
+    Bruce Lee" — a ranked mix of his films and specific fight scenes) and
+    concluded nearly all of it is already possible today with a plain
+    `MemberList` — any admin can create one, add movies and fight scenes
+    to the same ranked reel, and it's public immediately. No new list
+    type, schema, or content model is actually needed for the *content*
+    side of this. The one real gap is **discoverability**: an admin's
+    curated list only surfaces via `/lists` browse or their own profile,
+    not anywhere tied to what it's about. Candidate anchors, none chosen:
+    the relevant actor's page, the relevant movie's page, a homepage rail
+    (would overlap with the separate "Editor's Picks rail" backlog item
+    below), or just a "Curated" filter/badge within `/lists` itself with
+    no dedicated anchor page at all. Still not scoped — revisit once
+    there's conviction on where curated lists should actually surface.
 - **Streamlined, swipeable fight scene viewing (YouTube Shorts-style)** —
   replace or supplement the current card-grid presentation
   (`FightSceneSection`, `/search/fight-scenes`) with a full-screen,


### PR DESCRIPTION
## Summary

Documentation-only. The "Lists expansion" backlog entry in `DECISIONS.md` listed "themed admin-curated collections (e.g. 'Essential Bruce Lee')" as a starter idea. Worked through a concrete example of it before building anything, and concluded it's not actually a new feature:

- Mixing movies and specific fight scenes in one ranked list, with admin authorship — all already possible today with a plain `MemberList`. No new list type, schema, or content model needed for the content side.
- The one real gap is **discoverability**: an admin's curated list only surfaces via `/lists` browse or their own profile, with no anchor tied to what it's actually about.
- No conviction yet on what that anchor should be (the actor's page, the movie's page, a homepage rail — which would overlap with the separate "Editor's Picks rail" backlog idea — or just a "Curated" filter within `/lists` itself), so this stays deferred rather than getting built now.

This PR just updates the backlog entry to capture that narrowed understanding for whoever revisits it next, so the next look at this doesn't re-derive the same "wait, isn't this just a regular list?" conclusion from scratch.

## Checklist

- [ ] `README.md` updated — not applicable, no user-facing change
- [ ] `.env.example` updated — not applicable
- [x] `DECISIONS.md` updated (this is the change)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` / `npm run build` — clean (docs-only change, included as a sanity check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk7DenHhY4AKCd1TmUKaQR)_