### PR TITLE
Close Save-to-list, Share, and Lists-nav dropdowns on outside click

### DIFF
--- a/src/components/add-to-list-control.tsx
+++ b/src/components/add-to-list-control.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 export interface AddToListItem {
   id: string;
@@ -50,6 +51,7 @@ export function AddToListControl({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
 
   // These "Fight Ticket" cards clip their own box (clip-path) to get the
@@ -77,6 +79,12 @@ export function AddToListControl({
       window.removeEventListener("resize", closeOnScrollOrResize);
     };
   }, [open]);
+
+  // The menu renders into a portal (see the comment above), so it isn't a
+  // DOM descendant of this component's own wrapper -- both the button and
+  // the portaled menu itself have to be checked, or clicking inside the
+  // menu would count as "outside" and close it before its own onClick runs.
+  useClickOutside([buttonRef, menuRef], () => setOpen(false), open);
 
   if (!signedIn) {
     return (
@@ -151,6 +159,7 @@ export function AddToListControl({
       {open && menuPos &&
         createPortal(
           <div
+            ref={menuRef}
             className="fixed z-50 w-64 max-w-[calc(100vw-2rem)] rounded-md border border-neutral-700 bg-neutral-900 p-3 shadow-xl"
             style={{ top: menuPos.top, right: menuPos.right }}
           >

--- a/src/components/lists-nav-menu.tsx
+++ b/src/components/lists-nav-menu.tsx
@@ -1,20 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 // A small chevron next to the "Lists" nav link reveals Leaderboard --
 // click-to-toggle, not hover, so it works identically on touch and
 // desktop (a hover-only menu is unreachable on mobile, where there's no
 // hover state at all). "Lists" itself stays a plain, unchanged link;
 // the chevron is a separate control so neither behavior is ambiguous.
-// Same dropdown pattern (and lack of click-outside-to-close) as
-// ShareButton, src/components/share-button.tsx.
+// Same dropdown pattern as ShareButton, src/components/share-button.tsx.
 export function ListsNavMenu() {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useClickOutside(wrapperRef, () => setOpen(false), open);
 
   return (
-    <div className="relative flex items-center">
+    <div ref={wrapperRef} className="relative flex items-center">
       <Link href="/lists" className="text-sm whitespace-nowrap text-neutral-300 hover:text-white">
         Lists
       </Link>

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 export function ShareButton({
   path,
@@ -19,6 +20,8 @@ export function ShareButton({
   const [menuOpen, setMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [youtubeCopied, setYoutubeCopied] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useClickOutside(wrapperRef, () => setMenuOpen(false), menuOpen);
 
   function absoluteUrl() {
     return `${window.location.origin}${path}`;
@@ -64,7 +67,7 @@ export function ShareButton({
   }
 
   return (
-    <div className="relative">
+    <div ref={wrapperRef} className="relative">
       <button
         onClick={handleClick}
         title="Share"

--- a/src/hooks/use-click-outside.ts
+++ b/src/hooks/use-click-outside.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+// Closes an open dropdown/menu on a click outside all of `refs` -- shared by
+// every button-triggered dropdown in the app (AddToListControl, ShareButton,
+// ListsNavMenu), which previously each left this out and only closed on an
+// explicit re-click of their own toggle, on scroll, or not at all. `mousedown`
+// rather than `click` so this fires before a target element's own `onClick`
+// (e.g. a list item inside the menu), and only while `active` so idle menus
+// don't pay for a document-wide listener.
+export function useClickOutside(
+  refs: RefObject<HTMLElement | null> | RefObject<HTMLElement | null>[],
+  onOutside: () => void,
+  active: boolean,
+) {
+  useEffect(() => {
+    if (!active) return;
+    const list = Array.isArray(refs) ? refs : [refs];
+    function handlePointerDown(e: MouseEvent) {
+      const target = e.target as Node;
+      if (list.some((ref) => ref.current?.contains(target))) return;
+      onOutside();
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [active, refs, onOutside]);
+}


### PR DESCRIPTION
## Summary

- Bug reported live on the fights page: the "Save to list" popup (`AddToListControl`) stayed open after clicking anywhere else on the page — it only ever closed on a re-click of its own toggle button, or (that one control only) on scroll/resize.
- Two other dropdowns share the exact same pattern per an existing `DECISIONS.md` note ("same dropdown look, and same lack of click-outside-to-close, as the existing `ShareButton`") — `ShareButton`'s share menu and the navbar's "Lists" chevron submenu (`ListsNavMenu`) — so both had the identical bug.
- Added a small shared `src/hooks/use-click-outside.ts` hook rather than duplicating the same listener three times, and wired it into all three. `AddToListControl`'s menu renders into a portal (to escape a fight-ticket card's `clip-path`), so it needed two refs (button + portaled menu) checked against; the other two just wrap button+menu in one ref.
- Since `AddToListControl` and `ShareButton` are each a single shared component, this fixes every place they render — movie pages, every fight scene card (`/search/fights`, the movie page teaser, the fights collection page), fight scene permalinks, and the share menu wherever it appears — not just the fights page where it was first noticed.

Pure bug fix, no behavior change to what these controls do — see `.claude/CLAUDE.md`'s own carve-out for why this doesn't touch `README.md`/`DECISIONS.md`.

## Checklist

- [x] `README.md` — not applicable, no user-facing feature/behavior changed, just a fixed interaction bug
- [x] `.env.example` — not applicable
- [x] `DECISIONS.md` — not applicable, pure bug fix (no judgment call to log)
- [x] `npm run lint` and `npm run build` pass locally

## Test plan

- Logged in as the seeded `member` account via Playwright and reproduced the original bug on `/search/fights` (opened the Save-to-list popup, clicked elsewhere on the page, confirmed it stayed open) before the fix.
- After the fix: confirmed the same popup now closes on an outside click.
- Confirmed clicks *inside* the menu still work correctly post-fix: checking a list checkbox (verified the `POST .../fight-scene-entries` request fires and the checkbox ends up checked), and creating+adding a new list via the "Add" button — neither gets swallowed by the new outside-click handler.
- `npm run lint` and `npm run build` both clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fd9iMkqf82hph77ZKSJMGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fd9iMkqf82hph77ZKSJMGQ)_