### PR TITLE
Merge admin and member reviews into one section

### DIFF
--- a/src/components/reviews-section.tsx
+++ b/src/components/reviews-section.tsx
@@ -43,6 +43,49 @@ function byNetScore(a: MemberReviewData, b: MemberReviewData) {
 // down further since these cards (w-72) are narrower than that feed's grid.
 const CARD_CLAMP_THRESHOLD = 160;
 
+function AdminReviewCard({
+  review,
+  canEdit,
+  onStartEdit,
+}: {
+  review: EditorialReviewData;
+  canEdit: boolean;
+  onStartEdit: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = review.content.length > CARD_CLAMP_THRESHOLD;
+
+  return (
+    <div className="w-72 shrink-0 rounded-md border border-amber-800/40 bg-amber-950/10 p-3">
+      <p className={`whitespace-pre-wrap text-sm text-neutral-300 ${!expanded && isLong ? "line-clamp-4" : ""}`}>
+        {review.content}
+      </p>
+      {isLong && (
+        <button
+          onClick={() => setExpanded((e) => !e)}
+          className="mt-1 text-xs font-medium text-red-500 hover:underline"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+        <span className="rounded border border-amber-700 px-1.5 py-0.5 font-semibold text-amber-500">
+          Admin Review
+        </span>
+        <span>
+          {review.author.username} &middot; updated {formatDate(review.updatedAt)}
+        </span>
+        {canEdit && (
+          <button onClick={onStartEdit} className="text-neutral-400 hover:text-white">
+            Edit
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function MemberReviewCard({
   review,
   canEdit,
@@ -354,19 +397,7 @@ export function ReviewsSection({
           </div>
           {adminError && <p className="text-sm text-red-500">{adminError}</p>}
         </div>
-      ) : (
-        adminReview && (
-          <div className="mb-6 rounded-md border border-amber-800/40 bg-amber-950/10 p-4">
-            <p className="max-w-2xl whitespace-pre-wrap text-neutral-300">{adminReview.content}</p>
-            <p className="mt-3 text-xs text-neutral-500">
-              <span className="mr-2 rounded border border-amber-700 px-1.5 py-0.5 font-semibold text-amber-500">
-                Admin Review
-              </span>
-              Reviewed by {adminReview.author.username} &middot; updated {formatDate(adminReview.updatedAt)}
-            </p>
-          </div>
-        )
-      )}
+      ) : null}
 
       {signedIn ? (
         !hasReviewed && (
@@ -424,9 +455,19 @@ export function ReviewsSection({
 
       {memberError && <p className="mb-4 text-sm text-red-500">{memberError}</p>}
 
-      {memberReviews.length > 0 ? (
+      {(adminReview && !editingAdmin) || memberReviews.length > 0 ? (
         <>
           <div className="rail-scrollbar flex gap-4 overflow-x-auto pb-2">
+            {adminReview && !editingAdmin && (
+              <AdminReviewCard
+                review={adminReview}
+                canEdit={isAdmin}
+                onStartEdit={() => {
+                  setAdminDraft(adminReview.content);
+                  setEditingAdmin(true);
+                }}
+              />
+            )}
             {memberReviews.map((review) => (
               <MemberReviewCard
                 key={review.id}


### PR DESCRIPTION
## Summary

`ReviewsSection` on the movie detail page previously showed the admin (editorial) review in its own amber callout box above a separate horizontally-scrolling rail of member review cards — two visually distinct sections for what users see as one "Reviews" feature.

- Folded the admin review into the same rail as a card (new `AdminReviewCard`, styled like `MemberReviewCard` with the same clamp/"Show more" behavior for long content), pinned first when present. No vote buttons on it — editorial reviews were never votable.
- Compose/edit entry points are unchanged: the header's "Write admin review"/"Edit admin review" button and the new in-rail card's own "Edit" link both toggle the same `editingAdmin` state, which still opens the existing full-width textarea above the rail (kept full-width rather than shrunk into a card — editorial reviews run up to 10,000 characters via a 10-row textarea; `MemberReviewCard`'s shape is sized for members' 5,000-character cap).
- No schema change: `EditorialReview` and `MemberReview` stay separate Prisma models with their current behavior (one shared row per movie, no voting, edited in place vs. one row per member with voting). This was a deliberate scope call — see the "Full data-model unification" option that was considered and set aside below.
- The separate `/movies/[id]/reviews` page is untouched — it never rendered the editorial review at all (member reviews only, paginated), so there was no split there to unify.

### Scope considered and set aside

Two ways to interpret "one section" were on the table: this visual-only merge (chosen), or retiring `EditorialReview` as a model entirely and migrating admin reviews into the `MemberReview` table (an `isEditorial` flag, giving admins the same multi-review/voting/pagination behavior as members). The latter is a real schema change plus a data migration plus a behavior change (the admin review stops being a singular, always-editable-in-place "canonical" review) — set aside in favor of the lower-risk visual merge for this PR.

## Checklist

- [x] `README.md` — not applicable, no user-facing feature, env var, setup step, or seed data changed (existing reviews, new shared layout only).
- [x] `.env.example` — not applicable.
- [ ] `DECISIONS.md` — not updated yet. The scope call above (visual merge vs. full model unification) is arguably worth a `DECISIONS.md` entry under Feature Decisions — happy to add one if you'd like it on record.
- [x] `npm run lint` and `npm run build` pass locally.

## Test plan

- `npm run lint` and `npm run build` both pass cleanly on this branch (merged current `master` in first — no conflicts).
- Verified via static review: the merged ternary correctly covers every combination of (admin review present/absent) × (editingAdmin true/false) × (member reviews present/absent), including the empty-state message.
- **Not verified in a live browser** — this environment has no configured database, so the dev server can't be run against real data. Recommend checking the Vercel preview before merging: admin review card should appear first in the rail when present, "Edit" from the card and "Edit admin review" from the header should both open the same form, and the empty state should read correctly with zero, admin-only, and member-only reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hn2xPJWf39umbC2vX3hVg)_