### PR TITLE
Fight scene card: Manage chip, star ratings, and start-time touch-target fixes

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -3791,16 +3791,22 @@ day. Requested directly ("like the movies") rather than resizing the
 numbered grid in place (the fix originally mocked for it). `RatingRow`
 now renders `StarRatingPicker` — the same half-click 5-star control
 `RatingCard` uses for the movie-level overall score — instead of its own
-button grid, with the same member/admin color split (`RatingCard`'s
-member tab uses the picker's own default yellow; admin passes
-`fillColorClassName="text-amber-500"`). This is a deliberate step away
-from the ticket card's ink-only visual language (see "Fight Scenes
-introduced as a core feature" above, and the TICKET_INK/TICKET_MUTED/
-TICKET_STAMP palette comment in the component) — colored stars now
-appear inside the cream-and-ink ticket stub — traded for touch-target
-parity and one shared rating control instead of two divergent ones. The
-old `SCORES` (1-10) array was removed as dead code once nothing
-referenced it.
+button grid, reusing the mechanic ("like the movies") without importing
+`RatingCard`'s yellow/amber colors: `fillColorClassName` is instead set
+to the ticket's own ink (`TICKET_INK`, member "Your rating") and stamp
+red (`TICKET_STAMP`, admin "Editors' rating" — the same red already used
+two inches away on the rating-average stamp circles), via Tailwind
+arbitrary-value classes (`text-[#1a1712]`/`text-[#a4291e]`) rather than
+touching `StarIcon`. Considered and rejected: `RatingCard`'s literal
+yellow/amber, which would have broken the ticket card's deliberately
+ink-only visual language (see "Fight Scenes introduced as a core
+feature" above, and the TICKET_INK/TICKET_MUTED/TICKET_STAMP palette
+comment in the component) by introducing two colors foreign to it. The
+star's unfilled outline (`StarIcon`'s hardcoded `text-neutral-600`,
+tuned for the site's dark theme) still isn't ticket-themed — left as-is,
+flagged rather than fixed, since it reads fine against the cream
+background and wasn't part of what was asked. The old `SCORES` (1-10)
+array was removed as dead code once nothing referenced it.
 
 ## Deferred & Backlog
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -3780,6 +3780,28 @@ comparison and more obvious once live on a real device.
   `hasBasicDetails`/`hasDetails` untouched for desktop's gating, which
   still needs Box Office counted.
 
