### PR TITLE
Document a stopping point for iterative code-review loops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,22 @@ once they've explicitly said so in the conversation (e.g. "merge",
 "merge it," "go ahead and merge") — a green CI check alone is not
 authorization to merge.
 
+## Know when to stop iterating on code review
+
+Don't let a `/code-review` → fix → re-review loop run indefinitely on the
+same piece of code. If a fix made to satisfy one round's finding introduces
+new state or complexity (an ordering/sequencing mechanism, a new ref, a new
+guard flag), and the *next* round finds a bug in that new complexity, treat
+that as a signal to step back rather than patch forward again — prefer
+reverting to the simpler design over adding a third layer of guarding logic,
+even if it means accepting a minor, self-correcting edge case (e.g. a brief
+UI flicker) instead of eliminating it entirely. This matters most for
+stateful/async code (autosave, debounced writes, optimistic updates) — this
+repo already has a few such surfaces (Fight Count edits, fight scene
+ratings) where the same compounding-fix pattern could otherwise recur. As a
+rule of thumb, 3-4 rounds with no new *category* of finding is a reasonable
+place to stop and either ship or explicitly justify what's left.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know


### PR DESCRIPTION
## Summary

Adds a convention to `CLAUDE.md` for recognizing when a `/code-review` → fix → re-review loop has stopped converging (a fix's new complexity causes the next round's finding), rather than patching forward indefinitely. Prompted by a recent PR (#121) where fixing one round's finding introduced new state/complexity that the next round then found a bug in, repeating several times before the design was simplified back down instead.

## Checklist

- [x] `README.md` updated to reflect this change — not applicable, process/convention doc only, no user-facing change
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated if this involved a real judgment call — not applicable; this is a process convention for future Claude sessions working on the repo, not a product/architecture decision
- [x] `npm run lint` and `npm run build` pass locally — not applicable, no code changed (`CLAUDE.md` only)

## Test plan

Doc-only change — read through for accuracy and placement (added alongside the other process conventions near the end of "Working on this repo," matching their tone and format).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtGafH5PKfkxU9h3a1F1mo)_