### PR TITLE
Fill the neutral-200 gap in the Poster House palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,7 @@
   --color-neutral-500: #8f7a63;
   --color-neutral-400: #c9b8a0;
   --color-neutral-300: #dcd0bd;
+  --color-neutral-200: #e7dbc8;
   --color-neutral-100: #f2e6d3;
 
   --color-red-950: #2c0f0a;


### PR DESCRIPTION
## Summary

The "Poster House" palette remap in `globals.css`'s `@theme inline` block remaps `--color-neutral-950` through `--color-neutral-100`, but skipped `neutral-200` — so any `text-neutral-200`/`bg-neutral-200` class anywhere on the site silently fell back to Tailwind's default cool gray instead of the warm Poster House palette. This was flagged as a known gap when the original hero-redesign PR landed, deliberately deferred rather than folded in since it affects roughly a dozen files sitewide, not just the movie detail page that PR touched.

- Adds `--color-neutral-200: #e7dbc8` — interpolated between the existing `neutral-300` (`#dcd0bd`) and `neutral-100` (`#f2e6d3`) swatches, continuing the same warm tan/cream progression.
- Confirmed via `grep` that every current `neutral-200` usage sitewide (11 files: discussion, reviews, fun facts, list controls, fight scenes, spoiler text, profile tabs, etc.) is light-toned text/hover-state on a dark background — exactly the kind of near-white text this swatch is for, not a stray/unrelated usage.

## Checklist

- [x] `README.md` — not applicable, no user-facing feature, env var, setup step, or seed data changed (a missing theme token, not new content).
- [x] `.env.example` — not applicable.
- [ ] `DECISIONS.md` — not updated. This closes a gap the original Poster House PR's own entry already flagged as deferred; not a new judgment call.
- [x] `npm run lint` and `npm run build` pass locally.

## Test plan

- `npm run lint` and `npm run build` both pass cleanly on this branch (merged current `master` in first — no conflicts; this branch was cut before the other recently-merged mobile-friendliness PRs, so it now carries all of that work too).
- Verified via `grep` that the new swatch's value sits correctly between its neighbors and that every current call site is a text/hover-state usage consistent with the palette's intent.
- **Not verified in a live browser** — this environment has no configured database, so the dev server can't be run against real data. Recommend a quick Vercel preview check on any page using `neutral-200` (e.g. the Discussion or Reviews section on a movie detail page) to confirm the warm tone renders as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hn2xPJWf39umbC2vX3hVg)_