### PR TITLE
Show the movie title above the poster on mobile

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -360,6 +360,20 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
     </div>
   );
 
+  // Rendered twice below, same reasoning as movieDetailsCard above: in
+  // source order the title sits inside the content column, after the
+  // poster -- fine on desktop's sm:flex-row layout, but on mobile's single
+  // flex-col column that puts the backdrop and poster ahead of the movie's
+  // own name. A second, mobile-only copy sits above the poster instead.
+  // sm:mt-2 (no bare mt-2) is safe on the shared element: whichever
+  // instance is hidden at a given breakpoint doesn't have its margin
+  // "count" either.
+  const titleBlock = (
+    <h1 className="font-display text-4xl text-balance text-neutral-100 sm:mt-2 sm:text-5xl">
+      {movie.title} {year && <span className="font-editorial text-2xl font-normal text-neutral-400">({year})</span>}
+    </h1>
+  );
+
   const serializedFightScenes = fightScenes.map((scene) => {
     const summary = fightSceneRatingSummaries.get(scene.id);
     const adminSummary = fightSceneAdminRatingSummaries.get(scene.id);
@@ -476,6 +490,8 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       </div>
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pt-8 sm:flex-row">
+        <div className="sm:hidden">{titleBlock}</div>
+
         <div className="w-40 shrink-0 sm:w-56">
           <div className="relative rounded-sm border border-neutral-600 bg-neutral-800 p-2 shadow-xl">
             {/* corner accents, so the mat reads as a mounted print rather
@@ -537,9 +553,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             )}
           </div>
 
-          <h1 className="font-display mt-2 text-4xl text-balance text-neutral-100 sm:text-5xl">
-            {movie.title} {year && <span className="font-editorial text-2xl font-normal text-neutral-400">({year})</span>}
-          </h1>
+          <div className="hidden sm:block">{titleBlock}</div>
 
           {movie.tagline && (
             <p className="font-editorial mt-2 text-base text-neutral-400 italic">&ldquo;{movie.tagline}&rdquo;</p>

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -365,13 +365,23 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
   // poster -- fine on desktop's sm:flex-row layout, but on mobile's single
   // flex-col column that puts the backdrop and poster ahead of the movie's
   // own name. A second, mobile-only copy sits above the poster instead.
-  // sm:mt-2 (no bare mt-2) is safe on the shared element: whichever
+  // Only the desktop copy is a real <h1> -- the mobile copy is a <p> with
+  // identical styling, so the page never has two <h1> elements in the DOM
+  // at once (a raw-markup consumer like a crawler or a jsdom-based test
+  // doesn't resolve the responsive hidden/sm:block classes the way a real
+  // browser does, so two real <h1>s would both read as present). Plain
+  // text, not aria-hidden, on the mobile <p> -- aria-hidden can't be
+  // conditional on breakpoint, and this copy is the only one actually
+  // shown on mobile, so hiding it from assistive tech there would be worse
+  // than the duplicate-heading problem it'd be avoiding.
+  // sm:mt-2 (no bare mt-2) is safe on the shared className: whichever
   // instance is hidden at a given breakpoint doesn't have its margin
   // "count" either.
-  const titleBlock = (
-    <h1 className="font-display text-4xl text-balance text-neutral-100 sm:mt-2 sm:text-5xl">
+  const titleClassName = "font-display text-4xl text-balance text-neutral-100 sm:mt-2 sm:text-5xl";
+  const titleText = (
+    <>
       {movie.title} {year && <span className="font-editorial text-2xl font-normal text-neutral-400">({year})</span>}
-    </h1>
+    </>
   );
 
   const serializedFightScenes = fightScenes.map((scene) => {
@@ -490,7 +500,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
       </div>
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pt-8 sm:flex-row">
-        <div className="sm:hidden">{titleBlock}</div>
+        <p className={`${titleClassName} sm:hidden`}>{titleText}</p>
 
         <div className="w-40 shrink-0 sm:w-56">
           <div className="relative rounded-sm border border-neutral-600 bg-neutral-800 p-2 shadow-xl">
@@ -553,7 +563,7 @@ export default async function MovieDetailPage({ params }: { params: Promise<{ id
             )}
           </div>
 
-          <div className="hidden sm:block">{titleBlock}</div>
+          <h1 className={`hidden ${titleClassName} sm:block`}>{titleText}</h1>
 
           {movie.tagline && (
             <p className="font-editorial mt-2 text-base text-neutral-400 italic">&ldquo;{movie.tagline}&rdquo;</p>


### PR DESCRIPTION
## Summary

On the movie detail page's mobile layout (`flex-col` below `sm:`), the title lived inside the content column in source order — after the poster — which is fine on desktop (`sm:flex-row`, poster and content sit side by side) but on mobile put the full backdrop banner and poster image ahead of the movie's own name. A mobile visitor scrolled past roughly 450–500px of backdrop, artwork, and metadata badges before the title appeared as text.

- Reuses the existing `movieDetailsCard` pattern already in this file (render the same content twice, toggled by breakpoint) for the title (title + year): a mobile-only copy now sits above the poster, and the original copy stays in place in the content column, hidden below `sm:`. Desktop is pixel-for-pixel unchanged.
- **Follow-up commit from a code-review pass on the first one**: the initial version rendered the identical content as `<h1>` in both positions, meaning the page always carried two `<h1>` elements in the DOM (only one hidden via CSS `display:none`). A real browser resolves that correctly (never double-announced to actual users), but a raw-markup consumer — an SEO/accessibility linter, or a `jsdom`-based test that doesn't resolve Tailwind's responsive classes — would see two matching headings, which would break a future `getByRole('heading', { name: movie.title })` test with an ambiguous match. Fixed by making only the desktop-position instance a real `<h1>`; the mobile-position instance is a `<p>` with identical styling, not `aria-hidden` (aria-hidden can't be conditional on breakpoint, and the mobile copy is the only one actually shown on mobile, so hiding it from assistive tech there would trade a markup nit for a real accessibility regression).

## Checklist

- [x] `README.md` — not applicable, no user-facing feature, env var, setup step, or seed data changed (existing content, new mobile position only).
- [x] `.env.example` — not applicable.
- [ ] `DECISIONS.md` — not updated. This is a straightforward bug fix (title reachable but out of order on mobile) using an established in-file pattern, not really a judgment call between alternatives worth logging on its own.
- [x] `npm run lint` and `npm run build` pass locally.

## Test plan

- `npm run lint` and `npm run build` both pass cleanly on this branch.
- Verified via static review, including a code-review pass that caught and fixed the duplicate-`<h1>` issue described above.
- **Not verified in a live browser** — this environment has no configured database, so the dev server can't be run against real data. Recommend checking the Vercel preview on an actual phone before merging: title should appear directly under the backdrop banner, above the poster, matching the rest of the page's styling; desktop should look identical to what's currently live.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hn2xPJWf39umbC2vX3hVg)_