### PR TITLE
Collapse the sitewide navbar behind a hamburger menu on mobile

### DIFF
--- a/src/components/mobile-nav-toggle.tsx
+++ b/src/components/mobile-nav-toggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+// Wraps the navbar's search bar + nav links (passed as children, still
+// server-rendered by Navbar) so they can collapse behind a hamburger button
+// on mobile. At sm:+ this is a no-op: sm:contents removes the wrapper from
+// the box tree entirely, so children participate directly in Navbar's flex
+// row exactly as before (picking up their own sm:order-*/sm:flex-* classes
+// unchanged) and the toggle button itself is sm:hidden.
+export function MobileNavToggle({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls="mobile-nav-panel"
+        aria-label={open ? "Close menu" : "Open menu"}
+        className="ml-auto flex h-9 w-9 items-center justify-center rounded-md border border-neutral-700 text-neutral-300 hover:text-white sm:hidden"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" className="h-5 w-5">
+          {open ? <path d="M6 6l12 12M18 6L6 18" /> : <path d="M4 7h16M4 12h16M4 17h16" />}
+        </svg>
+      </button>
+      {/* Closes the panel on any click inside it (a nav link, the Lists
+          submenu chevron, Sign out) -- Navbar stays mounted across
+          client-side navigations, so without this the panel would still
+          show open on the next page. */}
+      <div
+        id="mobile-nav-panel"
+        onClick={() => setOpen(false)}
+        className={`${open ? "flex" : "hidden"} w-full flex-col gap-3 sm:contents`}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -6,6 +6,7 @@ import { SearchBar } from "@/components/search-bar";
 import { SignOutButton } from "@/components/sign-out-button";
 import { ListsNavMenu } from "@/components/lists-nav-menu";
 import { VerifyEmailBanner } from "@/components/verify-email-banner";
+import { MobileNavToggle } from "@/components/mobile-nav-toggle";
 
 export async function Navbar() {
   const session = await auth();
@@ -19,49 +20,51 @@ export async function Navbar() {
       {needsVerification && <VerifyEmailBanner />}
       <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-4 px-4 py-3">
         <Logo />
-        <div className="order-3 w-full sm:order-2 sm:w-auto sm:flex-1">
-          <SearchBar />
-        </div>
-        <nav className="order-2 flex w-full flex-wrap items-center justify-start gap-x-3 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap sm:gap-x-4">
-          <Link href="/search" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
-            Movies
-          </Link>
-          <Link href="/search/fight-scenes" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
-            Fights
-          </Link>
-          <ListsNavMenu />
-          <Link href="/movies/submit" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
-            + Add Movie
-          </Link>
-          {session?.user ? (
-            <>
-              {(session.user.role === "ADMIN" || session.user.role === "REVIEWER") && (
-                <Link href="/admin" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
-                  Admin
+        <MobileNavToggle>
+          <div className="order-3 w-full sm:order-2 sm:w-auto sm:flex-1">
+            <SearchBar />
+          </div>
+          <nav className="order-2 flex w-full flex-wrap items-center justify-start gap-x-3 gap-y-2 sm:order-3 sm:ml-auto sm:w-auto sm:flex-nowrap sm:gap-x-4">
+            <Link href="/search" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
+              Movies
+            </Link>
+            <Link href="/search/fight-scenes" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
+              Fights
+            </Link>
+            <ListsNavMenu />
+            <Link href="/movies/submit" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
+              + Add Movie
+            </Link>
+            {session?.user ? (
+              <>
+                {(session.user.role === "ADMIN" || session.user.role === "REVIEWER") && (
+                  <Link href="/admin" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
+                    Admin
+                  </Link>
+                )}
+                <Link
+                  href={`/members/${session.user.username}`}
+                  className="text-sm whitespace-nowrap text-neutral-500 hover:text-white"
+                >
+                  {session.user.username}
                 </Link>
-              )}
-              <Link
-                href={`/members/${session.user.username}`}
-                className="text-sm whitespace-nowrap text-neutral-500 hover:text-white"
-              >
-                {session.user.username}
-              </Link>
-              <SignOutButton />
-            </>
-          ) : (
-            <>
-              <Link href="/login" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
-                Sign in
-              </Link>
-              <Link
-                href="/register"
-                className="rounded-md bg-red-700 px-3 py-1.5 text-sm font-medium whitespace-nowrap text-white hover:bg-red-600"
-              >
-                Join
-              </Link>
-            </>
-          )}
-        </nav>
+                <SignOutButton />
+              </>
+            ) : (
+              <>
+                <Link href="/login" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
+                  Sign in
+                </Link>
+                <Link
+                  href="/register"
+                  className="rounded-md bg-red-700 px-3 py-1.5 text-sm font-medium whitespace-nowrap text-white hover:bg-red-600"
+                >
+                  Join
+                </Link>
+              </>
+            )}
+          </nav>
+        </MobileNavToggle>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary

Part of the movie detail page mobile-friendliness pass (see #115) — this piece turned out to be sitewide rather than page-scoped, so it's split into its own PR per that review's recommended order (small polish first, this bigger change second).

`navbar.tsx` had no mobile breakpoint at all. Below `sm:`, every nav item (Movies, Fights, Lists, + Add Movie, Admin/Reviewer if applicable, username, Sign out — or Sign in/Join when logged out) rendered inline and wrapped across however many lines it took, stacked below a full-width search bar row, stacked below the logo. Because the header is `sticky top-0`, this wasn't just a first-load cost — it was a permanent multi-row tax on the visible viewport at every scroll position, on every page, compounding directly with the movie detail page's own backdrop banner (see #115) to push real content further down and shrink usable scroll space throughout the visit.

`MobileNavToggle` (new, `src/components/mobile-nav-toggle.tsx`) wraps the search bar + nav links — still server-rendered by `Navbar`, passed through as `children` — in a client component that collapses them behind a hamburger button below `sm:`.

- **Desktop unchanged.** At `sm:`+, the wrapper is `display:contents`, which removes it from the box tree entirely — its children become direct flex items of `Navbar`'s existing row again, picking up their original `sm:order-2`/`sm:order-3`/`sm:flex-nowrap` classes exactly as before. The toggle button itself is `sm:hidden`. No pixel-level change at `sm:`+.
- **Mobile:** logo + hamburger button in the header row; tapping it reveals the search bar and nav links as a full-width panel below. Tapping anything inside the panel (a link, the Lists submenu, Sign out) closes it — `Navbar` stays mounted across client-side navigations (it's in the root layout), so without this the panel would still show open on the next page.
- **`VerifyEmailBanner` deliberately left outside the collapsible panel**, always visible regardless of menu state — it's an active account-status prompt, not nav chrome, so hiding it behind a closed hamburger menu would defeat its purpose.

## Checklist

- [x] `README.md` — not applicable, no user-facing feature, env var, setup step, or seed data changed (existing nav links, new presentation only).
- [x] `.env.example` — not applicable.
- [ ] `DECISIONS.md` — not updated. This is largely a mechanical breakpoint fix (add a mobile collapse that didn't exist), not really a judgment call between alternatives worth logging — happy to add an entry if you'd rather have one given it's a sitewide component.
- [x] `npm run lint` and `npm run build` pass locally.

## Test plan

- `npm run lint` and `npm run build` both pass cleanly on this branch.
- Verified via static review: the `sm:contents` mechanism, breakpoint scoping, and that no existing class on the search bar/nav was touched.
- **Not verified in a live browser** — this environment has no configured database, so the dev server can't be run against real data. This PR touches every page (shared root layout), so I'd recommend checking the Vercel preview on an actual phone before merging — specifically: the hamburger opens/closes correctly, the panel's contents match the original mobile stacking order (nav links above search, same as before), and desktop is visually identical to what's currently live.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hn2xPJWf39umbC2vX3hVg)_