### PR TITLE
Mobile touch-friendliness pass for the movie detail page

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -466,7 +466,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
 
   return (
     <div className="flex flex-1 flex-col">
-      <div className="relative h-64 w-full sm:h-80">
+      <div className="relative h-40 w-full sm:h-80">
         {backdropUrl ? (
           <Image src={backdropUrl} alt="" fill priority unoptimized sizes="100vw" className="object-cover" />
         ) : (
@@ -537,7 +537,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             )}
           </div>
 
-          <h1 className="font-display mt-2 text-5xl text-balance text-neutral-100">
+          <h1 className="font-display mt-2 text-4xl text-balance text-neutral-100 sm:text-5xl">
             {movie.title} {year && <span className="font-editorial text-2xl font-normal text-neutral-400">({year})</span>}
           </h1>
 
@@ -559,7 +559,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             </div>
           )}
 
-          <div className="mt-5 flex flex-wrap items-baseline gap-10">
+          <div className="mt-5 flex flex-wrap items-baseline gap-6 sm:gap-10">
             <div>
               <p className="font-cond text-xs tracking-wider text-neutral-500 uppercase">Community Score</p>
               <p className="font-display mt-1 text-3xl text-amber-500">

--- a/src/components/add-to-list-control.tsx
+++ b/src/components/add-to-list-control.tsx
@@ -134,7 +134,7 @@ export function AddToListControl({
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="New list…"
-              className="min-w-0 flex-1 rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 focus:border-red-600 focus:outline-none"
+              className="min-w-0 flex-1 rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
             />
             <button
               type="submit"

--- a/src/components/add-to-list-control.tsx
+++ b/src/components/add-to-list-control.tsx
@@ -115,7 +115,7 @@ export function AddToListControl({
         {variant === "icon" ? <BookmarkIcon /> : "+ Add to list"}
       </button>
       {open && (
-        <div className="absolute right-0 z-10 mt-2 w-64 rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl">
+        <div className="absolute right-0 z-10 mt-2 w-64 max-w-[calc(100vw-2rem)] rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl">
           {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
           <ul className="mb-3 flex max-h-48 flex-col gap-1 overflow-y-auto">
             {lists.map((list) => (

--- a/src/components/admin-rating-widget.tsx
+++ b/src/components/admin-rating-widget.tsx
@@ -100,7 +100,7 @@ export function AdminRatingWidget({
         value={note}
         onChange={(e) => setNote(e.target.value)}
         placeholder="Editor's note (optional)"
-        className="mb-2 w-full rounded-sm border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm text-neutral-100 focus:border-amber-600 focus:outline-none"
+        className="mb-2 w-full rounded-sm border border-neutral-700 bg-neutral-900 px-2 py-1 text-base text-neutral-100 focus:border-amber-600 focus:outline-none"
         rows={2}
       />
       <button

--- a/src/components/discussion-thread.tsx
+++ b/src/components/discussion-thread.tsx
@@ -194,7 +194,7 @@ export function DiscussionThread({
             onChange={(e) => setEditContent(e.target.value)}
             rows={2}
             maxLength={MAX_CONTENT_LENGTH}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
           />
           <div className="flex gap-2">
             <button
@@ -230,7 +230,7 @@ export function DiscussionThread({
             placeholder="Share your thoughts on this movie… use [spoiler]text[/spoiler] to hide spoilers"
             rows={3}
             maxLength={MAX_CONTENT_LENGTH}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
           />
           <div className="flex items-center gap-3">
             <button
@@ -285,7 +285,7 @@ export function DiscussionThread({
                   rows={2}
                   maxLength={MAX_CONTENT_LENGTH}
                   placeholder="Write a reply…"
-                  className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                  className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
                 />
                 <button
                   onClick={() => submit(replyContent, post.id)}

--- a/src/components/fight-count-control.tsx
+++ b/src/components/fight-count-control.tsx
@@ -96,7 +96,7 @@ export function FightCountControl({
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             disabled={saving}
-            className="w-20 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            className="w-20 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
           />
           <button
             onClick={handleSave}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -185,7 +185,7 @@ function FightSceneForm({
         onChange={(e) => setUrl(e.target.value)}
         onBlur={suggestTitle}
         placeholder="Paste the YouTube link to this fight scene…"
-        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
       />
       <p className="text-xs text-neutral-500">
         {isEditing
@@ -198,7 +198,7 @@ function FightSceneForm({
         onChange={(e) => setTitle(e.target.value)}
         maxLength={MAX_TITLE_LENGTH}
         placeholder={suggestingTitle ? "Suggesting a title from YouTube…" : 'Title, e.g. "Mirror Room Finale"'}
-        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
       />
       <div>
         <p className="mb-1 text-xs text-neutral-500">Actors in this scene (select at least one)</p>

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -641,7 +641,7 @@ export function FightSceneSection({
                 ) : (
                   <span>Round {scene.roundNumber}</span>
                 )}
-                <div className="flex items-center gap-1.5">
+                <div className="flex items-center gap-2.5 sm:gap-1.5">
                   <FavoriteButton
                     movieId={movieId}
                     fightSceneId={scene.id}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -701,7 +701,7 @@ export function FightSceneSection({
                       value={startTimeDrafts[scene.id] ?? formatMmSs(scene.youtubeStartSeconds)}
                       onChange={(e) => setStartTimeDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))}
                       placeholder="mm:ss"
-                      className="w-14 border bg-transparent px-1 py-0.5 text-center focus:outline-none"
+                      className="w-16 border bg-transparent px-1 py-0.5 text-center text-base focus:outline-none"
                       style={{ borderColor: TICKET_INK, color: TICKET_INK }}
                     />
                     <button onClick={() => handleSetStartTime(scene.id)} className="underline hover:opacity-70">
@@ -819,7 +819,7 @@ export function FightSceneSection({
                     maxLength={MAX_NOTE_LENGTH}
                     placeholder="Editor's note (optional)"
                     rows={2}
-                    className="mt-2 w-full border bg-transparent px-2 py-1 text-xs focus:outline-none"
+                    className="mt-2 w-full border bg-transparent px-2 py-1 text-base focus:outline-none"
                     style={{ borderColor: TICKET_INK, color: TICKET_INK }}
                   />
                 </div>

--- a/src/components/fun-facts-section.tsx
+++ b/src/components/fun-facts-section.tsx
@@ -244,7 +244,7 @@ export function FunFactsSection({
               placeholder="Did you know…?"
               rows={2}
               maxLength={MAX_CONTENT_LENGTH}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+              className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
             />
             <div className="flex items-center gap-3">
               <button
@@ -287,7 +287,7 @@ export function FunFactsSection({
                         onChange={(e) => setEditContent(e.target.value)}
                         rows={2}
                         maxLength={MAX_CONTENT_LENGTH}
-                        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                        className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
                       />
                       <div className="flex gap-2">
                         <button

--- a/src/components/movie-rail.tsx
+++ b/src/components/movie-rail.tsx
@@ -58,7 +58,7 @@ export function MovieRailTrack({
           type="button"
           onClick={() => scrollBy(-SCROLL_BY)}
           aria-label="Scroll left"
-          className="absolute left-1 top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white opacity-0 transition hover:bg-black/70 focus-visible:opacity-100 group-hover:opacity-100"
+          className="absolute left-1 top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white opacity-100 transition hover:bg-black/70 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
             <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
@@ -70,7 +70,7 @@ export function MovieRailTrack({
           type="button"
           onClick={() => scrollBy(SCROLL_BY)}
           aria-label="Scroll right"
-          className="absolute right-1 top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white opacity-0 transition hover:bg-black/70 focus-visible:opacity-100 group-hover:opacity-100"
+          className="absolute right-1 top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white opacity-100 transition hover:bg-black/70 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
             <path d="M9 18l6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/components/rating-widget.tsx
+++ b/src/components/rating-widget.tsx
@@ -82,7 +82,7 @@ export function RatingWidget({
   return (
     <div className="rounded-md border border-neutral-800 bg-neutral-900 p-3">
       <p className="font-cond mb-1 text-sm tracking-wide text-neutral-400 uppercase">Your rating</p>
-      <div className="flex flex-wrap gap-1">
+      <div className="grid grid-cols-5 gap-1 sm:flex sm:flex-wrap">
         {SCORES.map((value) => (
           <button
             key={value}

--- a/src/components/reviews-section.tsx
+++ b/src/components/reviews-section.tsx
@@ -84,7 +84,7 @@ function MemberReviewCard({
             onChange={(e) => onEditContentChange(e.target.value)}
             rows={6}
             maxLength={MAX_MEMBER_LENGTH}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-2 py-1 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
           />
           <div className="flex items-center gap-2">
             <button
@@ -332,7 +332,7 @@ export function ReviewsSection({
             rows={10}
             maxLength={MAX_ADMIN_LENGTH}
             placeholder="Write the admin review…"
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
           />
           <div className="flex items-center gap-3">
             <button
@@ -379,7 +379,7 @@ export function ReviewsSection({
                   rows={6}
                   maxLength={MAX_MEMBER_LENGTH}
                   placeholder="Write your review…"
-                  className="w-full max-w-2xl rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-red-600 focus:outline-none"
+                  className="w-full max-w-2xl rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-base text-neutral-100 focus:border-red-600 focus:outline-none"
                 />
                 <div className="flex items-center gap-3">
                   <button

--- a/src/components/star-rating-picker.tsx
+++ b/src/components/star-rating-picker.tsx
@@ -29,7 +29,7 @@ export function StarRatingPicker({
         const fillPct = display >= high ? 100 : display >= low ? 50 : 0;
         return (
           <span key={i} className="relative">
-            <StarIcon fillPct={fillPct} className="h-5 w-5" fillColorClassName={fillColorClassName} />
+            <StarIcon fillPct={fillPct} className="h-7 w-7 sm:h-5 sm:w-5" fillColorClassName={fillColorClassName} />
             <button
               type="button"
               disabled={disabled}


### PR DESCRIPTION
## Summary

Mobile-friendliness fixes for the movie detail page and its embedded components, found by reading through `src/app/movies/[id]/page.tsx` and everything it renders. All changes are scoped via Tailwind's `sm:` breakpoint to leave desktop unchanged, except the iOS auto-zoom fix (intentionally applied everywhere it appears on this page — see below).

- **iOS Safari auto-zoom fix (applies at all breakpoints).** Every compose/edit textarea and input reachable from this page — Discussion posts/replies/edits, Reviews compose/edit/admin, Fun Facts compose/edit, Fight Count edit, Add Fight Scene URL/title, Add to List "new list" field, and three admin-only fields (`AdminRatingWidget`'s note, the per-fight-scene admin note and start-time inputs) — rendered under 16px. iOS Safari force-zooms the viewport on focus of any field under that threshold, so tapping into any of these on a phone snapped the whole page into an unwanted zoomed-in state. Bumped to `text-base` (16px).
- **Touch target / layout polish (mobile-only via `sm:`):**
  - `StarRatingPicker`'s half-star hit zones enlarged (`h-5` → `h-7` below `sm:`).
  - `RatingWidget`'s 1–10 score row now lays out as a predictable 5-column grid on mobile instead of an uneven `flex-wrap`.
  - Backdrop banner height reduced on mobile (`h-64` → `h-40`, `sm:h-80` unchanged) so it costs less of a phone's first viewport.
  - Title steps down on mobile (`text-5xl` → `text-4xl`, `sm:text-5xl` unchanged) so it wraps less aggressively.
  - Community/Editors' score row gap tightened on mobile (`gap-10` → `gap-6`, `sm:gap-10` unchanged).
  - `MovieRail`'s prev/next arrows were `opacity-0`, revealed only via hover/focus — never on touch, so they were invisible but still tappable on mobile. Now visible by default below `sm:`; unchanged hover-reveal behavior at `sm:`+.
  - `AddToListControl`'s dropdown panel width is now capped to the viewport (`max-w-[calc(100vw-2rem)]`) so it can't render wider than the screen. **Partial fix** — the panel is used both near the left edge (movie-level button) and near the right edge (per-fight-scene icon button) with a single right-anchored position, so this doesn't fully solve left-edge clipping for the left-anchored case without the component knowing which context it's in. Flagging as a possible follow-up rather than overclaiming it's solved.
  - Widened the gap between the Favorite/Add to list/Share icon buttons on each fight-scene card on mobile, to reduce mis-taps between adjacent icons.

### Known open item — backdrop height vs. an existing decision

`DECISIONS.md` (from the original hero-redesign PR) already has an entry stating the backdrop banner was deliberately kept "full strength, always visible" at every width, after an earlier mockup pass that *hid* it below 760px was explicitly rejected. This PR's mobile height reduction doesn't hide the backdrop (it still renders unconditionally at every width, just shorter on phones), so it's a narrower change than what was rejected — but it's clearly adjacent to that prior call. Keeping it in for now at the site owner's direction, to revisit after seeing it in practice rather than settling it here. Not adding a `DECISIONS.md` entry yet since this isn't a finalized decision.

## Checklist

- [x] `README.md` updated — not applicable, no user-facing feature, env var, setup step, or seed data changed (this is UI-only polish).
- [x] `.env.example` — not applicable, no new environment variable.
- [ ] `DECISIONS.md` — intentionally not updated; see "Known open item" above. Revisit once the backdrop-height question is settled.
- [x] `npm run lint` and `npm run build` pass locally.

## Test plan

- `npm run lint` and `npm run build` both pass cleanly on this branch.
- Verified via static review of every affected component (breakpoint scoping, class-name correctness, no logic changes).
- **Not verified in a live browser at mobile widths** — this environment has no configured database, so the dev server can't be run against real data. Recommend checking the Vercel preview deployment on an actual phone (or device emulation) before merging, particularly the `AddToListControl` dropdown positioning and the `MovieRail` arrow visibility, since those are the two changes most likely to look different than intended without visual confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hn2xPJWf39umbC2vX3hVg)_