+### Fight scene rating switched from numbered ticket buttons to the shared star picker
+**PR #TBD.** `RatingRow` (`fight-scene-section.tsx`, shared by the member
+"Your rating" and admin "Editors' rating" on each fight scene ticket card)
+had been flagged in a mobile touch-target review as the card's smallest
+control — flat 24×24px numbered buttons — and deferred twice: once on a
+mistaken belief it had already been fixed by the movie-level Ratings PR,
+once as explicitly out of scope for a footer-chip fix landing the same
+day. Requested directly ("like the movies") rather than resizing the
+numbered grid in place (the fix originally mocked for it). `RatingRow`
+now renders `StarRatingPicker` — the same half-click 5-star control
+`RatingCard` uses for the movie-level overall score — instead of its own
+button grid, with the same member/admin color split (`RatingCard`'s
+member tab uses the picker's own default yellow; admin passes
+`fillColorClassName="text-amber-500"`). This is a deliberate step away
+from the ticket card's ink-only visual language (see "Fight Scenes
+introduced as a core feature" above, and the TICKET_INK/TICKET_MUTED/
+TICKET_STAMP palette comment in the component) — colored stars now
+appear inside the cream-and-ink ticket stub — traded for touch-target
+parity and one shared rating control instead of two divergent ones. The
+old `SCORES` (1-10) array was removed as dead code once nothing
+referenced it.
+
 ## Deferred & Backlog
 
 - **Drag-and-drop reordering for ranked list items** — `ListItemRows`

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -261,10 +261,11 @@ function RatingRow({
   score: number | null;
   onRate: (value: number) => void;
   disabled: boolean;
-  // Member "Your rating" leaves this at the picker's own default (yellow);
-  // the admin Editors' rating passes amber, matching RatingCard's same
-  // member/admin color split for the overall-score picker.
-  fillColorClassName?: string;
+  // Ticket ink for "Your rating", ticket stamp-red for Editors' -- the same
+  // two colors already used elsewhere on this card (the ink border/text and
+  // the rating-average stamp circles), rather than RatingCard's yellow/amber,
+  // so the star picker stays inside the ticket's own ink-on-cream palette.
+  fillColorClassName: string;
 }) {
   return (
     <div className="mt-3">
@@ -776,7 +777,7 @@ export function FightSceneSection({
                 )}
               </div>
 
-              <div className="mt-4 flex items-start justify-between gap-3">
+              <div className="mt-4 flex items-start justify-between gap-3 border-t pt-3" style={{ borderColor: "#b8ab8c" }}>
                 <div>
                   <p className="text-[10px] tracking-wide uppercase" style={{ color: TICKET_MUTED }}>
                     Submitted by
@@ -839,7 +840,13 @@ export function FightSceneSection({
               </div>
 
               {signedIn && (
-                <RatingRow label="Your rating" score={ratings[scene.id] ?? null} onRate={(value) => handleRate(scene.id, value)} disabled={false} />
+                <RatingRow
+                  label="Your rating"
+                  score={ratings[scene.id] ?? null}
+                  onRate={(value) => handleRate(scene.id, value)}
+                  disabled={false}
+                  fillColorClassName={`text-[${TICKET_INK}]`}
+                />
               )}
 
               {isAdmin && expandedAdminIds.has(scene.id) && (
@@ -849,7 +856,7 @@ export function FightSceneSection({
                     score={adminRatings[scene.id] ?? null}
                     onRate={(value) => handleAdminRate(scene.id, value)}
                     disabled={false}
-                    fillColorClassName="text-amber-500"
+                    fillColorClassName={`text-[${TICKET_STAMP}]`}
                   />
                   <textarea
                     value={adminNoteDrafts[scene.id] ?? ""}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -7,9 +7,9 @@ import type { FightSceneCast, FightSceneTag, Person, User } from "@/generated/pr
 import { ShareButton } from "@/components/share-button";
 import { AddToListControl, type AddToListItem } from "@/components/add-to-list-control";
 import { FavoriteButton } from "@/components/favorite-button";
+import { StarRatingPicker } from "@/components/star-rating-picker";
 import { youtubeWatchUrl } from "@/lib/youtube";
 
-const SCORES = Array.from({ length: 10 }, (_, i) => i + 1);
 const MAX_NOTE_LENGTH = 2000;
 // How many scenes render before a "Show more" click is needed — enough for
 // two full rows on the widest (3-column) layout.
@@ -250,31 +250,35 @@ function ActionChip({ onClick, children }: { onClick: () => void; children: stri
   );
 }
 
-function RatingRow({ label, score, onRate, disabled }: { label: string; score: number | null; onRate: (value: number) => void; disabled: boolean }) {
+function RatingRow({
+  label,
+  score,
+  onRate,
+  disabled,
+  fillColorClassName,
+}: {
+  label: string;
+  score: number | null;
+  onRate: (value: number) => void;
+  disabled: boolean;
+  // Member "Your rating" leaves this at the picker's own default (yellow);
+  // the admin Editors' rating passes amber, matching RatingCard's same
+  // member/admin color split for the overall-score picker.
+  fillColorClassName?: string;
+}) {
   return (
     <div className="mt-3">
       <p className="mb-1 text-[10px] uppercase tracking-wide" style={{ color: TICKET_MUTED }}>
         {label}
       </p>
-      <div className="flex flex-wrap gap-1">
-        {SCORES.map((value) => {
-          const active = score !== null && value <= score;
-          return (
-            <button
-              key={value}
-              disabled={disabled}
-              onClick={() => onRate(value)}
-              className="h-6 w-6 border text-[10px] font-bold transition disabled:opacity-50"
-              style={{
-                borderColor: TICKET_INK,
-                background: active ? TICKET_INK : "transparent",
-                color: active ? "#e8dcc4" : TICKET_INK,
-              }}
-            >
-              {value}
-            </button>
-          );
-        })}
+      <div className="flex items-center gap-2">
+        <StarRatingPicker size="lg" value={score} disabled={disabled} onSelect={onRate} fillColorClassName={fillColorClassName} />
+        <p className="text-sm font-bold" style={{ color: TICKET_INK }}>
+          {score ?? "—"}
+          <span className="text-[10px] font-normal" style={{ color: TICKET_MUTED }}>
+            /10
+          </span>
+        </p>
       </div>
     </div>
   );
@@ -845,6 +849,7 @@ export function FightSceneSection({
                     score={adminRatings[scene.id] ?? null}
                     onRate={(value) => handleAdminRate(scene.id, value)}
                     disabled={false}
+                    fillColorClassName="text-amber-500"
                   />
                   <textarea
                     value={adminNoteDrafts[scene.id] ?? ""}

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -732,12 +732,10 @@ export function FightSceneSection({
                       value={startTimeDrafts[scene.id] ?? formatMmSs(scene.youtubeStartSeconds)}
                       onChange={(e) => setStartTimeDrafts((prev) => ({ ...prev, [scene.id]: e.target.value }))}
                       placeholder="mm:ss"
-                      className="w-16 border bg-transparent px-1 py-0.5 text-center text-base focus:outline-none"
+                      className="min-h-8 w-16 border bg-transparent px-1 text-center text-base focus:outline-none"
                       style={{ borderColor: TICKET_INK, color: TICKET_INK }}
                     />
-                    <button onClick={() => handleSetStartTime(scene.id)} className="underline hover:opacity-70">
-                      Save
-                    </button>
+                    <ActionChip onClick={() => handleSetStartTime(scene.id)}>Save</ActionChip>
                   </div>
                 )}
               </div>

--- a/src/components/fight-scene-section.tsx
+++ b/src/components/fight-scene-section.tsx
@@ -348,9 +348,23 @@ export function FightSceneSection({
   // rating/note) expanded — collapsed by default so an admin's own cards
   // aren't cluttered with tools they're not currently using.
   const [expandedAdminIds, setExpandedAdminIds] = useState<Set<string>>(new Set());
+  // Which cards have their Edit/Delete/Verify chips expanded — separate from
+  // expandedAdminIds since "Manage" is available to any submitter (not just
+  // admins) and gates a different part of the card (the footer chip row, not
+  // the admin tools panel below the video).
+  const [expandedActionIds, setExpandedActionIds] = useState<Set<string>>(new Set());
 
   function toggleAdminTools(id: string) {
     setExpandedAdminIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleActions(id: string) {
+    setExpandedActionIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -767,12 +781,21 @@ export function FightSceneSection({
                   </p>
                   {(canEdit || canDelete || canVerify || isAdmin) && (
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {canEdit && <ActionChip onClick={() => setEditingId(scene.id)}>Edit</ActionChip>}
-                      {canDelete && <ActionChip onClick={() => handleDelete(scene.id)}>Delete</ActionChip>}
-                      {canVerify && (
-                        <ActionChip onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)}>
-                          {scene.isVerified ? "Unverify" : "Verify"}
+                      {(canEdit || canDelete || canVerify) && (
+                        <ActionChip onClick={() => toggleActions(scene.id)}>
+                          {expandedActionIds.has(scene.id) ? "Close" : "Manage"}
                         </ActionChip>
+                      )}
+                      {expandedActionIds.has(scene.id) && (
+                        <>
+                          {canEdit && <ActionChip onClick={() => setEditingId(scene.id)}>Edit</ActionChip>}
+                          {canDelete && <ActionChip onClick={() => handleDelete(scene.id)}>Delete</ActionChip>}
+                          {canVerify && (
+                            <ActionChip onClick={() => handleVerifyToggle(scene.id, !scene.isVerified)}>
+                              {scene.isVerified ? "Unverify" : "Verify"}
+                            </ActionChip>
+                          )}
+                        </>
                       )}
                       {isAdmin && (
                         <ActionChip onClick={() => toggleAdminTools(scene.id)}>


### PR DESCRIPTION
## Summary

Continues the mobile-friendliness pass on the Fight Scenes card (`src/components/fight-scene-section.tsx`), following up on #123 (footer action chips). Four changes:

- **Manage chip.** Edit / Delete / Verify rendered unconditionally alongside Admin tools whenever the viewer had permission — worst case (an admin on their own scene) was four always-on chips. They now sit behind a single `Manage`/`Close` toggle chip, mirroring the disclosure pattern `Admin tools` already used. `Admin tools` itself is untouched — still its own separate toggle gating the start-time/Editors'-rating panel.
- **Star ratings.** `RatingRow` (shared by the member "Your rating" and admin "Editors' rating") rendered its own flat 24×24px 1-10 button grid — the smallest control on the page. It now renders `StarRatingPicker`, the same half-click 5-star control `RatingCard` uses for the movie-level overall score, at a proper touch-target size.
- **Ticket-palette recolor.** Rather than importing `RatingCard`'s yellow/amber star colors as-is, the star fill uses the ticket's own ink (member) and stamp-red (Editors', matching the rating-average stamp circles) — same star mechanic, no colors foreign to the ticket's ink-on-cream visual language. Also adds a thin separator between the tags row and the "Submitted by" footer, matching the border style already used for the admin tools panel.
- **Start-time touch target.** The admin "Start at" `mm:ss` input + "Save" link was the last surviving small-touch-target control after everything else on the card moved to 32px+ chips and star pickers. `Save` is now an `ActionChip`; the input gets a matching `min-h-8`.

`DECISIONS.md` documents the star-picker/recolor tradeoff (a real judgment call — trading the ticket's previously ink-only palette for touch-target parity and one shared rating control). Deferred/out of scope: the title's two-line length and redundant "HD" suffix, and `StarIcon`'s hardcoded unfilled-star outline color — both flagged for a possible follow-up, not fixed here.

## Checklist

- [x] `README.md` updated to reflect this change (or not applicable — no user-facing feature, env var, setup step, or seed data changed) — not applicable, styling/interaction fixes only
- [x] `.env.example` updated if a new environment variable was added — not applicable
- [x] `DECISIONS.md` updated if this involved a real judgment call, an architecture/schema-shaping change, or an explicit deferral — yes, see the star-picker/recolor entry
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- `npm run lint` and `npm run build` — clean after each of the four commits
- Compared each change against a mockup before implementing (Manage chip, star-picker recolor)
- Reviewed an actual Vercel preview render with live data mid-way through, which surfaced the start-time touch-target fix
- Will do a final check of the merged preview on mobile before merge
